### PR TITLE
[Belt] Change reduceReverse to reduceRight, etc.

### DIFF
--- a/jscomp/others/belt_Array.ml
+++ b/jscomp/others/belt_Array.ml
@@ -14,7 +14,7 @@
 (* Array operations *)
 
 external length: 'a array -> int = "%array_length"
-external size: 'a array -> int = "%array_length"  
+external size: 'a array -> int = "%array_length"
 external getUnsafe: 'a array -> int -> 'a = "%array_unsafe_get"
 external setUnsafe: 'a array -> int -> 'a -> unit = "%array_unsafe_set"
 external getUndefined: 'a array -> int -> 'a Js.undefined = "%array_unsafe_get"
@@ -27,34 +27,34 @@ let getExn arr i =
 let set arr i v =
   if i >= 0 && i < length arr then (setUnsafe arr i v; true) else false
 
-let setExn arr i v = 
-  [%assert i >= 0 && i < length arr];  
-  setUnsafe arr i v 
+let setExn arr i v =
+  [%assert i >= 0 && i < length arr];
+  setUnsafe arr i v
 
 
-external truncateToLengthUnsafe : 'a array -> int ->  unit = "length" [@@bs.set]  
+external truncateToLengthUnsafe : 'a array -> int ->  unit = "length" [@@bs.set]
 external makeUninitialized : int -> 'a Js.undefined array = "Array" [@@bs.new]
 external makeUninitializedUnsafe : int -> 'a  array = "Array" [@@bs.new]
 
 
 let copy a =
-  let l = length a in 
-  let v = makeUninitializedUnsafe l in 
-  for i = 0 to l - 1 do 
+  let l = length a in
+  let v = makeUninitializedUnsafe l in
+  for i = 0 to l - 1 do
     setUnsafe v i (getUnsafe a i)
   done ;
   v
 
-let swapUnsafe xs i j =    
-  let tmp = getUnsafe xs i in 
+let swapUnsafe xs i j =
+  let tmp = getUnsafe xs i in
   setUnsafe xs i (getUnsafe xs j) ;
   setUnsafe xs j tmp
 
-let shuffleInPlace xs =     
-  let len = length xs in 
+let shuffleInPlace xs =
+  let len = length xs in
   for i = 0 to len - 1 do
     swapUnsafe xs i (Js_math.random_int i len) (* [i,len)*)
-  done 
+  done
 
 let shuffle xs =
   let result = copy xs in
@@ -72,16 +72,16 @@ let reverseInPlace xs =
 
 let reverse xs =
   let len = length xs in
-  let result = makeUninitializedUnsafe len in 
+  let result = makeUninitializedUnsafe len in
   for i = 0 to len - 1 do
     setUnsafe result i (getUnsafe xs (len - 1 - i))
   done;
   result
-  
+
 let make l f =
   if l <= 0 then [||]
-  else 
-    let res = makeUninitializedUnsafe l in 
+  else
+    let res = makeUninitializedUnsafe l in
     for i = 0 to  l - 1 do
       setUnsafe res i f
     done;
@@ -92,14 +92,14 @@ let make l f =
      on whether we create a float array or a regular one... *)
 let makeByU l f =
   if l <= 0 then [||]
-  else 
-    let res = makeUninitializedUnsafe l in 
+  else
+    let res = makeUninitializedUnsafe l in
     for i = 0 to  l - 1 do
       setUnsafe res i (f i [@bs])
     done;
     res
 
-let makeBy l f = makeByU l (fun[@bs] a -> f a) 
+let makeBy l f = makeByU l (fun[@bs] a -> f a)
 
 let makeByAndShuffleU l f =
   let u  = makeByU l f in
@@ -109,7 +109,7 @@ let makeByAndShuffleU l f =
 let makeByAndShuffle l f = makeByAndShuffleU l (fun[@bs] a -> f a)
 
 let range start finish =
-  let cut = finish - start in 
+  let cut = finish - start in
   if cut < 0  then [||]
   else
     let arr = makeUninitializedUnsafe (cut + 1 ) in
@@ -125,36 +125,36 @@ let rangeBy start finish ~step =
   else
     let nb = cut/step + 1 in
     let arr = makeUninitializedUnsafe  nb in
-    let cur = ref start in 
+    let cur = ref start in
     for i = 0 to nb - 1 do
       setUnsafe arr i !cur;
-      cur := !cur + step ; 
+      cur := !cur + step ;
     done;
-    arr 
+    arr
 
-let zip xs ys = 
-  let lenx, leny = length xs, length ys in 
-  let len = Pervasives.min lenx leny  in 
-  let s = makeUninitializedUnsafe len in 
-  for i = 0 to len - 1 do 
+let zip xs ys =
+  let lenx, leny = length xs, length ys in
+  let len = Pervasives.min lenx leny  in
+  let s = makeUninitializedUnsafe len in
+  for i = 0 to len - 1 do
     setUnsafe s i (getUnsafe xs i, getUnsafe ys i)
-  done ; 
-  s 
+  done ;
+  s
 
-let zipByU xs ys f = 
-  let lenx, leny = length xs, length ys in 
-  let len = Pervasives.min lenx leny  in 
-  let s = makeUninitializedUnsafe len in 
-  for i = 0 to len - 1 do 
+let zipByU xs ys f =
+  let lenx, leny = length xs, length ys in
+  let len = Pervasives.min lenx leny  in
+  let s = makeUninitializedUnsafe len in
+  for i = 0 to len - 1 do
     setUnsafe s i (f (getUnsafe xs i) (getUnsafe ys i) [@bs])
-  done ; 
-  s 
+  done ;
+  s
 
 let zipBy xs ys f = zipByU xs ys (fun [@bs] a b -> f a b)
 
 let concat a1 a2 =
   let l1 = length a1 in
-  let l2 = length a2 in 
+  let l2 = length a2 in
   let a1a2 = makeUninitializedUnsafe (l1 + l2) in
   for i = 0 to l1 - 1 do
     setUnsafe a1a2 i (getUnsafe a1 i)
@@ -166,21 +166,21 @@ let concat a1 a2 =
 
 let concatMany arrs =
   let lenArrs = length arrs in
-  let totalLen = ref 0 in 
+  let totalLen = ref 0 in
   for i = 0 to lenArrs - 1 do
     totalLen := !totalLen + length (getUnsafe arrs i)
   done;
   let result = makeUninitializedUnsafe !totalLen in
-  totalLen := 0 ; 
+  totalLen := 0 ;
   for j = 0 to lenArrs - 1 do
-    let cur = getUnsafe arrs j in 
+    let cur = getUnsafe arrs j in
     for k = 0 to length cur - 1 do
       setUnsafe result !totalLen (getUnsafe cur k);
       incr totalLen
-    done 
+    done
   done ;
   result
-  
+
 let slice a ~offset ~len =
   if len <= 0  then  [||]
   else
@@ -189,7 +189,7 @@ let slice a ~offset ~len =
       if offset < 0 then
         max (lena + offset) 0
       else offset in
-    let hasLen = lena - ofs in  
+    let hasLen = lena - ofs in
     let copyLength = min hasLen len in
     if copyLength <= 0 then [||]
     else
@@ -201,19 +201,19 @@ let slice a ~offset ~len =
 
 
 let fill a ~offset ~len v =
-  if len > 0 then 
+  if len > 0 then
     let lena = length a in
     let ofs =
       if offset < 0 then
         max (lena + offset ) 0
       else offset in
-    let hasLen = lena - ofs in      
+    let hasLen = lena - ofs in
     let fillLength = min hasLen len in
     if fillLength > 0 then
       for i = ofs to  ofs + fillLength - 1 do
-        setUnsafe a i v 
-      done 
-        
+        setUnsafe a i v
+      done
+
 
 let blitUnsafe ~src:a1  ~srcOffset:srcofs1 ~dst:a2 ~dstOffset:srcofs2 ~len:blitLength =
   if srcofs2 <= srcofs1 then
@@ -223,18 +223,18 @@ let blitUnsafe ~src:a1  ~srcOffset:srcofs1 ~dst:a2 ~dstOffset:srcofs2 ~len:blitL
   else
     for j = blitLength - 1 downto 0 do
       setUnsafe a2 (j + srcofs2) (getUnsafe a1 (j + srcofs1))
-    done 
+    done
 
-(* We don't need check [blitLength] since when [blitLength < 0] the 
+(* We don't need check [blitLength] since when [blitLength < 0] the
    for loop will be nop
-*)    
-let blit ~src:a1 ~srcOffset:ofs1 ~dst:a2 ~dstOffset:ofs2 ~len =  
+*)
+let blit ~src:a1 ~srcOffset:ofs1 ~dst:a2 ~dstOffset:ofs2 ~len =
     let lena1 = length a1 in
-    let lena2 = length a2 in 
+    let lena2 = length a2 in
     let srcofs1 = if ofs1 < 0 then max (lena1 + ofs1) 0 else ofs1 in
     let srcofs2 = if ofs2 < 0 then max (lena2 + ofs2) 0 else ofs2 in
     let blitLength =
-      min len (min (lena1 - srcofs1) (lena2 - srcofs2)) in 
+      min len (min (lena1 - srcofs1) (lena2 - srcofs2)) in
     (* blitUnsafe a1 srcofs1 a2 srcofs2 blitLength *)
     (if srcofs2 <= srcofs1 then
       for j = 0 to blitLength - 1 do
@@ -249,68 +249,68 @@ let forEachU a f =
   for i = 0 to length a - 1 do f(getUnsafe a i) [@bs] done
 
 let forEach a f = forEachU a (fun[@bs] a -> f a)
-  
+
 let mapU a f =
   let l = length a in
-  let r = makeUninitializedUnsafe l in 
+  let r = makeUninitializedUnsafe l in
   for i = 0 to l - 1 do
     setUnsafe r i (f(getUnsafe a i) [@bs])
   done;
   r
 
 let map a f = mapU a (fun[@bs] a -> f a)
-  
+
 let keepU a f =
   let l = length a in
   let r = makeUninitializedUnsafe l in
-  let j = ref 0 in 
+  let j = ref 0 in
   for i = 0 to l - 1 do
-    let v = (getUnsafe a i) in 
+    let v = (getUnsafe a i) in
     if f v [@bs] then
-      begin 
+      begin
         setUnsafe r !j v;
-        incr j 
+        incr j
       end
   done;
   truncateToLengthUnsafe r !j;
-  r 
+  r
 
 let keep a f = keepU a (fun [@bs] a -> f a)
-    
+
 let keepMapU a f =
   let l = length a in
   let r = makeUninitializedUnsafe l in
-  let j = ref 0 in 
+  let j = ref 0 in
   for i = 0 to l - 1 do
-    let v = getUnsafe a i in 
+    let v = getUnsafe a i in
     match f v [@bs] with
     | None -> ()
-    | Some v -> 
-      begin 
+    | Some v ->
+      begin
         setUnsafe r !j v;
-        incr j 
+        incr j
       end
   done;
   truncateToLengthUnsafe r !j;
-  r 
+  r
 
 let keepMap a f = keepMapU a (fun[@bs] a -> f a)
-    
+
 let forEachWithIndexU a f=
   for i = 0 to length a - 1 do f i (getUnsafe a i) [@bs] done
 
 let forEachWithIndex a f = forEachWithIndexU a (fun[@bs] a b -> f a b)
-    
+
 let mapWithIndexU  a f =
   let l = length a in
-  let r = makeUninitializedUnsafe l in 
+  let r = makeUninitializedUnsafe l in
   for i = 0 to l - 1 do
     setUnsafe r i (f i (getUnsafe a i) [@bs])
   done;
   r
 
 let mapWithIndex a f = mapWithIndexU a (fun[@bs] a b -> f a b)
-  
+
 let reduceU a x f =
   let r = ref x in
   for i = 0 to length a - 1 do
@@ -319,42 +319,48 @@ let reduceU a x f =
   !r
 
 let reduce a x f = reduceU a x (fun[@bs] a b -> f a b)
-    
-let reduceReverseU a x f =
+
+let reduceRightU a x f =
   let r = ref x in
   for i = length a - 1 downto 0 do
     r := f  !r (getUnsafe a i) [@bs]
   done;
   !r
 
-let reduceReverse a x f = reduceReverseU a x (fun[@bs] a b -> f a b)
+let reduceRight a x f = reduceRightU a x (fun[@bs] a b -> f a b)
 
-let reduceReverse2U a b x f =
+let reduceReverseU = reduceRightU
+let reduceReverse = reduceRight
+
+let reduceRight2U a b x f =
   let r = ref x in
   let len = min (length a) (length b) in
   for i = len - 1 downto  0 do
     r := f !r (getUnsafe a i) (getUnsafe b i) [@bs]
   done;
-  !r 
+  !r
 
-let reduceReverse2 a b x f =
-  reduceReverse2U a b x (fun [@bs] a b c -> f a b c)
+let reduceRight2 a b x f =
+  reduceRight2U a b x (fun [@bs] a b c -> f a b c)
 
-let rec everyAux arr i b len =   
-  if i = len then true 
-  else if b (getUnsafe arr i) [@bs] then 
+let reduceReverse2U = reduceRight2U
+let reduceReverse2 = reduceRight2
+
+let rec everyAux arr i b len =
+  if i = len then true
+  else if b (getUnsafe arr i) [@bs] then
     everyAux arr (i + 1) b len
-  else false    
+  else false
 
 let rec someAux arr i b len =
   if i = len then false
   else
   if b (getUnsafe arr i) [@bs] then true
   else someAux arr (i + 1) b len
-      
-let everyU arr b =   
-  let len = length arr in 
-  everyAux arr 0 b len 
+
+let everyU arr b =
+  let len = length arr in
+  everyAux arr 0 b len
 
 let every arr f = everyU arr (fun[@bs] b -> f b)
 
@@ -362,21 +368,21 @@ let someU arr b =
   let len = length arr in
   someAux arr 0 b len
 let some arr f = someU arr (fun [@bs] b -> f b)
-    
-let rec everyAux2 arr1 arr2 i b len =   
-  if i = len then true 
-  else if b (getUnsafe arr1 i) (getUnsafe arr2 i) [@bs] then 
-    everyAux2 arr1 arr2 (i + 1) b len
-  else false      
 
-let rec someAux2 arr1 arr2 i b len =   
+let rec everyAux2 arr1 arr2 i b len =
+  if i = len then true
+  else if b (getUnsafe arr1 i) (getUnsafe arr2 i) [@bs] then
+    everyAux2 arr1 arr2 (i + 1) b len
+  else false
+
+let rec someAux2 arr1 arr2 i b len =
   if i = len then false
   else if b (getUnsafe arr1 i) (getUnsafe arr2 i) [@bs] then
     true
   else someAux2 arr1 arr2 (i + 1) b len
 
 
-let every2U  a b p =   
+let every2U  a b p =
   everyAux2  a b 0 p (min (length a) (length b))
 
 let every2 a b p = every2U  a b (fun[@bs] a b -> p a b)
@@ -385,26 +391,26 @@ let some2U a b p =
   someAux2 a b 0 p (min (length a) (length b))
 
 let some2 a b p = some2U a b (fun [@bs] a b -> p a b)
-    
+
 let eqU a b p =
   let lena = length a in
   let lenb = length b in
-  if lena = lenb then 
+  if lena = lenb then
     everyAux2 a b 0 p lena
   else false
 
 let eq a b p = eqU a b (fun [@bs] a b -> p a b )
 
-let rec everyCmpAux2 arr1 arr2 i b len =   
+let rec everyCmpAux2 arr1 arr2 i b len =
   if i = len then 0
   else
-    let c = b (getUnsafe arr1 i) (getUnsafe arr2 i) [@bs]  in 
-    if c = 0 then 
+    let c = b (getUnsafe arr1 i) (getUnsafe arr2 i) [@bs]  in
+    if c = 0 then
       everyCmpAux2 arr1 arr2 (i + 1) b len
     else c
 
 let cmpU a b p =
-  let lena = length a in  
+  let lena = length a in
   let lenb = length b in
   if lena > lenb then 1
   else if lena < lenb then -1

--- a/jscomp/others/belt_Array.mli
+++ b/jscomp/others/belt_Array.mli
@@ -13,20 +13,20 @@
 (* Adapted significantly by Authors of BuckleScript *)
 
 
-(** {!Belt.Array}    
-    Utililites for Array functions 
+(** {!Belt.Array}
+    Utililites for Array functions
 *)
 
 
 external length: 'a array -> int = "%array_length"
 (** [length xs] return the size of the array *)
-  
+
 external size: 'a array -> int = "%array_length"
 (** {b See} {!length} *)
 
 val get: 'a array -> int -> 'a option
 
-val getExn: 'a array -> int -> 'a  
+val getExn: 'a array -> int -> 'a
 (** [getExn arr i]
 
     {b raise} an exception if [i] is out of range
@@ -40,22 +40,22 @@ external getUnsafe: 'a array -> int -> 'a = "%array_unsafe_get"
     no  bounds checking, this would cause type error
     if [i] does not stay within range
 *)
-  
+
 external getUndefined: 'a array -> int -> 'a Js.undefined = "%array_unsafe_get"
 (** [getUndefined arr i]
 
-    It does the samething in the runtime as {!getUnsafe}, 
-    it is {i type safe} since the return type still track whether it is 
+    It does the samething in the runtime as {!getUnsafe},
+    it is {i type safe} since the return type still track whether it is
     in range or not
 *)
 
 val set: 'a array -> int -> 'a -> bool
-(** [set arr n x] modifies [arr] in place, 
-    it replaces the nth element of [arr] with [x] 
+(** [set arr n x] modifies [arr] in place,
+    it replaces the nth element of [arr] with [x]
     @return false means not updated due to out of range
 *)
 
-val setExn: 'a array -> int -> 'a -> unit 
+val setExn: 'a array -> int -> 'a -> unit
 (** [setExn arr i x]
     {b raise} an exception if [i] is out of range
 *)
@@ -64,7 +64,7 @@ external setUnsafe: 'a array -> int -> 'a -> unit = "%array_unsafe_set"
 
 val shuffleInPlace: 'a array -> unit
 
-val shuffle: 'a array -> 'a array  
+val shuffle: 'a array -> 'a array
 (** [shuffle xs]
     @return a fresh array *)
 
@@ -79,13 +79,13 @@ external makeUninitialized: int -> 'a Js.undefined array = "Array" [@@bs.new]
 external makeUninitializedUnsafe: int -> 'a array = "Array" [@@bs.new]
 (** [makeUninitializedUnsafe n]
 
-    {b Unsafe}   
+    {b Unsafe}
 *)
 
 
 val make: int -> 'a  -> 'a array
-(** [make n e] 
-    return an array of size [n] filled  with value [e]    
+(** [make n e]
+    return an array of size [n] filled  with value [e]
     @return an empty array when [n] is negative.
 *)
 
@@ -102,23 +102,23 @@ val rangeBy: int -> int -> step:int -> int array
 
     @return empty array when step is 0 or negative
     it also return empty array when [start > finish]
-    
+
     @example {[
      rangeBy 0 10 ~step:3 = [|0;3;6;9|];;
      rangeBy 0 12 ~step:3 = [|0;3;6;9;12|];;
      rangeBy 33 0 ~step:1 =  [||];;
      rangeBy 33 0 ~step:(-1) = [||];;
      rangeBy 3 12 ~step:(-1) = [||];;
-     rangeBy 3 3 ~step:0 = [||] ;;     
+     rangeBy 3 3 ~step:0 = [||] ;;
      rangeBy 3 3 ~step:(1) = [|3|] ;;
    ]}
-*)    
+*)
 
 val makeByU: int -> (int -> 'a [@bs]) -> 'a array
 val makeBy: int -> (int -> 'a ) -> 'a array
-(** [makeBy n f] 
-    
-    return an empty array when [n] is negative 
+(** [makeBy n f]
+
+    return an empty array when [n] is negative
     return an array of size [n] populated by [f i] start from [0] to [n - 1]
 
     @example {[
@@ -127,16 +127,16 @@ val makeBy: int -> (int -> 'a ) -> 'a array
 *)
 
 val makeByAndShuffleU: int -> (int -> 'a [@bs]) -> 'a array
-val makeByAndShuffle: int -> (int -> 'a ) -> 'a array    
+val makeByAndShuffle: int -> (int -> 'a ) -> 'a array
 (** [makeByAndShuffle n f]
 
     Equivalent to [shuffle (makeBy n f)]
-*)    
+*)
 
 
 val zip: 'a array -> 'b array -> ('a * 'b) array
-(** [zip a b] 
-    
+(** [zip a b]
+
     Stop with the shorter array
 
     @example {[
@@ -146,10 +146,10 @@ val zip: 'a array -> 'b array -> ('a * 'b) array
 
 
  val zipByU: 'a array -> 'b array -> ('a -> 'b -> 'c [@bs]) -> 'c array
- val zipBy: 'a array -> 'b array -> ('a -> 'b -> 'c ) -> 'c array         
+ val zipBy: 'a array -> 'b array -> ('a -> 'b -> 'c ) -> 'c array
  (**
     [zipBy xs ys f]
-   
+
     Stops with shorter array
 
     Equivalent to [map (zip xs ys) (fun (a,b) -> f a b) ]
@@ -160,7 +160,7 @@ val concat: 'a array -> 'a array -> 'a array
 
     @return a fresh array containing the
     concatenation of the arrays [v1] and [v2], so even if [v1] or [v2]
-    is empty, it can not be shared 
+    is empty, it can not be shared
 *)
 
 val concatMany: 'a array array -> 'a array
@@ -172,25 +172,25 @@ val concatMany: 'a array array -> 'a array
 
 val slice: 'a array -> offset:int -> len:int -> 'a array
 (** [slice arr offset len]
-    
+
     [offset] can be negative,
     [slice arr -1 1] means get the last element as a singleton array
 
     [slice arr -(very_large_index) len] will do a copy of the array
-    
+
     if the array does not have enough data, [slice] extracts through
     the end of sequence
 *)
 
 
 val copy: 'a array -> 'a array
-(** [copy a] 
+(** [copy a]
 
     @return a copy of [a], that is, a fresh array
    containing the same elements as [a]. *)
 
 val fill: 'a array -> offset:int -> len:int -> 'a -> unit
-(** [fill arr ~offset ~len x] 
+(** [fill arr ~offset ~len x]
 
     Modifies [arr] in place,
     storing [x] in elements number [offset] to [offset + len - 1].
@@ -208,24 +208,24 @@ val fill: 'a array -> offset:int -> len:int -> 'a -> unit
     ]}
  *)
 
-val blit: 
+val blit:
     src:'a array -> srcOffset:int -> dst:'a array -> dstOffset:int -> len:int -> unit
-(** [blit ~src:v1 ~srcOffset:o1 ~dst:v2 ~dstOffset:o2 ~len] 
+(** [blit ~src:v1 ~srcOffset:o1 ~dst:v2 ~dstOffset:o2 ~len]
 
     copies [len] elements
    from array [v1], starting at element number [o1], to array [v2],
-   starting at element number [o2]. 
-   
+   starting at element number [o2].
+
     It works correctly even if
     [v1] and [v2] are the same array, and the source and
     destination chunks overlap.
 
-    [offset] can be negative, [-1] means [len - 1], if [len + offset]  is still 
-    negative, it will be set as 0   
+    [offset] can be negative, [-1] means [len - 1], if [len + offset]  is still
+    negative, it will be set as 0
 *)
 
 val blitUnsafe:
-  src:'a array -> srcOffset:int -> dst:'a array -> dstOffset:int -> len:int -> unit 
+  src:'a array -> srcOffset:int -> dst:'a array -> dstOffset:int -> len:int -> unit
 (**
    {b Unsafe} blit without bounds checking
 *)
@@ -236,7 +236,7 @@ val forEach: 'a array ->  ('a -> unit ) -> unit
 
     Call f on each element of [xs] from the beginning to end
 *)
-  
+
 val mapU: 'a array ->  ('a -> 'b [@bs]) -> 'b array
 val map: 'a array ->  ('a -> 'b ) -> 'b array
 (** [map xs f ]
@@ -244,7 +244,7 @@ val map: 'a array ->  ('a -> 'b ) -> 'b array
     @return a new array by calling [f] to element of [xs] from
     the beginning to end
 *)
-    
+
 val keepU: 'a array -> ('a -> bool [@bs]) -> 'a array
 val keep: 'a array -> ('a -> bool ) -> 'a array
 (** [keep xs p ]
@@ -256,7 +256,7 @@ val keep: 'a array -> ('a -> bool ) -> 'a array
 *)
 
 val keepMapU: 'a array -> ('a -> 'b option [@bs]) -> 'b array
-val keepMap: 'a array -> ('a -> 'b option) -> 'b array 
+val keepMap: 'a array -> ('a -> 'b option) -> 'b array
 (** [keepMap xs p]
     @return a new array that keep all elements that return a non-None applied [p]
 
@@ -275,13 +275,13 @@ val forEachWithIndex: 'a array ->  (int -> 'a -> unit ) -> unit
 *)
 
 val mapWithIndexU: 'a array ->  (int -> 'a -> 'b [@bs]) -> 'b array
-val mapWithIndex: 'a array ->  (int -> 'a -> 'b ) -> 'b array    
+val mapWithIndex: 'a array ->  (int -> 'a -> 'b ) -> 'b array
 (** [mapWithIndex xs f ]
 
     The same with {!map} except that [f] is supplied with one
     more argument: the index starting from 0
 *)
-    
+
 val reduceU:  'b array -> 'a -> ('a -> 'b -> 'a [@bs]) ->'a
 val reduce:  'b array -> 'a -> ('a -> 'b -> 'a ) ->'a
 (** [reduce xs init f]
@@ -289,39 +289,51 @@ val reduce:  'b array -> 'a -> ('a -> 'b -> 'a ) ->'a
     @example {[
       reduce [|2;3;4|] 1 (+) = 10
     ]}
-   
+
 *)
 
 val reduceReverseU: 'b array -> 'a -> ('a -> 'b ->  'a [@bs]) ->  'a
+[@@ocaml.deprecated "Use reduceRightU instead"]
 val reduceReverse: 'b array -> 'a -> ('a -> 'b ->  'a ) ->  'a
-(** [reduceReverse xs init f]
+[@@ocaml.deprecated "Use reduceRight instead"]
+
+val reduceRightU: 'b array -> 'a -> ('a -> 'b ->  'a [@bs]) ->  'a
+val reduceRight: 'b array -> 'a -> ('a -> 'b ->  'a ) ->  'a
+(** [reduceRight xs init f]
     @example {[
-      reduceReverse [|1;2;3;4|] 100 (-) = 90 
+      reduceRight [|1;2;3;4|] 100 (-) = 90
     ]}
 *)
 
 val reduceReverse2U:
   'a array -> 'b array -> 'c  -> ('c -> 'a -> 'b ->  'c [@bs]) ->  'c
-val reduceReverse2:  
+[@@ocaml.deprecated "Use reduceRight2U instead"]
+val reduceReverse2:
+  'a array -> 'b array -> 'c  -> ('c -> 'a -> 'b ->  'c) ->  'c
+[@@ocaml.deprecated "Use reduceRight2 instead"]
+
+val reduceRight2U:
+  'a array -> 'b array -> 'c  -> ('c -> 'a -> 'b ->  'c [@bs]) ->  'c
+val reduceRight2:
   'a array -> 'b array -> 'c  -> ('c -> 'a -> 'b ->  'c) ->  'c
 (**
    @example {[
-     reduceReverse2 [|1;2;3|] [|1;2|] 0 (fun acc x y -> acc + x + y) = 6
+     reduceRight2 [|1;2;3|] [|1;2|] 0 (fun acc x y -> acc + x + y) = 6
    ]}
 *)
-  
+
 val someU: 'a array -> ('a -> bool [@bs]) -> bool
 val some: 'a array -> ('a -> bool) -> bool
 (** [some xs p]
     @return true if one of element satifies [p]
 *)
-  
+
 val everyU: 'a array -> ('a -> bool [@bs]) -> bool
 val every: 'a array -> ('a -> bool ) -> bool
 (** [every xs p]
     @return true if all elements satisfy [p]
 *)
-  
+
 val every2U: 'a array -> 'b array -> ('a -> 'b -> bool [@bs]) -> bool
 val every2: 'a array -> 'b array -> ('a -> 'b -> bool ) -> bool
 (** [every2 xs ys p] only tests the length of shorter
@@ -329,7 +341,7 @@ val every2: 'a array -> 'b array -> ('a -> 'b -> bool ) -> bool
     @example {[
       every2 [|1;2;3|] [|0;1|] (>) = true;;
       (every2 [||] [|1|] (fun   x y -> x > y)) = true;;
-      (every2 [|2;3|] [|1|] (fun   x y -> x > y)) = true;; 
+      (every2 [|2;3|] [|1|] (fun   x y -> x > y)) = true;;
     ]}
 *)
 
@@ -343,19 +355,19 @@ val some2: 'a array -> 'b array -> ('a -> 'b -> bool ) -> bool
       (some2 [|2;3|] [|1;4|] (fun   x y -> x > y)) = true;;
     ]}
 *)
-  
+
 val cmpU: 'a array -> 'a array -> ('a -> 'a -> int [@bs]) -> int
 val cmp: 'a array -> 'a array -> ('a -> 'a -> int ) -> int
 (** [cmp a b]
-    
-    - Compared by length if [length a <> length b] 
+
+    - Compared by length if [length a <> length b]
     - Otherwise compare one by one [f ai bi]
 *)
 
 val eqU:  'a array -> 'a array -> ('a -> 'a -> bool [@bs]) -> bool
 val eq:  'a array -> 'a array -> ('a -> 'a -> bool ) -> bool
 (** [eq a b]
-    
+
     - return false if length is not the same
     - equal one by one using [f ai bi]
 *)

--- a/jscomp/others/belt_List.ml
+++ b/jscomp/others/belt_List.ml
@@ -48,7 +48,7 @@
    {[
      type 'a t = {
        head : 'a;
-       mutable tail : 'a t | int 
+       mutable tail : 'a t | int
      }
    ]}
    In the future, we could come up with a safer version
@@ -63,24 +63,24 @@ type 'a t = 'a list
 
 module A = Belt_Array
 
-external mutableCell : 
+external mutableCell :
   'a -> 'a t ->  'a t = "#makemutablelist"
-(* 
+(*
     [mutableCell x []] == [x]
     but tell the compiler that is a mutable cell, so it wont
     be mis-inlined in the future
      dont inline a binding to mutable cell, it is mutable
 *)
-external unsafeMutateTail : 
-  'a t -> 'a t -> unit = "#setfield1"    
+external unsafeMutateTail :
+  'a t -> 'a t -> unit = "#setfield1"
 (*
-   - the cell is not empty   
+   - the cell is not empty
    - it is mutated
-*)  
-external unsafeTail :   
+*)
+external unsafeTail :
   'a t -> 'a t = "%field1"
 (*
-   - the cell is not empty   
+   - the cell is not empty
 *)
 
 let head x =
@@ -88,23 +88,23 @@ let head x =
   | [] -> None
   | x::_ -> Some x
 
-let headExn x = 
-  match x with 
-  | [] -> [%assert "headExn"]  
-  | x::_ -> x 
+let headExn x =
+  match x with
+  | [] -> [%assert "headExn"]
+  | x::_ -> x
 
 let tail x =
   match x with
   | [] -> None
-  | _::xs -> Some xs 
+  | _::xs -> Some xs
 
-let tailExn x =   
-  match x with 
+let tailExn x =
+  match x with
   | [] -> [%assert "tailExn"]
   | _::t -> t
-  
+
 let add xs x  = x :: xs
-                
+
 (* Assume [n >=0] *)
 let rec nthAux x n =
   match x with
@@ -122,189 +122,189 @@ let get x n =
 
 let getExn x n =
   if n < 0 then [%assert "getExn"]
-  else nthAuxAssert x n 
+  else nthAuxAssert x n
 
 let rec partitionAux p cell precX precY =
   match cell with
   | [] -> ()
   | h::t ->
     let next = mutableCell h [] in
-    if p h [@bs] then     
-      begin 
+    if p h [@bs] then
+      begin
         unsafeMutateTail precX next ;
         partitionAux p t next precY
-      end 
-    else 
-      begin 
+      end
+    else
+      begin
         unsafeMutateTail precY next ;
-        partitionAux p t precX next 
-      end 
+        partitionAux p t precX next
+      end
 
-let rec splitAux cell precX precY = 
-  match cell with 
-  | [] -> () 
-  | (a,b)::t -> 
-    let nextA = mutableCell a [] in 
-    let nextB = mutableCell b [] in 
-    unsafeMutateTail precX nextA;  
-    unsafeMutateTail precY nextB; 
+let rec splitAux cell precX precY =
+  match cell with
+  | [] -> ()
+  | (a,b)::t ->
+    let nextA = mutableCell a [] in
+    let nextB = mutableCell b [] in
+    unsafeMutateTail precX nextA;
+    unsafeMutateTail precY nextB;
     splitAux t nextA nextB
 
-(* return the tail pointer so it can continue copy other 
+(* return the tail pointer so it can continue copy other
    list
-*)  
+*)
 let rec copyAuxCont cellX prec =
   match cellX with
   | [] -> prec
   | h::t ->
     let next = mutableCell h [] in
-    unsafeMutateTail prec next ; 
+    unsafeMutateTail prec next ;
     copyAuxCont t next
 
 let rec copyAuxWitFilter f cellX prec =
   match cellX with
-  | [] -> 
+  | [] ->
     ()
   | h::t ->
-    if f h [@bs] then 
-      begin 
+    if f h [@bs] then
+      begin
         let next = mutableCell h [] in
-        unsafeMutateTail prec next ; 
+        unsafeMutateTail prec next ;
         copyAuxWitFilter f t next
       end
-    else copyAuxWitFilter f t prec 
+    else copyAuxWitFilter f t prec
 
 let rec copyAuxWitFilterMap f cellX prec =
   match cellX with
-  | [] -> 
+  | [] ->
     ()
   | h::t ->
     match f h [@bs] with
-    | Some h -> 
-      begin 
+    | Some h ->
+      begin
         let next = mutableCell h [] in
-        unsafeMutateTail prec next ; 
+        unsafeMutateTail prec next ;
         copyAuxWitFilterMap f t next
       end
-    | None ->  copyAuxWitFilterMap f t prec 
+    | None ->  copyAuxWitFilterMap f t prec
 
-let rec removeAssocAuxWithMap  cellX x  prec f =  
-  match cellX with 
+let rec removeAssocAuxWithMap  cellX x  prec f =
+  match cellX with
   | [] -> false
-  | ((a,_) as h):: t -> 
-    if f a x [@bs] then 
+  | ((a,_) as h):: t ->
+    if f a x [@bs] then
       (unsafeMutateTail prec t ; true)
-    else  
-      let next = mutableCell h [] in 
-      unsafeMutateTail prec next ; 
-      removeAssocAuxWithMap t x next f 
+    else
+      let next = mutableCell h [] in
+      unsafeMutateTail prec next ;
+      removeAssocAuxWithMap t x next f
 
-let rec setAssocAuxWithMap cellX x k prec eq = 
-  match cellX with       
-  | [] -> false 
-  | ((a,_) as h) :: t -> 
-    if eq a x [@bs] then 
+let rec setAssocAuxWithMap cellX x k prec eq =
+  match cellX with
+  | [] -> false
+  | ((a,_) as h) :: t ->
+    if eq a x [@bs] then
       (unsafeMutateTail prec ( (x,k)::t); true)
-    else       
-      let next = mutableCell h [] in 
-      unsafeMutateTail prec next ; 
-      setAssocAuxWithMap t x k next eq 
+    else
+      let next = mutableCell h [] in
+      unsafeMutateTail prec next ;
+      setAssocAuxWithMap t x k next eq
 
-      
+
 let rec copyAuxWithMap cellX prec f =
   match cellX with
-  | [] -> 
+  | [] ->
     ()
   | h::t ->
     let next = mutableCell (f h [@bs]) [] in
-    unsafeMutateTail prec next ; 
+    unsafeMutateTail prec next ;
     copyAuxWithMap t next f
 
 
 let rec zipAux  cellX cellY prec =
   match cellX, cellY with
-  | h1::t1, h2::t2 -> 
+  | h1::t1, h2::t2 ->
     let next = mutableCell ( h1, h2) [] in
-    unsafeMutateTail prec next ; 
+    unsafeMutateTail prec next ;
     zipAux  t1 t2 next
-  | [],_ | _,[] -> 
+  | [],_ | _,[] ->
     ()
 
 let rec copyAuxWithMap2 f cellX cellY prec =
   match cellX, cellY with
-  | h1::t1, h2::t2 -> 
+  | h1::t1, h2::t2 ->
     let next = mutableCell (f h1 h2 [@bs]) [] in
-    unsafeMutateTail prec next ; 
+    unsafeMutateTail prec next ;
     copyAuxWithMap2 f t1 t2 next
-  | [],_ | _,[] -> 
+  | [],_ | _,[] ->
     ()
 
 let rec copyAuxWithMapI f i cellX prec =
   match cellX with
   | h::t ->
     let next = mutableCell (f i h [@bs]) [] in
-    unsafeMutateTail prec next ; 
+    unsafeMutateTail prec next ;
     copyAuxWithMapI f (i + 1) t next
-  | [] -> 
+  | [] ->
     ()
 
-let rec takeAux n cell prec = 
+let rec takeAux n cell prec =
   if n = 0 then true
-  else 
-    match cell with 
-    | [] -> false 
-    | x::xs -> 
-      let cell = mutableCell x [] in 
-      unsafeMutateTail prec cell; 
-      takeAux (n - 1) xs cell 
+  else
+    match cell with
+    | [] -> false
+    | x::xs ->
+      let cell = mutableCell x [] in
+      unsafeMutateTail prec cell;
+      takeAux (n - 1) xs cell
 
-let rec splitAtAux n cell prec = 
-  if n = 0 then Some cell 
-  else 
-    match cell with 
-    | [] -> None 
-    | x::xs -> 
-      let cell = mutableCell x [] in 
-      unsafeMutateTail prec cell;  
+let rec splitAtAux n cell prec =
+  if n = 0 then Some cell
+  else
+    match cell with
+    | [] -> None
+    | x::xs ->
+      let cell = mutableCell x [] in
+      unsafeMutateTail prec cell;
       splitAtAux (n - 1) xs cell
 
-(* invarint [n >= 0] *)    
-let  take lst n = 
+(* invarint [n >= 0] *)
+let  take lst n =
   if n < 0 then None
-  else 
+  else
   if n = 0 then Some []
-  else 
+  else
     match lst with
-    | [] -> None 
-    | x::xs -> 
-      let cell = mutableCell x [] in 
+    | [] -> None
+    | x::xs ->
+      let cell = mutableCell x [] in
       let has = takeAux (n-1) xs cell in
       if has then Some cell
       else None
 (* invariant [n >= 0 ] *)
-let rec dropAux l n = 
+let rec dropAux l n =
   if n = 0 then Some l
-  else 
-    match l with 
+  else
+    match l with
     | _::tl ->  dropAux tl (n -1)
-    | [] -> None 
+    | [] -> None
 
-let drop lst n =       
-  if n < 0 then None 
-  else 
-    dropAux lst n 
+let drop lst n =
+  if n < 0 then None
+  else
+    dropAux lst n
 
-let splitAt lst n =     
-  if n < 0 then None 
-  else 
-  if n = 0 then Some ([],lst) 
-  else 
-    match lst with 
-    | [] ->  None 
-    | x::xs -> 
-      let cell = mutableCell x [] in 
-      let rest = splitAtAux (n - 1) xs cell in 
-      match rest with 
+let splitAt lst n =
+  if n < 0 then None
+  else
+  if n = 0 then Some ([],lst)
+  else
+    match lst with
+    | [] ->  None
+    | x::xs ->
+      let cell = mutableCell x [] in
+      let rest = splitAtAux (n - 1) xs cell in
+      match rest with
       | Some rest -> Some (cell, rest)
       | None -> None
 
@@ -312,8 +312,8 @@ let concat xs ys =
   match xs with
   | [] -> ys
   | h::t ->
-    let cell = mutableCell h [] in       
-    unsafeMutateTail (copyAuxCont t cell) ys; 
+    let cell = mutableCell h [] in
+    unsafeMutateTail (copyAuxCont t cell) ys;
     cell
 
 let mapU xs f =
@@ -324,25 +324,25 @@ let mapU xs f =
     copyAuxWithMap t cell f;
     cell
 
-let map xs f = mapU xs (fun[@bs] x -> f x )     
+let map xs f = mapU xs (fun[@bs] x -> f x )
 
 let zipByU l1 l2 f =
   match (l1, l2) with
-  | (a1::l1, a2::l2) -> 
+  | (a1::l1, a2::l2) ->
     let cell = mutableCell (f a1 a2 [@bs]) []  in
-    copyAuxWithMap2 f l1 l2 cell; 
-    cell 
+    copyAuxWithMap2 f l1 l2 cell;
+    cell
   | [], _ | _, [] -> []
 
-let zipBy l1 l2 f = zipByU l1 l2 (fun[@bs] x y -> f x y)  
+let zipBy l1 l2 f = zipByU l1 l2 (fun[@bs] x y -> f x y)
 
-let mapWithIndexU  xs f  = 
-  match xs with 
+let mapWithIndexU  xs f  =
+  match xs with
     [] -> []
-  | h::t -> 
-    let cell = mutableCell (f 0 h [@bs]) [] in 
+  | h::t ->
+    let cell = mutableCell (f 0 h [@bs]) [] in
     copyAuxWithMapI f 1 t cell;
-    cell 
+    cell
 
 let mapWithIndex xs f = mapWithIndexU xs (fun[@bs] i x -> f i x)
 
@@ -355,14 +355,14 @@ let makeByU n f =
     let i = ref 1 in
     while !i < n do
       let v = mutableCell (f !i [@bs]) [] in
-      unsafeMutateTail !cur v ; 
+      unsafeMutateTail !cur v ;
       cur := v ;
       incr i ;
     done
     ;
     headX
 
-let makeBy n f = makeByU n (fun[@bs] x -> f x)    
+let makeBy n f = makeByU n (fun[@bs] x -> f x)
 
 let make n v =
   if n <= 0 then []
@@ -372,7 +372,7 @@ let make n v =
     let i = ref 1 in
     while !i < n do
       let v = mutableCell v [] in
-      unsafeMutateTail !cur v ; 
+      unsafeMutateTail !cur v ;
       cur := v ;
       incr i ;
     done
@@ -386,7 +386,7 @@ let rec lengthAux x acc =
 
 let length xs = lengthAux xs 0
 let size = length
-  
+
 let rec fillAux arr i x =
   match x with
   | [] -> ()
@@ -395,11 +395,11 @@ let rec fillAux arr i x =
     fillAux arr (i + 1) t
 
 let rec fromArrayAux a i res =
-  if i < 0 then res 
-  else fromArrayAux a (i - 1) (A.getUnsafe a i :: res) 
-    
+  if i < 0 then res
+  else fromArrayAux a (i - 1) (A.getUnsafe a i :: res)
+
 let fromArray a =
-  fromArrayAux a (A.length a - 1) []    
+  fromArrayAux a (A.length a - 1) []
 
 let ofArray = fromArray
 
@@ -409,17 +409,17 @@ let toArray ( x : _ t) =
   fillAux arr 0 x;
   arr
 
-let shuffle xs = 
+let shuffle xs =
   let v = toArray xs in
   A.shuffleInPlace v ;
-  fromArray v 
+  fromArray v
 
 let rec fillAuxMap arr i x f =
   match x with
   | [] -> ()
   | h::t ->
     A.setUnsafe arr i (f h [@bs]) ;
-    fillAuxMap arr (i + 1) t f  
+    fillAuxMap arr (i + 1) t f
 
 (* module J = Js_json *)
 (* type json = J.t  *)
@@ -429,8 +429,8 @@ let rec fillAuxMap arr i x f =
 (*   fillAuxMap arr 0 x f; *)
 (*   J.array arr *)
 
-(* TODO: best practice about raising excpetion 
-   1. raise OCaml exception, no stacktrace 
+(* TODO: best practice about raising excpetion
+   1. raise OCaml exception, no stacktrace
    2. raise JS exception, how to pattern match
 *)
 
@@ -450,7 +450,7 @@ let rec fillAuxMap arr i x f =
 (*       head *)
 (*   | None -> *)
 (*     [%assert "Not array when decoding list"] *)
-    
+
 let rec reverseConcat l1 l2 =
   match l1 with
     [] -> l2
@@ -460,18 +460,18 @@ let reverse l = reverseConcat l []
 
 let rec flattenAux prec xs =
   match xs with
-  | [] -> unsafeMutateTail prec [] 
+  | [] -> unsafeMutateTail prec []
   | h::r -> flattenAux (copyAuxCont h prec) r
 
 
-let rec flatten xs =     
-  match xs with 
+let rec flatten xs =
+  match xs with
   | [] -> []
   | []::xs -> flatten xs
-  | (h::t):: r ->  
-    let cell = mutableCell h [] in 
+  | (h::t):: r ->
+    let cell = mutableCell h [] in
     flattenAux (copyAuxCont t cell) r ;
-    cell 
+    cell
 
 let concatMany xs =
   match xs with
@@ -484,128 +484,140 @@ let concatMany xs =
       v := concat (A.getUnsafe xs i) !v
     done ;
     !v
-    
-let rec mapRevAux f accu xs = 
-  match xs with 
+
+let rec mapRevAux f accu xs =
+  match xs with
   | [] -> accu
   | a::l -> mapRevAux f (f a [@bs] :: accu) l
 
-let mapReverseU l f  =
+let mapRightU l f  =
   mapRevAux f [] l
 
-let mapReverse l f = mapReverseU l (fun [@bs] x -> f x)
+let mapRight l f = mapRightU l (fun [@bs] x -> f x)
 
-let rec forEachU xs f  = 
-  match xs with 
+let mapReverseU = mapRightU
+let mapReverse = mapRight
+
+let rec forEachU xs f  =
+  match xs with
     [] -> ()
-  | a::l -> f a [@bs]; forEachU l f 
+  | a::l -> f a [@bs]; forEachU l f
 
-let forEach xs f = forEachU xs (fun [@bs] x -> f x)  
+let forEach xs f = forEachU xs (fun [@bs] x -> f x)
 
-let rec iteri xs i f  = 
-  match xs with 
+let rec iteri xs i f  =
+  match xs with
     [] -> ()
-  | a::l -> f i a [@bs]; iteri l (i + 1) f 
+  | a::l -> f i a [@bs]; iteri l (i + 1) f
 
-let forEachWithIndexU l f  = iteri l 0 f 
+let forEachWithIndexU l f  = iteri l 0 f
 let forEachWithIndex l f = forEachWithIndexU l (fun [@bs] i x -> f i x)
 
 let rec reduceU l accu f   =
   match l with
     [] -> accu
-  | a::l -> reduceU l (f accu a [@bs]) f 
+  | a::l -> reduceU l (f accu a [@bs]) f
 
-let reduce l accu f =   
+let reduce l accu f =
   reduceU l accu (fun[@bs] acc x -> f acc x )
 
 
-let rec reduceReverseUnsafeU l accu f  =
+let rec reduceRightUnsafeU l accu f  =
   match l with
     [] -> accu
-  | a::l -> f (reduceReverseUnsafeU l accu f) a [@bs]
+  | a::l -> f (reduceRightUnsafeU l accu f) a [@bs]
 
-let reduceReverseU (type a ) (type b) (l : a list) (acc : b) f =
+let reduceRightU (type a ) (type b) (l : a list) (acc : b) f =
   let len = length  l in
   if len < 1000 then
-    reduceReverseUnsafeU l acc f
+    reduceRightUnsafeU l acc f
   else
-    A.reduceReverseU (toArray l) acc f
-      
-let reduceReverse l accu f =   
-  reduceReverseU l accu (fun [@bs] a b -> f a b)
+    A.reduceRightU (toArray l) acc f
+
+let reduceRight l accu f =
+  reduceRightU l accu (fun [@bs] a b -> f a b)
+
+let reduceReverseU = reduceRightU
+let reduceReverse = reduceRight
 
 let rec mapRevAux2 l1 l2 accu f =
-  match (l1, l2) with  
+  match (l1, l2) with
   | (a1::l1, a2::l2) -> mapRevAux2  l1 l2  (f a1 a2 [@bs]:: accu) f
-  | _, [] | [], _ -> accu 
+  | _, [] | [], _ -> accu
 
-let mapReverse2U l1 l2 f =
+let mapRight2U l1 l2 f =
   mapRevAux2 l1 l2  [] f
 
-let mapReverse2 l1 l2 f = mapReverse2U l1 l2 (fun [@bs] a b -> f a b)   
+let mapRight2 l1 l2 f = mapRight2U l1 l2 (fun [@bs] a b -> f a b)
+
+let mapReverse2U = mapRight2U
+let mapReverse2 = mapRight2
 
 let rec forEach2U  l1 l2 f =
   match (l1, l2) with
   | (a1::l1, a2::l2) -> f a1 a2 [@bs]; forEach2U  l1 l2 f
   | [],_ | _, [] -> ()
 
-let forEach2 l1 l2 f = forEach2U l1 l2 (fun [@bs] a b -> f a b)  
+let forEach2 l1 l2 f = forEach2U l1 l2 (fun [@bs] a b -> f a b)
 
 let rec reduce2U l1 l2 accu f =
   match (l1, l2) with
-  | (a1::l1, a2::l2) -> 
-    reduce2U l1 l2 (f accu a1 a2 [@bs]) f 
+  | (a1::l1, a2::l2) ->
+    reduce2U l1 l2 (f accu a1 a2 [@bs]) f
   | [], _ | _, [] -> accu
 
-let reduce2 l1 l2 acc f = reduce2U l1 l2 acc (fun[@bs] a b c -> f a b c )  
+let reduce2 l1 l2 acc f = reduce2U l1 l2 acc (fun[@bs] a b c -> f a b c )
 
-let rec reduceReverse2UnsafeU l1 l2 accu f  =
+let rec reduceRight2UnsafeU l1 l2 accu f  =
   match (l1, l2) with
     ([], []) -> accu
   | (a1::l1, a2::l2) ->
-    f (reduceReverse2UnsafeU l1 l2 accu f)  a1 a2 [@bs]
+    f (reduceRight2UnsafeU l1 l2 accu f)  a1 a2 [@bs]
   | _, [] | [], _ -> accu
 
-let reduceReverse2U (type a ) (type b ) (type c)
+let reduceRight2U (type a ) (type b ) (type c)
     (l1 : a list) (l2 : b list) (acc : c) f  =
   let len = length l1 in
   if len < 1000 then
-    reduceReverse2UnsafeU l1 l2 acc f
+    reduceRight2UnsafeU l1 l2 acc f
   else
-    A.reduceReverse2U (toArray l1) (toArray l2) acc f
-      
-let reduceReverse2 l1 l2 acc f =
-  reduceReverse2U l1 l2 acc (fun [@bs] a b c -> f a b c)  
+    A.reduceRight2U (toArray l1) (toArray l2) acc f
 
-let rec everyU xs p = 
-  match xs with 
+let reduceRight2 l1 l2 acc f =
+  reduceRight2U l1 l2 acc (fun [@bs] a b c -> f a b c)
+
+let reduceReverse2U = reduceRight2U
+let reduceReverse2 = reduceRight2
+
+let rec everyU xs p =
+  match xs with
     [] -> true
   | a::l -> p a [@bs] && everyU l p
 
-let every xs p = everyU xs (fun[@bs] x -> p x)  
+let every xs p = everyU xs (fun[@bs] x -> p x)
 
-let rec someU xs p = 
-  match xs with 
+let rec someU xs p =
+  match xs with
     [] -> false
-  | a::l -> p a [@bs] || someU l p 
+  | a::l -> p a [@bs] || someU l p
 
-let some xs p = someU xs (fun[@bs] x -> p x)  
+let some xs p = someU xs (fun[@bs] x -> p x)
 
 let rec every2U l1 l2  p =
   match (l1, l2) with
   | _,[] | [], _ -> true
   | (a1::l1, a2::l2) -> p a1 a2 [@bs] && every2U l1 l2 p
 
-let every2 l1 l2 p = every2U l1 l2 (fun[@bs] a b -> p a b)  
+let every2 l1 l2 p = every2U l1 l2 (fun[@bs] a b -> p a b)
 
-let rec cmpByLength l1 l2 = 
+let rec cmpByLength l1 l2 =
   match l1, l2 with
   | [], [] -> 0
   | _,  [] -> 1
   | [], _ -> -1
   | _ :: l1s , _ :: l2s ->
     cmpByLength l1s l2s
-               
+
 let rec cmpU l1 l2  p =
   match (l1, l2) with
   | [], [] -> 0
@@ -617,13 +629,13 @@ let rec cmpU l1 l2  p =
       cmpU l1 l2 p
     else c
 
-let cmp l1 l2 f = cmpU l1 l2 (fun [@bs] x y -> f x y)    
+let cmp l1 l2 f = cmpU l1 l2 (fun [@bs] x y -> f x y)
 
 
 let rec eqU l1 l2  p =
   match (l1, l2) with
   | [], [] -> true
-  | _ , [] 
+  | _ , []
   | [], _ -> false
   | (a1::l1, a2::l2) ->
     if p a1 a2 [@bs]  then
@@ -634,134 +646,134 @@ let eq l1 l2 f = eqU l1 l2 (fun [@bs] x y -> f x y)
 let rec some2U l1 l2 p =
   match (l1, l2) with
   | [], _ | _, [] -> false
-  | (a1::l1, a2::l2) -> p a1 a2 [@bs] || some2U l1 l2 p 
+  | (a1::l1, a2::l2) -> p a1 a2 [@bs] || some2U l1 l2 p
 
-let some2 l1 l2 p = some2U l1 l2 (fun[@bs] a b -> p a b)  
+let some2 l1 l2 p = some2U l1 l2 (fun[@bs] a b -> p a b)
 
-let rec hasU xs x eq  = 
-  match xs with 
+let rec hasU xs x eq  =
+  match xs with
     [] -> false
-  | a::l -> eq a x [@bs] || hasU l x eq 
+  | a::l -> eq a x [@bs] || hasU l x eq
 
-let has xs x eq = hasU xs x (fun [@bs] a b -> eq a b)  
+let has xs x eq = hasU xs x (fun [@bs] a b -> eq a b)
 
 
-let rec getAssocU  xs x eq = 
-  match xs with 
+let rec getAssocU  xs x eq =
+  match xs with
   | [] -> None
-  | (a,b)::l -> 
-    if eq a x [@bs] then Some b 
-    else getAssocU l x eq 
+  | (a,b)::l ->
+    if eq a x [@bs] then Some b
+    else getAssocU l x eq
 
-let getAssoc xs x eq = getAssocU xs x (fun[@bs] a b -> eq  a b)    
+let getAssoc xs x eq = getAssocU xs x (fun[@bs] a b -> eq  a b)
 
 
-let rec hasAssocU xs x eq = 
-  match xs with 
+let rec hasAssocU xs x eq =
+  match xs with
   | [] -> false
-  | (a, b) :: l -> eq a x [@bs] || hasAssocU l x eq 
+  | (a, b) :: l -> eq a x [@bs] || hasAssocU l x eq
 
-let hasAssoc xs x eq = hasAssocU xs x (fun[@bs] a b -> eq a b)  
+let hasAssoc xs x eq = hasAssocU xs x (fun[@bs] a b -> eq a b)
 
 
 
-let  removeAssocU xs x eq  = 
-  match xs with 
+let  removeAssocU xs x eq  =
+  match xs with
   | [] -> []
   | (a, _ as pair) :: l ->
-    if eq a x [@bs] then l 
-    else 
-      let cell = mutableCell pair [] in 
-      let removed = removeAssocAuxWithMap l x cell eq in 
-      if removed then 
-        cell 
+    if eq a x [@bs] then l
+    else
+      let cell = mutableCell pair [] in
+      let removed = removeAssocAuxWithMap l x cell eq in
+      if removed then
+        cell
       else xs
-      
+
 let removeAssoc xs x eq = removeAssocU xs x (fun [@bs] a b -> eq a b)
 
-let setAssocU xs x k eq = 
+let setAssocU xs x k eq =
   match xs with
   | [] -> [x,k]
-  | (a, _ as pair) :: l -> 
-    if eq a x [@bs] then (x,k)::l 
-    else 
-      let cell = mutableCell pair [] in 
-      let replaced = setAssocAuxWithMap l x k cell eq in 
-      if replaced then cell 
-      else (x,k)::xs 
+  | (a, _ as pair) :: l ->
+    if eq a x [@bs] then (x,k)::l
+    else
+      let cell = mutableCell pair [] in
+      let replaced = setAssocAuxWithMap l x k cell eq in
+      if replaced then cell
+      else (x,k)::xs
 
 let setAssoc xs x k eq = setAssocU xs x k (fun [@bs] a b -> eq a b)
 
-let rec getByU xs p = 
-  match xs with 
+let rec getByU xs p =
+  match xs with
   | [] -> None
-  | x :: l -> 
+  | x :: l ->
     if p x [@bs] then Some x
-    else getByU l p 
+    else getByU l p
 
-let getBy xs p = getByU xs (fun[@bs] a -> p a)    
+let getBy xs p = getByU xs (fun[@bs] a -> p a)
 
-let rec keepU xs p  = 
-  match xs with 
+let rec keepU xs p  =
+  match xs with
   | [] -> []
-  | h::t -> 
-    if p h [@bs] then 
-      begin 
-        let cell = mutableCell h [] in 
+  | h::t ->
+    if p h [@bs] then
+      begin
+        let cell = mutableCell h [] in
         copyAuxWitFilter p t cell ;
-        cell 
+        cell
       end
-    else 
+    else
       keepU t p
-        
+
 let keep xs p = keepU xs (fun[@bs] x -> p x)
 
-let rec keepMapU xs p  = 
-  match xs with 
+let rec keepMapU xs p  =
+  match xs with
   | [] -> []
-  | h::t -> 
+  | h::t ->
     match p h [@bs] with
     | Some h ->
-      begin 
-        let cell = mutableCell h [] in 
+      begin
+        let cell = mutableCell h [] in
         copyAuxWitFilterMap p t cell ;
-        cell 
+        cell
       end
-    | None -> 
+    | None ->
       keepMapU t p
 
-let keepMap xs p = keepMapU xs (fun [@bs] x -> p x)      
+let keepMap xs p = keepMapU xs (fun [@bs] x -> p x)
 
-let partitionU l p  =    
-  match l with 
+let partitionU l p  =
+  match l with
   | [] -> [],[]
-  | h::t -> 
-    let nextX = mutableCell h [] in 
-    let nextY = mutableCell h [] in 
-    let b = p h [@bs]  in 
+  | h::t ->
+    let nextX = mutableCell h [] in
+    let nextY = mutableCell h [] in
+    let b = p h [@bs]  in
     partitionAux p t nextX nextY;
-    if b then 
-      nextX, unsafeTail nextY  
-    else       
-      unsafeTail nextX, nextY 
+    if b then
+      nextX, unsafeTail nextY
+    else
+      unsafeTail nextX, nextY
 
-let partition l p = partitionU l (fun [@bs] x -> p x)      
+let partition l p = partitionU l (fun [@bs] x -> p x)
 
-let rec unzip xs = 
-  match xs with 
+let rec unzip xs =
+  match xs with
   | [] -> ([], [])
   | (x,y)::l ->
     let cellX = mutableCell x [] in
-    let cellY = mutableCell y [] in 
-    splitAux l cellX cellY ; 
+    let cellY = mutableCell y [] in
+    splitAux l cellX cellY ;
     cellX, cellY
 
 
 let rec zip l1 l2 =
   match (l1, l2) with
     _, [] | [], _ -> []
-  | (a1::l1, a2::l2) -> 
-    let cell = mutableCell (a1,a2) [] in 
-    zipAux l1 l2 cell; 
+  | (a1::l1, a2::l2) ->
+    let cell = mutableCell (a1,a2) [] in
+    zipAux l1 l2 cell;
     cell
 

--- a/jscomp/others/belt_List.mli
+++ b/jscomp/others/belt_List.mli
@@ -23,13 +23,13 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 (** {!Belt.List}
-    
+
     Utilities for List data type.
-    
+
     This module is compatible with original ocaml stdlib.
     In general, all functions comes with the original stdlib also
     applies to this collection, however, this module provides  faster
-    and stack safer utilities 
+    and stack safer utilities
 
 *)
 
@@ -52,11 +52,11 @@ val head: 'a t -> 'a option
      head [1;2;3] = Some 1 ;;
    ]}
 *)
-val headExn: 'a t -> 'a  
+val headExn: 'a t -> 'a
 (** [headExn h]
 
     {b See} {!head}
-    
+
     {b raise} an exception if [h] is empty
 
 *)
@@ -68,12 +68,12 @@ val tail: 'a t -> 'a t option
       tail [1;2] = Some [2];;
     ]}
 *)
-    
-val tailExn: 'a t -> 'a t 
+
+val tailExn: 'a t -> 'a t
 (** [tailExn h]
 
     {b See} {!tail}
-    
+
     {b raise} an exception if [h] is empty
 *)
 
@@ -99,40 +99,40 @@ val getExn: 'a t -> int -> 'a
 (** [getExn xs n]
 
     {b See} {!get}
-    
+
     {b raise} an exception if [n] is larger than the length
-*)  
+*)
 
 val make: int -> 'a -> 'a t
-(**  [make n v] 
-  
-    - return a list of length [n] with each element filled with [v]  
+(**  [make n v]
+
+    - return a list of length [n] with each element filled with [v]
     - return the empty list if [n] is negative
 
      @example {[
        make 3 1 =  [1;1;1]
      ]}
 *)
-    
-val makeByU: int -> (int -> 'a [@bs]) -> 'a t 
+
+val makeByU: int -> (int -> 'a [@bs]) -> 'a t
 val makeBy: int -> (int -> 'a) -> 'a t
-(** [makeBy n f] 
-    
+(** [makeBy n f]
+
     - return a list of length [n] with element [i] initialized with [f i]
     - return the empty list if [n] is negative
 
     @example {[
       makeBy 5 (fun i -> i) = [0;1;2;3;4]
     ]}
-*)    
+*)
 
-val shuffle: 'a t -> 'a t 
+val shuffle: 'a t -> 'a t
 (** [shuffle xs]
    @return a new list in random order
 *)
 
 
-val drop: 'a t -> int -> 'a t option 
+val drop: 'a t -> int -> 'a t option
 (** [drop xs n]
 
     return the list obtained by dropping the first [n] elements,
@@ -145,7 +145,7 @@ val drop: 'a t -> int -> 'a t option
     ]}
 *)
 
-val take: 'a t -> int -> 'a t option 
+val take: 'a t -> int -> 'a t option
 (** [take xs n]
 
     return a list with the first [n] elements from [xs],
@@ -158,7 +158,7 @@ val take: 'a t -> int -> 'a t option
     ]}
 *)
 
-val splitAt: 'a t -> int -> ('a list * 'a list) option 
+val splitAt: 'a t -> int -> ('a list * 'a list) option
 (**
     [splitAt xs n]
     split the list [xs] at position [n]
@@ -166,9 +166,9 @@ val splitAt: 'a t -> int -> ('a list * 'a list) option
 
    @example{[
      splitAt [0;1;2;3;4] 2 = Some ([0;1], [2;3;4])
-   ]} 
+   ]}
 *)
-    
+
 val concat: 'a t -> 'a t -> 'a t
 (**
     [concat xs ys]
@@ -197,7 +197,7 @@ val reverseConcat: 'a t -> 'a t -> 'a t
      reverseConcat [1;2] [3;4] = [2;1;3;4]
    ]}
 *)
-    
+
 val flatten: 'a t t -> 'a t
 (**
     [flatten ls]
@@ -236,7 +236,7 @@ val zipBy: 'a t -> 'b t -> ('a -> 'b -> 'c) -> 'c t
 (** [zipBy xs ys f]
 
     {b See} {!zip}
-    
+
     Equivalent to [zip xs ys |> List.map (fun (x,y) -> f x y)]
 *)
 
@@ -248,10 +248,10 @@ val mapWithIndex: 'a t -> (int -> 'a -> 'b) -> 'b t
     ]}
 *)
 
-val ofArray: 'a array -> 'a t 
+val ofArray: 'a array -> 'a t
 [@@ocaml.deprecated "Use fromArray instead"]
 
-val fromArray: 'a array -> 'a t 
+val fromArray: 'a array -> 'a t
 (** @example {[
       fromArray [|1;2;3|]  = [1;2;3]
     ]}
@@ -273,12 +273,15 @@ val reverse: 'a t -> 'a t
       reverse [1;2;3] = [3;2;1]
     ]}
 *)
-    
+
 val mapReverseU: 'a t -> ('a -> 'b [@bs]) -> 'b t
 val mapReverse: 'a t -> ('a -> 'b) -> 'b t
-(** [mapReverse a f]
+[@@ocaml.deprecated "Use mapRight instead"]
 
-    Equivalent to [reverse (map a f)]    
+val mapRight: 'a t -> ('a -> 'b) -> 'b t
+(** [mapRight a f]
+
+    Equivalent to [reverse (map a f)]
 *)
 
 val forEachU: 'a t -> ('a -> 'b [@bs]) -> unit
@@ -290,7 +293,7 @@ val forEach: 'a t -> ('a -> 'b) -> unit
       !us  = 1 + 2 + 3 + 4;;
     ]}
 *)
-  
+
 val forEachWithIndexU: 'a t -> (int -> 'a -> 'b [@bs]) -> unit
 val forEachWithIndex: 'a t -> (int -> 'a -> 'b) -> unit
 (** [forEachWithIndex xs f]
@@ -312,33 +315,39 @@ val reduce:  'a t -> 'b -> ('b -> 'a -> 'b) -> 'b
       reduce [1;2;3;4] [] add = [4;3;2;1];
     ]}
 *)
-  
+
 val reduceReverseU: 'a t -> 'b -> ('b -> 'a ->  'b [@bs]) -> 'b
 val reduceReverse: 'a t -> 'b -> ('b -> 'a ->  'b) -> 'b
-(** [reduceReverse xs f]
+[@@ocaml.deprecated "Use reduceRight instead"]
+
+val reduceRight: 'a t -> 'b -> ('b -> 'a ->  'b) -> 'b
+(** [reduceRight xs f]
 
     @example {[
-      reduceReverse [1;2;3;4] 0 (+) = 10;;
-      reduceReverse [1;2;3;4] 10 (-) = 0;;
-      reduceReverse [1;2;3;4] [] add = [1;2;3;4];;
+      reduceRight [1;2;3;4] 0 (+) = 10;;
+      reduceRight [1;2;3;4] 10 (-) = 0;;
+      reduceRight [1;2;3;4] [] add = [1;2;3;4];;
     ]}
 *)
-  
+
 val mapReverse2U: 'a t -> 'b t -> ('a -> 'b -> 'c [@bs]) -> 'c t
 val mapReverse2: 'a t -> 'b t -> ('a -> 'b -> 'c) -> 'c t
-(** [mapReverse2 xs ys f]
+[@@ocaml.deprecated "Use mapRight2 instead"]
 
-    equivalent to [reverse (zipBy xs ys f)]    
+val mapRight2: 'a t -> 'b t -> ('a -> 'b -> 'c) -> 'c t
+(** [mapRight2 xs ys f]
+
+    equivalent to [reverse (zipBy xs ys f)]
 
     @example {[
-      mapReverse2 [1;2;3] [1;2] (+) = [4;2]
+      mapRight2 [1;2;3] [1;2] (+) = [4;2]
     ]}
 *)
 
 val forEach2U: 'a t -> 'b t -> ('a -> 'b -> 'c [@bs]) -> unit
 val forEach2: 'a t -> 'b t -> ('a -> 'b -> 'c) -> unit
 (** [forEach2 xs ys f] stop with the shorter list
-*)  
+*)
 
 
 val reduce2U:
@@ -347,20 +356,24 @@ val reduce2:
   'b t -> 'c t -> 'a -> ('a -> 'b -> 'c -> 'a) -> 'a
 (** [reduce2 xs ys init f ]
 
-    stops with the shorter list. 
+    stops with the shorter list.
 *)
 
 val reduceReverse2U:
   'a t -> 'b t -> 'c -> ('c -> 'a -> 'b ->  'c [@bs]) -> 'c
 val reduceReverse2:
   'a t -> 'b t -> 'c -> ('c -> 'a -> 'b ->  'c) -> 'c
+[@@ocaml.deprecated "Use reduceRight2 instead"]
+
+val reduceRight2:
+  'a t -> 'b t -> 'c -> ('c -> 'a -> 'b ->  'c) -> 'c
 (**
-   [reduceReverse2 xs ys init f ]
+   [reduceRight2 xs ys init f ]
 
    Stops with the shorter list
 
    @example {[
-     reduceReverse2 [1;2;3] [1;2] 0 (fun acc x y -> acc + x + y) = 6
+     reduceRight2 [1;2;3] [1;2] 0 (fun acc x y -> acc + x + y) = 6
    ]}
 *)
 
@@ -388,7 +401,7 @@ val every2: 'a t -> 'b t -> ('a -> 'b -> bool ) -> bool
 (** [every2 xs ys p] stop with the shorter list
     @example {[
       (every2 [] [1] (fun   x y -> x > y)) = true;;
-      (every2 [2;3] [1] (fun   x y -> x > y)) = true;;    
+      (every2 [2;3] [1] (fun   x y -> x > y)) = true;;
     ]}
 *)
 
@@ -406,7 +419,7 @@ val cmpByLength: 'a t -> 'a t -> int
 
     Compare two lists solely by length
 *)
-  
+
 val cmpU: 'a t -> 'a t -> ('a -> 'a -> int [@bs]) -> int
 val cmp: 'a t -> 'a t -> ('a -> 'a -> int) -> int
 (**
@@ -419,7 +432,7 @@ val cmp: 'a t -> 'a t -> ('a -> 'a -> int) -> int
 
    {b Attention}: The total ordering of List is different from Array,
    for Array, we compare the length first and one by one later, while
-   for lists, we just compare one by one 
+   for lists, we just compare one by one
 *)
 
 
@@ -433,7 +446,7 @@ val eq: 'a t -> 'a t -> ('a -> 'a -> bool) -> bool
       eq [1;2;3] [1;2] (=) = false ;;
       eq [1;2] [1;2] (=) = true
     ]}
-*)  
+*)
 
 
 val hasU:  'a t -> 'b -> ('a -> 'b -> bool [@bs]) -> bool
@@ -450,7 +463,7 @@ val getBy: 'a t -> ('a -> bool) -> 'a option
       getBy [1;4;3;2] (fun x -> x mod 2 = 0) = Some 4
     ]}
 *)
-    
+
 val keepU: 'a t ->  ('a -> bool [@bs]) -> 'a t
 val keep: 'a t ->  ('a -> bool) -> 'a t
 (** [keep  xs p]
@@ -489,7 +502,7 @@ val unzip: ('a * 'b) t -> 'a t * 'b t
 val getAssocU: ('a * 'c) t -> 'b ->  ('a -> 'b -> bool [@bs])  -> 'c option
 val getAssoc: ('a * 'c) t -> 'b ->  ('a -> 'b -> bool)  -> 'c option
 (** [getAssoc xs k eq]
-    
+
     return the second element of a pair in [xs] where the first element equals [x],
     or [None] if not found
     @example {[
@@ -517,19 +530,15 @@ val removeAssoc: ('a * 'c) t -> 'b ->  ('a -> 'b -> bool) -> ('a * 'c) t
 *)
 
 val setAssocU: ('a * 'c) t -> 'a -> 'c -> ('a -> 'a -> bool [@bs]) -> ('a * 'c) t
-val setAssoc: ('a * 'c) t -> 'a -> 'c -> ('a -> 'a -> bool) -> ('a * 'c) t    
+val setAssoc: ('a * 'c) t -> 'a -> 'c -> ('a -> 'a -> bool) -> ('a * 'c) t
 (** [setAssoc xs k v eq]
     if [k] exists in [xs], replace it with the new [v], otherwise, add
     it to the head
     @example {[
       setAssoc [1,"a"; 2, "b"; 3, "c"] 2 "x" (=) =
-      [1,"a"; 2, "x"; 3,"c"] ;; 
+      [1,"a"; 2, "x"; 3,"c"] ;;
 
-      setAssoc [1,"a"; 3, "c"] 2 "2" (=) = 
-      [2,"2"; 1,"a"; 3, "c"] 
+      setAssoc [1,"a"; 3, "c"] 2 "2" (=) =
+      [2,"2"; 1,"a"; 3, "c"]
     ]}
-*)    
-
-
-
-
+*)

--- a/lib/js/belt_Array.js
+++ b/lib/js/belt_Array.js
@@ -386,7 +386,7 @@ function reduce(a, x, f) {
   return reduceU(a, x, Curry.__2(f));
 }
 
-function reduceReverseU(a, x, f) {
+function reduceRightU(a, x, f) {
   var r = x;
   for(var i = a.length - 1 | 0; i >= 0; --i){
     r = f(r, a[i]);
@@ -394,11 +394,11 @@ function reduceReverseU(a, x, f) {
   return r;
 }
 
-function reduceReverse(a, x, f) {
-  return reduceReverseU(a, x, Curry.__2(f));
+function reduceRight(a, x, f) {
+  return reduceRightU(a, x, Curry.__2(f));
 }
 
-function reduceReverse2U(a, b, x, f) {
+function reduceRight2U(a, b, x, f) {
   var r = x;
   var len = Caml_primitive.caml_int_min(a.length, b.length);
   for(var i = len - 1 | 0; i >= 0; --i){
@@ -407,8 +407,8 @@ function reduceReverse2U(a, b, x, f) {
   return r;
 }
 
-function reduceReverse2(a, b, x, f) {
-  return reduceReverse2U(a, b, x, Curry.__3(f));
+function reduceRight2(a, b, x, f) {
+  return reduceRight2U(a, b, x, Curry.__3(f));
 }
 
 function everyU(arr, b) {
@@ -555,6 +555,14 @@ function cmp(a, b, p) {
   return cmpU(a, b, Curry.__2(p));
 }
 
+var reduceReverseU = reduceRightU;
+
+var reduceReverse = reduceRight;
+
+var reduceReverse2U = reduceRight2U;
+
+var reduceReverse2 = reduceRight2;
+
 exports.get = get;
 exports.getExn = getExn;
 exports.set = set;
@@ -596,8 +604,12 @@ exports.reduceU = reduceU;
 exports.reduce = reduce;
 exports.reduceReverseU = reduceReverseU;
 exports.reduceReverse = reduceReverse;
+exports.reduceRightU = reduceRightU;
+exports.reduceRight = reduceRight;
 exports.reduceReverse2U = reduceReverse2U;
 exports.reduceReverse2 = reduceReverse2;
+exports.reduceRight2U = reduceRight2U;
+exports.reduceRight2 = reduceRight2;
 exports.someU = someU;
 exports.some = some;
 exports.everyU = everyU;

--- a/lib/js/belt_List.js
+++ b/lib/js/belt_List.js
@@ -755,17 +755,14 @@ function concatMany(xs) {
   }
 }
 
-function mapReverseU(l, f) {
-  var f$1 = f;
-  var _accu = /* [] */0;
-  var _xs = l;
+function mapRevAux(f, _accu, _xs) {
   while(true) {
     var xs = _xs;
     var accu = _accu;
     if (xs) {
       _xs = xs[1];
       _accu = /* :: */[
-        f$1(xs[0]),
+        f(xs[0]),
         accu
       ];
       continue ;
@@ -776,8 +773,12 @@ function mapReverseU(l, f) {
   };
 }
 
-function mapReverse(l, f) {
-  return mapReverseU(l, Curry.__1(f));
+function mapRightU(l, f) {
+  return mapRevAux(f, /* [] */0, l);
+}
+
+function mapRight(l, f) {
+  return mapRevAux(Curry.__1(f), /* [] */0, l);
 }
 
 function forEachU(_xs, f) {
@@ -840,28 +841,28 @@ function reduce(l, accu, f) {
   return reduceU(l, accu, Curry.__2(f));
 }
 
-function reduceReverseUnsafeU(l, accu, f) {
+function reduceRightUnsafeU(l, accu, f) {
   if (l) {
-    return f(reduceReverseUnsafeU(l[1], accu, f), l[0]);
+    return f(reduceRightUnsafeU(l[1], accu, f), l[0]);
   } else {
     return accu;
   }
 }
 
-function reduceReverseU(l, acc, f) {
+function reduceRightU(l, acc, f) {
   var len = length(l);
   if (len < 1000) {
-    return reduceReverseUnsafeU(l, acc, f);
+    return reduceRightUnsafeU(l, acc, f);
   } else {
-    return Belt_Array.reduceReverseU(toArray(l), acc, f);
+    return Belt_Array.reduceRightU(toArray(l), acc, f);
   }
 }
 
-function reduceReverse(l, accu, f) {
-  return reduceReverseU(l, accu, Curry.__2(f));
+function reduceRight(l, accu, f) {
+  return reduceRightU(l, accu, Curry.__2(f));
 }
 
-function mapReverse2U(l1, l2, f) {
+function mapRight2U(l1, l2, f) {
   var _l1 = l1;
   var _l2 = l2;
   var _accu = /* [] */0;
@@ -885,8 +886,8 @@ function mapReverse2U(l1, l2, f) {
   };
 }
 
-function mapReverse2(l1, l2, f) {
-  return mapReverse2U(l1, l2, Curry.__2(f));
+function mapRight2(l1, l2, f) {
+  return mapRight2U(l1, l2, Curry.__2(f));
 }
 
 function forEach2U(_l1, _l2, f) {
@@ -930,25 +931,25 @@ function reduce2(l1, l2, acc, f) {
   return reduce2U(l1, l2, acc, Curry.__3(f));
 }
 
-function reduceReverse2UnsafeU(l1, l2, accu, f) {
+function reduceRight2UnsafeU(l1, l2, accu, f) {
   if (l1 && l2) {
-    return f(reduceReverse2UnsafeU(l1[1], l2[1], accu, f), l1[0], l2[0]);
+    return f(reduceRight2UnsafeU(l1[1], l2[1], accu, f), l1[0], l2[0]);
   } else {
     return accu;
   }
 }
 
-function reduceReverse2U(l1, l2, acc, f) {
+function reduceRight2U(l1, l2, acc, f) {
   var len = length(l1);
   if (len < 1000) {
-    return reduceReverse2UnsafeU(l1, l2, acc, f);
+    return reduceRight2UnsafeU(l1, l2, acc, f);
   } else {
-    return Belt_Array.reduceReverse2U(toArray(l1), toArray(l2), acc, f);
+    return Belt_Array.reduceRight2U(toArray(l1), toArray(l2), acc, f);
   }
 }
 
-function reduceReverse2(l1, l2, acc, f) {
-  return reduceReverse2U(l1, l2, acc, Curry.__3(f));
+function reduceRight2(l1, l2, acc, f) {
+  return reduceRight2U(l1, l2, acc, Curry.__3(f));
 }
 
 function everyU(_xs, p) {
@@ -1409,6 +1410,22 @@ var size = length;
 
 var ofArray = fromArray;
 
+var mapReverseU = mapRightU;
+
+var mapReverse = mapRight;
+
+var reduceReverseU = reduceRightU;
+
+var reduceReverse = reduceRight;
+
+var mapReverse2U = mapRight2U;
+
+var mapReverse2 = mapRight2;
+
+var reduceReverse2U = reduceRight2U;
+
+var reduceReverse2 = reduceRight2;
+
 exports.length = length;
 exports.size = size;
 exports.head = head;
@@ -1442,6 +1459,7 @@ exports.toArray = toArray;
 exports.reverse = reverse;
 exports.mapReverseU = mapReverseU;
 exports.mapReverse = mapReverse;
+exports.mapRight = mapRight;
 exports.forEachU = forEachU;
 exports.forEach = forEach;
 exports.forEachWithIndexU = forEachWithIndexU;
@@ -1450,14 +1468,17 @@ exports.reduceU = reduceU;
 exports.reduce = reduce;
 exports.reduceReverseU = reduceReverseU;
 exports.reduceReverse = reduceReverse;
+exports.reduceRight = reduceRight;
 exports.mapReverse2U = mapReverse2U;
 exports.mapReverse2 = mapReverse2;
+exports.mapRight2 = mapRight2;
 exports.forEach2U = forEach2U;
 exports.forEach2 = forEach2;
 exports.reduce2U = reduce2U;
 exports.reduce2 = reduce2;
 exports.reduceReverse2U = reduceReverse2U;
 exports.reduceReverse2 = reduceReverse2;
+exports.reduceRight2 = reduceRight2;
 exports.everyU = everyU;
 exports.every = every;
 exports.someU = someU;


### PR DESCRIPTION
Addresses feedback regarding similarity to JS terminology. Fewer keystrokes, so I guess it's nice anyway.

Same for the uncurried version, and map.

Hopefully this is the last piece of naming-related bikeshedding we need to do for a while.