### PR TITLE
Fix external declaration for Js.String.get

### DIFF
--- a/jscomp/others/js_string.ml
+++ b/jscomp/others/js_string.ml
@@ -34,7 +34,7 @@ external fromCodePointMany : int array -> t = "String.fromCodePoint" [@@bs.val] 
 (* String.raw: ES2015, meant to be used with template strings, not directly *)
 
 external length : t -> int = "" [@@bs.get]
-external get : t -> int -> t = "" [@@bs.get_index]
+external get : t -> int -> t option = "" [@@bs.get_index][@@bs.return {undefined_to_opt}]
 
 external charAt : int ->  t = "" [@@bs.send.pipe: t]
 external charCodeAt : int -> float  = "" [@@bs.send.pipe: t]


### PR DESCRIPTION
Js.String.get will return `undefined` if the index passed in is greater than the length of the string passed in. This commit changes the external declaration to return an option rather than a string.

I haven't modified or added any tests at the moment. I guess this is more of a slightly helpful issue than a ready-to-merge PR. Sorry about that!