### PR TITLE
[Do not merge] Sound promises (Repromise)

### DIFF
--- a/jscomp/others/js_promise.mli
+++ b/jscomp/others/js_promise.mli
@@ -1,0 +1,57 @@
+type (+'a, +'e) rejectable
+type never
+
+type +'a t = ('a, never) rejectable
+type +'a promise = 'a t
+
+
+
+(* Note: does not allow rejection. *)
+(* Note, in Repromise, there is:
+     val new_ : unit -> 'a t * ('a -> unit) *)
+val make : (resolve:('a -> unit) -> unit) -> 'a t
+
+val resolve : 'a -> 'a t
+
+val then_ : ('a -> 'b t) -> 'a t -> 'b t
+
+val map : ('a -> 'b) -> 'a t -> 'b t
+
+(* Note: in Repromise, these operate on lists instead of arrays. *)
+val all : ('a t) array -> ('a array) t
+(* Note: all2, ..., all6 can be implemented. *)
+
+val race : ('a t) array -> 'a t
+
+(* Note: there is no reject, catch. *)
+
+
+
+module Rejectable :
+sig
+  type (+'a, +'e) t = ('a, 'e) rejectable
+
+  val relax : 'a promise -> ('a, _) rejectable
+
+  val new_ : unit -> ('a, 'e) rejectable * ('a -> unit) * ('e -> unit)
+
+  val resolve : 'a -> ('a, _) rejectable
+
+  val reject : 'e -> (_, 'e) rejectable
+
+  val then_ :
+    ('a -> ('b, 'e) rejectable) -> ('a, 'e) rejectable -> ('b, 'e) rejectable
+
+  val map : ('a -> 'b) -> ('a, 'e) rejectable -> ('b, 'e) rejectable
+
+  val catch :
+    ('e -> ('a, 'e2) rejectable) -> ('a, 'e) rejectable -> ('a, 'e2) rejectable
+
+  val all : (('a, 'e) rejectable) array -> ('a array, 'e) rejectable
+
+  val race : (('a, 'e) rejectable) array -> ('a, 'e) rejectable
+end
+
+
+
+val onUnhandledException : (exn -> never) ref


### PR DESCRIPTION
I'm opening this PR to start the discussion on upstreaming the JS parts of [Repromise][repromise] into BuckleScript (cc @chenglou). The code in this PR isn't meant to be merged as-is. It's more a sketch of what the change would look like, if we wanted to reimplement `Js.Promise` using the approach of Repromise. The code itself compiles, but I haven't looked into the build failure coming from the surrounding build system.

The API is easiest seen in the new `js_promise.mli` file.

Please ask any questions, offer suggestions, etc.

The rest of this post is a summary of what Repromise does and how it works.

<br/>

1. JS promises are not sound, because resolving a promise with another promise (i.e., `promise(promise('a))`) collapses to just one level of promise (i.e., it turns into `promise('a)`).

    Repromise addresses this by dynamically checking values before they are used to resolve promises. If a value is found to be a promise, it is first wrapped in an object, to prevent the JS runtime from seeing one promise directly nested in another, i.e. `promise({wrapped: promise('a)})`. Repromise quietly unwraps these nested promises when they are later taken out of their outer promises.

2. Because this trick is used only when the nested value is a promise, in most cases, a Repromise is just a normal JS promise. For example, a `Repromise.t(int)` is just a completely ordinary JS promise that can be resolved with `int`s.

    This makes for pretty straightforward interop. It is generally easy to understand the JS representation of a `Repromise.t`. Bindings can be written using the `Repromise.t` type directly, though see the next point about rejection.

3. The "main" Repromise API [does not allow rejection][rejection]. We seem to prefer explicit error handling.

    Since JS promises do have rejection, Repromise provides `Repromise.Rejectable.t('a, 'e)` to help people write bindings. In fact, `Repromise.t('a) = Repromise.Rejectable.t('a, never)`, so these are actually two different views of the same implementation, and everything in (1), (2) applies.

4. Along with not supporting rejection, Repromise does not handle exceptions. For now, all exceptions raised in asynchronous callbacks are passed to `Repromise.onUnhandledException`, which kills the process by default (on native and Node). We will probably need to come up with a better default behavior.

5. Repromise is currently about 4K uncompressed.

<br/>

Minor points:

1. I chose `new_ : unit -> 'a t * ('a -> unit)` instead of `make : (('a -> unit) -> unit) -> 'a t` for the signature of the constructor in Repromise. It fits Reason/OCaml better (we can discuss). In this PR, to simulate backwards compatibility with `Js.Promise.t`, I left the `make`-style signature.

2. I don't know if `all` and `race` should expect/return arrays or lists. I went with arrays in this PR, again to simulate backwards compatibility with `Js.Promise.t`. Repromise has lists. We should probably pick whatever is going to be the most "natural" for BuckleScript/Reason users to write. I think `all` and `race` are typically used with very small numbers of promises. So, I wouldn't expect any performance difference to matter, though I haven't measured it.

3. The API in this PR is not actually backwards compatible with `Js.Promise.t`. It intentionally leaves out the `~reject` callback of the executor in `make`, and does not have `catch` (but does have `Js.Promise.Rejectable.catch`). It also lacks `all2` through `all6` right now, but those can be implemented.

4. I left out documentation, but I will be happy to add it after initial discussions.

5. Repromise is pretty [well-tested][tests]. I'll be happy to adapt tests to the BuckleScript build, again after initial discussions.

<br/>

Repromise also implements the same promise API for native code, but that is left out of this PR. My personal hope is that we can create some kind of isomorphic or near-isomorphic I/O and async story for Reason.



[repromise]: https://github.com/aantron/repromise
[rejection]: https://github.com/aantron/repromise/issues/16
[tests]: https://github.com/aantron/repromise/tree/master/test