### PR TITLE
Js.Obj.assign3

### DIFF
--- a/jscomp/others/js_obj.ml
+++ b/jscomp/others/js_obj.ml
@@ -65,6 +65,8 @@ let _ = Js.log target
 *)
 external assign : < .. > Js.t -> < .. > Js.t -> < .. > Js.t = "Object.assign" [@@bs.val]
 
+external assign3 : < .. > Js.t -> < .. > Js.t -> < .. > Js.t -> < .. > Js.t = "Object.assign" [@@bs.val]
+
 (* TODO:
 
 Should we map this API as directly as possible, provide some abstractions, or deliberately nerf it?


### PR DESCRIPTION
This addresses the common use-case of `Object.assign({}, a, b)`, aka the
JS idiom for immutably updating the object `a`.