### PR TITLE
Pass line number to bspp for correct line number directives generation

### DIFF
--- a/jscomp/core/bspack_main.ml
+++ b/jscomp/core/bspack_main.ml
@@ -42,7 +42,7 @@ let preprocess_string fn str oc =
     |> Lexer.filter_directive_from_lexbuf   in
   segments
   |> List.iter
-    (fun (start, pos) ->
+    (fun (start, pos, _) ->
        output_substring  oc str start (pos - start)
     )
 

--- a/jscomp/core/bspp_main.ml
+++ b/jscomp/core/bspp_main.ml
@@ -19,6 +19,7 @@ let preprocess fn oc =
   let ic = open_in_bin fn in 
   let lexbuf = Lexing.from_channel ic in 
   let buf = Buffer.create 4096 in 
+  let prevLineNumber = ref (-1) in
   Location.init lexbuf fn;
   Lexer.init ();
   lexbuf
@@ -33,7 +34,9 @@ let preprocess fn oc =
          begin
            seek_in ic start ; 
            Buffer.add_channel buf ic len ; 
-           Printf.fprintf oc "#%d \"%s\"" ln fn;
+           if !prevLineNumber <> -1 then
+            Printf.fprintf oc "#%d \"%s\"" (!prevLineNumber + 1) fn;
+           prevLineNumber := ln;
            Buffer.output_buffer oc buf ; 
            Buffer.clear buf;
          end

--- a/jscomp/core/bspp_main.ml
+++ b/jscomp/core/bspp_main.ml
@@ -27,12 +27,13 @@ let preprocess fn oc =
     TODO: output line directive
    *)
   |> List.iter
-    (fun (start, stop) ->       
+    (fun (start, stop, ln) ->       
        let len = stop - start in 
        if len <> 0 then 
          begin
            seek_in ic start ; 
            Buffer.add_channel buf ic len ; 
+           Printf.fprintf oc "#%d \"%s\"" ln fn;
            Buffer.output_buffer oc buf ; 
            Buffer.clear buf;
          end

--- a/vendor/ocaml/parsing/lexer.ml
+++ b/vendor/ocaml/parsing/lexer.ml
@@ -3006,21 +3006,21 @@ and __ocaml_lex_skip_sharp_bang_rec lexbuf __ocaml_lex_state =
     | None -> ()
     | Some (init, _preprocess) -> init ()
 
-  let rec filter_directive pos   acc lexbuf : (int * int ) list =
+  let rec filter_directive pos   acc lexbuf : (int * int * int) list =
     match token_with_comments lexbuf with
     | SHARP when at_bol lexbuf ->
         (* ^[start_pos]#if ... #then^[end_pos] *)
-        let start_pos = Lexing.lexeme_start lexbuf in 
+        let {pos_cnum; pos_lnum} = Lexing.lexeme_end_p lexbuf in 
         interpret_directive lexbuf 
           (fun lexbuf -> 
              filter_directive 
                (Lexing.lexeme_end lexbuf)
-               ((pos, start_pos) :: acc)
+               ((pos, pos_cnum, pos_lnum) :: acc)
                lexbuf
           
           )
           (fun _token -> filter_directive pos acc lexbuf  )
-    | EOF -> (pos, Lexing.lexeme_end lexbuf) :: acc
+    | EOF -> (pos, Lexing.lexeme_end lexbuf, (Lexing.lexeme_end_p lexbuf).pos_lnum) :: acc
     | _ -> filter_directive pos  acc lexbuf
 
   let filter_directive_from_lexbuf lexbuf = 

--- a/vendor/ocaml/parsing/lexer.ml
+++ b/vendor/ocaml/parsing/lexer.ml
@@ -2842,12 +2842,12 @@ and __ocaml_lex_skip_sharp_bang_rec lexbuf __ocaml_lex_state =
               | END -> 
                   begin
                     update_if_then_else Dir_out;
-                    cont lexbuf
+                    cont lexbuf false
                   end
               | ELSE -> 
                   begin
                     update_if_then_else Dir_if_false;
-                    cont lexbuf
+                    cont lexbuf true
                   end
               | IF ->
                   raise (Error (Unexpected_directive, Location.curr lexbuf))
@@ -2856,7 +2856,7 @@ and __ocaml_lex_skip_sharp_bang_rec lexbuf __ocaml_lex_state =
                      directive_parse token_with_comments lexbuf then
                     begin
                       update_if_then_else Dir_if_true;
-                      cont lexbuf
+                      cont lexbuf true
                     end
                   else skip_from_if_false ()                               
             end
@@ -2864,7 +2864,7 @@ and __ocaml_lex_skip_sharp_bang_rec lexbuf __ocaml_lex_state =
         if directive_parse token_with_comments lexbuf then
           begin 
             update_if_then_else Dir_if_true (* Next state: ELSE *);
-            cont lexbuf
+            cont lexbuf true
           end
         else
           skip_from_if_false ()
@@ -2886,7 +2886,7 @@ and __ocaml_lex_skip_sharp_bang_rec lexbuf __ocaml_lex_state =
               | END -> 
                   begin
                     update_if_then_else Dir_out;
-                    cont lexbuf
+                    cont lexbuf false
                   end  
               | IF ->  
                   raise (Error (Unexpected_directive, Location.curr lexbuf)) 
@@ -2908,7 +2908,7 @@ and __ocaml_lex_skip_sharp_bang_rec lexbuf __ocaml_lex_state =
         raise (Error(Unexpected_directive, Location.curr lexbuf))
     | END, (Dir_if_false | Dir_if_true ) -> 
         update_if_then_else  Dir_out;
-        cont lexbuf
+        cont lexbuf false
     | END,  Dir_out  -> 
         raise (Error(Unexpected_directive, Location.curr lexbuf))
     | token, (Dir_if_true | Dir_if_false | Dir_out) ->
@@ -2965,7 +2965,7 @@ and __ocaml_lex_skip_sharp_bang_rec lexbuf __ocaml_lex_state =
           loop lines' docs lexbuf
       | SHARP when at_bol lexbuf -> 
           interpret_directive lexbuf 
-            (fun lexbuf -> loop lines docs lexbuf)
+            (fun lexbuf _ -> loop lines docs lexbuf)
             (fun token -> sharp_look_ahead := Some token; SHARP)
 #if undefined BS_MIN_LEX_DEPS then
       | DOCSTRING doc ->
@@ -3010,17 +3010,17 @@ and __ocaml_lex_skip_sharp_bang_rec lexbuf __ocaml_lex_state =
     match token_with_comments lexbuf with
     | SHARP when at_bol lexbuf ->
         (* ^[start_pos]#if ... #then^[end_pos] *)
-        let {pos_cnum; pos_lnum} = Lexing.lexeme_end_p lexbuf in 
+        let start_pos = Lexing.lexeme_start lexbuf in
         interpret_directive lexbuf 
-          (fun lexbuf -> 
+          (fun lexbuf start -> 
              filter_directive 
                (Lexing.lexeme_end lexbuf)
-               ((pos, pos_cnum, pos_lnum) :: acc)
+               ((pos, start_pos, if start then (Lexing.lexeme_start_p lexbuf).pos_lnum else (Lexing.lexeme_end_p lexbuf).pos_lnum) :: acc)
                lexbuf
           
           )
           (fun _token -> filter_directive pos acc lexbuf  )
-    | EOF -> (pos, Lexing.lexeme_end lexbuf, (Lexing.lexeme_end_p lexbuf).pos_lnum) :: acc
+    | EOF -> (pos, Lexing.lexeme_end lexbuf, -1) :: acc
     | _ -> filter_directive pos  acc lexbuf
 
   let filter_directive_from_lexbuf lexbuf = 

--- a/vendor/ocaml/parsing/lexer.mli
+++ b/vendor/ocaml/parsing/lexer.mli
@@ -89,7 +89,7 @@ val set_preprocessor :
 (** semantic version predicate *)
 val semver : Location.t ->   string -> string -> bool
 
-val filter_directive_from_lexbuf : Lexing.lexbuf -> (int * int) list
+val filter_directive_from_lexbuf : Lexing.lexbuf -> (int * int * int) list
 
 val replace_directive_int : string -> int -> unit
 val replace_directive_string : string -> string -> unit

--- a/vendor/ocaml/parsing/lexer.mll
+++ b/vendor/ocaml/parsing/lexer.mll
@@ -1181,12 +1181,12 @@ and skip_sharp_bang = parse
               | END -> 
                   begin
                     update_if_then_else Dir_out;
-                    cont lexbuf
+                    cont lexbuf false
                   end
               | ELSE -> 
                   begin
                     update_if_then_else Dir_if_false;
-                    cont lexbuf
+                    cont lexbuf true
                   end
               | IF ->
                   raise (Error (Unexpected_directive, Location.curr lexbuf))
@@ -1195,7 +1195,7 @@ and skip_sharp_bang = parse
                      directive_parse token_with_comments lexbuf then
                     begin
                       update_if_then_else Dir_if_true;
-                      cont lexbuf
+                      cont lexbuf true
                     end
                   else skip_from_if_false ()                               
             end
@@ -1203,7 +1203,7 @@ and skip_sharp_bang = parse
         if directive_parse token_with_comments lexbuf then
           begin 
             update_if_then_else Dir_if_true (* Next state: ELSE *);
-            cont lexbuf
+            cont lexbuf true
           end
         else
           skip_from_if_false ()
@@ -1225,7 +1225,7 @@ and skip_sharp_bang = parse
               | END -> 
                   begin
                     update_if_then_else Dir_out;
-                    cont lexbuf
+                    cont lexbuf false
                   end  
               | IF ->  
                   raise (Error (Unexpected_directive, Location.curr lexbuf)) 
@@ -1247,7 +1247,7 @@ and skip_sharp_bang = parse
         raise (Error(Unexpected_directive, Location.curr lexbuf))
     | END, (Dir_if_false | Dir_if_true ) -> 
         update_if_then_else  Dir_out;
-        cont lexbuf
+        cont lexbuf false
     | END,  Dir_out  -> 
         raise (Error(Unexpected_directive, Location.curr lexbuf))
     | token, (Dir_if_true | Dir_if_false | Dir_out) ->
@@ -1304,7 +1304,7 @@ and skip_sharp_bang = parse
           loop lines' docs lexbuf
       | SHARP when at_bol lexbuf -> 
           interpret_directive lexbuf 
-            (fun lexbuf -> loop lines docs lexbuf)
+            (fun lexbuf _ -> loop lines docs lexbuf)
             (fun token -> sharp_look_ahead := Some token; SHARP)
 #if undefined BS_MIN_LEX_DEPS then
       | DOCSTRING doc ->
@@ -1349,17 +1349,17 @@ and skip_sharp_bang = parse
     match token_with_comments lexbuf with
     | SHARP when at_bol lexbuf ->
         (* ^[start_pos]#if ... #then^[end_pos] *)
-        let {pos_cnum; pos_lnum} = Lexing.lexeme_end_p lexbuf in 
+        let start_pos = Lexing.lexeme_start lexbuf in
         interpret_directive lexbuf 
-          (fun lexbuf -> 
+          (fun lexbuf start -> 
              filter_directive 
                (Lexing.lexeme_end lexbuf)
-               ((pos, pos_cnum, pos_lnum) :: acc)
+               ((pos, start_pos, if start then (Lexing.lexeme_start_p lexbuf).pos_lnum else (Lexing.lexeme_end_p lexbuf).pos_lnum) :: acc)
                lexbuf
           
           )
           (fun _token -> filter_directive pos acc lexbuf  )
-    | EOF -> (pos, Lexing.lexeme_end lexbuf, (Lexing.lexeme_end_p lexbuf).pos_lnum) :: acc
+    | EOF -> (pos, Lexing.lexeme_end lexbuf, -1) :: acc
     | _ -> filter_directive pos  acc lexbuf
 
   let filter_directive_from_lexbuf lexbuf = 

--- a/vendor/ocaml/parsing/lexer.mll
+++ b/vendor/ocaml/parsing/lexer.mll
@@ -1345,21 +1345,21 @@ and skip_sharp_bang = parse
     | None -> ()
     | Some (init, _preprocess) -> init ()
 
-  let rec filter_directive pos   acc lexbuf : (int * int ) list =
+  let rec filter_directive pos   acc lexbuf : (int * int * int) list =
     match token_with_comments lexbuf with
     | SHARP when at_bol lexbuf ->
         (* ^[start_pos]#if ... #then^[end_pos] *)
-        let start_pos = Lexing.lexeme_start lexbuf in 
+        let {pos_cnum; pos_lnum} = Lexing.lexeme_end_p lexbuf in 
         interpret_directive lexbuf 
           (fun lexbuf -> 
              filter_directive 
                (Lexing.lexeme_end lexbuf)
-               ((pos, start_pos) :: acc)
+               ((pos, pos_cnum, pos_lnum) :: acc)
                lexbuf
           
           )
           (fun _token -> filter_directive pos acc lexbuf  )
-    | EOF -> (pos, Lexing.lexeme_end lexbuf) :: acc
+    | EOF -> (pos, Lexing.lexeme_end lexbuf, (Lexing.lexeme_end_p lexbuf).pos_lnum) :: acc
     | _ -> filter_directive pos  acc lexbuf
 
   let filter_directive_from_lexbuf lexbuf = 


### PR DESCRIPTION
Currently if you have this code:
```ocaml
#if BS_NATIVE then
let a = 1
#else
let b = "1" + 1
#end
```
And you compile it with BS_NATIVE=true
You'll get an error on line 1 rather than line 3 (because the resulting
code, after the pp ran, is simply the code inside the `else`)