### PR TITLE
Add utility functions to belt_String.

### DIFF
--- a/jscomp/others/belt_String.ml
+++ b/jscomp/others/belt_String.ml
@@ -159,6 +159,11 @@ external substr : from:int -> t = "" [@@bs.send.pipe: t]
 *)
 external trim : t -> t = "" [@@bs.send]
 
+(* link to JS built-ins *)
+external str_length: t -> int = "length" [@@bs.get]
+external str_charAt: t -> int -> t = "charAt" [@@bs.send]
+external array_concat: 'a array -> 'a array -> 'a array = "concat" [@@bs.send]
+
 (**
   [reduce str f] takes a string argument, initial value, and a reducer
   function [f] whose arguments are an accumulated value and a character from the string.
@@ -178,11 +183,12 @@ external trim : t -> t = "" [@@bs.send]
   reduce "abcde" "" reverser = "edcba"
 ]}
 *)
+
 let reduce (s: string) (acc: 'a) (f: 'a -> string -> 'a) =
   (let rec helper (acc: 'a) (index: int) =
     match index with
-    | n when n == (Js.String.length s) -> acc
-    | n -> helper (f acc (Js.String.get s n)) (n + 1) in
+    | n when n == (str_length s) -> acc
+    | n -> helper (f acc (str_charAt s n)) (n + 1) in
 
   helper acc 0 : 'a)
 
@@ -209,7 +215,7 @@ map "abcde" toCode = [| 97.0; 98.0; 99.0; 100.0; 101.0 |]
 ]}
 *)
 let map (s : string) (f : string -> 'a) =
-  (reduce s [||] (fun acc item -> Belt.Array.concat acc [|(f item)|]) : 'a array)
+  (reduce s [||] (fun acc item -> array_concat acc [|(f item)|]) : 'a array)
 
 (**
   [stringKeep s f] applies a function [f] to each character in the given string [s].
@@ -237,4 +243,4 @@ keep "cauliflower" nonVowel = [|"c"; "l"; "f"; "l"; "w"; "r"|]
 *)
 let keep (s:string) (f: string -> bool) =
   (reduce s [||] (fun acc item ->
-    if (f item) then Belt.Array.concat acc [|item|] else acc) : 'a array)
+    if (f item) then array_concat acc [|item|] else acc) : 'a array)

--- a/jscomp/others/belt_String.ml
+++ b/jscomp/others/belt_String.ml
@@ -203,54 +203,55 @@ let reduce (s: string) (acc: 'a) (f: 'a -> string -> 'a) =
   helper acc 0 : 'a)
 
 (**
-  [stringMap s f] applies a function [f] to each character in the given string [s],
+  [map s f] applies a function [f] to each character in the given string [s],
   returning a new string with the concatenated results of the function calls.
+  Note that the return value from this function is a string.
 
 @example {[
 let addDash (s : string) = (s ^ "-" : string)
-stringMap "abcde" addDash = "a-b-c-d-e-"
+map "abcde" addDash = "a-b-c-d-e-"
 ]}
 *)
 
-let stringMap (s : string) (f : string -> string) =
+let map (s : string) (f : string -> string) =
   (reduce s "" (fun acc item -> acc ^ (f item)) : string)
 
 (**
-  [map s f] applies a function [f] to each character in the given string [s],
+  [arrayMap s f] applies a function [f] to each character in the given string [s],
   returning an array containing the results of the function calls.
   
 @example {[
 let toCode (s : string) = (Js.String.charCodeAt 0 s : float)
-map "abcde" toCode = [| 97.0; 98.0; 99.0; 100.0; 101.0 |]
+arrayMap "abcde" toCode = [| 97.0; 98.0; 99.0; 100.0; 101.0 |]
 ]}
 *)
-let map (s : string) (f : string -> 'a) =
+let arrayMap (s : string) (f : string -> 'a) =
   (reduce s [||] (fun acc item -> array_concat acc [|(f item)|]) : 'a array)
 
 (**
-  [stringKeep s f] applies a function [f] to each character in the given string [s].
+  [keep s f] applies a function [f] to each character in the given string [s].
   It returns a new string containing only the characters for which [f] returned [true].
 
 @example {[
 let nonVowel (s:string) = 
   (not (s = "a" || s = "e" || s = "i" || s = "o" || s = "u") : bool)
-stringKeep "cauliflower" nonVowel = "clflwr"
+keep "cauliflower" nonVowel = "clflwr"
 ]}
 *)
-let stringKeep (s: string) (f: string -> bool) =
+let keep (s: string) (f: string -> bool) =
   (reduce s "" (fun acc item ->
       if (f item) then acc ^ item else acc) : string)
 
 (**
-  [keep s f] applies a function [f] to each character in the given string [s].
+  [arrayKeep s f] applies a function [f] to each character in the given string [s].
   It returns an array containing only the characters for which [f] returned [true].
   
 @example {[
 let nonVowel (s:string) = 
   (not (s = "a" || s = "e" || s = "i" || s = "o" || s = "u") : bool)
-keep "cauliflower" nonVowel = [|"c"; "l"; "f"; "l"; "w"; "r"|]
+arrayKeep "cauliflower" nonVowel = [|"c"; "l"; "f"; "l"; "w"; "r"|]
 ]}
 *)
-let keep (s:string) (f: string -> bool) =
+let arrayKeep (s:string) (f: string -> bool) =
   (reduce s [||] (fun acc item ->
     if (f item) then array_concat acc [|item|] else acc) : 'a array)


### PR DESCRIPTION
Adds functions:

* `stringMap` and `stringKeep`, which apply a function to a string, character by character, returning a new string. 
* `map` and `keep`, which apply a function to a string, character by character, returning an array of `'a`.
* `reduce`, which applies a reducer function to a string, character by character. (All the other functions are defined in terms of `reduce`). I did not see a need for `stringReduce`