### PR TITLE
Support Js.Dict.unsafeDeleteKey on 'a Js.Dict.t

### DIFF
--- a/jscomp/others/js_dict.ml
+++ b/jscomp/others/js_dict.ml
@@ -53,7 +53,7 @@ external keys : 'a t -> key array = "Object.keys" [@@bs.val]
 external empty : unit -> 'a t = "" [@@bs.obj]
 
 
-let unsafeDeleteKey : string t -> string -> unit [@bs] =
+let unsafeDeleteKey : 'a t -> string -> unit [@bs] =
   fun%raw dict key -> {|
      delete dict[key];
      return 0

--- a/jscomp/others/js_dict.mli
+++ b/jscomp/others/js_dict.mli
@@ -60,7 +60,7 @@ external empty : unit -> 'a t = "" [@@bs.obj]
 (** [empty ()] returns an empty dictionary *)
 
 (** Experimental internal funciton *)
-val unsafeDeleteKey : string t -> string -> unit [@bs]
+val unsafeDeleteKey : 'a t -> string -> unit [@bs]
 
 (* external entries : 'a t -> (key * 'a) array = "Object.entries" [@@bs.val] *)
 val entries : 'a t -> (key * 'a) array


### PR DESCRIPTION
I believe `Js.Dict.unsafeDeleteKey` would work on `'a Js.Dict.t` yet the type signature scopes it down to a `string Js.Dict.t` making it quite awkward to delete a key-value pair in a Js.Dict.

My workaround is a bit ugly:

```ocaml
Js.Dict.set dict key (Obj.magic Js.Nullable.undefined)
```

I'm not sure why this function is experimental/internal, so maybe there was a reason this should be scoped to only `string Js.Dict.t`. Please share if so.

Thanks!