### PR TITLE
Attempt to extend Node.Buffer external definitions

### DIFF
--- a/jscomp/others/node_buffer.ml
+++ b/jscomp/others/node_buffer.ml
@@ -423,6 +423,7 @@ external includes :
   *)
 external includesString :
   t -> 
+  string ->
   ?byteOffset:int ->
   ?encoding: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
   unit -> bool = "includes"

--- a/jscomp/others/node_buffer.ml
+++ b/jscomp/others/node_buffer.ml
@@ -373,16 +373,16 @@ external readInt16BE : t -> ?offset:int -> unit -> int = "readInt16BE" [@@bs.sen
 external readInt16LE : t -> ?offset:int -> unit -> int = "readInt16LE" [@@bs.send]
 external readInt32BE : t -> ?offset:int -> unit -> int = "readInt32BE" [@@bs.send]
 external readInt32LE : t -> ?offset:int -> unit -> int = "readInt32LE" [@@bs.send]
-external readIntBE : t -> offset:int -> byteLength:int -> ?offset:int -> unit = "readIntBE" [@@bs.send]
-external readIntLE : t -> offset:int -> byteLength:int -> ?offset:int -> unit = "readIntLE" [@@bs.send]
+external readIntBE : t -> offset:int -> byteLength:int -> int = "readIntBE" [@@bs.send]
+external readIntLE : t -> offset:int -> byteLength:int -> int = "readIntLE" [@@bs.send]
 
 external readUint8 : t -> ?offset:int -> unit -> int = "readUInt8" [@@bs.send]
 external readUint16BE : t -> ?offset:int -> unit -> int = "readUInt16BE" [@@bs.send]
 external readUint16LE : t -> ?offset:int -> unit -> int = "readUInt16LE" [@@bs.send]
 external readUint32BE : t -> ?offset:int -> unit -> int = "readUInt32BE" [@@bs.send]
 external readUint32LE : t -> ?offset:int -> unit -> int = "readUInt32LE" [@@bs.send]
-external readUintBE : t -> offset:int -> byteLength:int -> ?offset:int -> unit = "readUIntBE" [@@bs.send]
-external readUintLE : t -> offset:int -> byteLength:int -> ?offset:int -> unit = "readUIntLE" [@@bs.send]
+external readUintBE : t -> offset:int -> byteLength:int -> int = "readUIntBE" [@@bs.send]
+external readUintLE : t -> offset:int -> byteLength:int -> int = "readUIntLE" [@@bs.send]
 
 (** Returns a new [Buffer] that references the same memory as the original, 
     but offset and cropped by the [start] and [end_] indices.

--- a/jscomp/others/node_buffer.ml
+++ b/jscomp/others/node_buffer.ml
@@ -26,84 +26,139 @@
 
 type t = Node.buffer 
 
-external isBuffer : 'a -> bool = "isBuffer" [@@bs.val] [@@bs.scope "Buffer"]
+(** Allocates a new [Buffer] of [size] bytes. If [fill] is not passed, the 
+    [Buffer] will be zero-filled.
 
-external fromString : string -> t = "from" [@@bs.val] [@@bs.scope "Buffer"]
+    @param size The desired length of the new [Buffer].
+    @param fill A value to pre-fill the new [Buffer] with. Default: [0].
+    @param encoding If [fill] is a string, this is its encoding.
 
-external fromArray : int array -> t = "from" [@@bs.val] [@@bs.scope "Buffer"]
-
-external fromBuffer : t -> t = "from" [@@bs.val] [@@bs.scope "Buffer"]
-
-external fromArrayBuffer : Js_typed_array2.array_buffer -> ?offset:int -> ?length:int -> unit -> t = "from" [@@bs.val] [@@bs.scope "Buffer"]
-
-external fromStringWithEncoding :
-  string ->
-  ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string])
-  -> t = "from"
- [@@bs.val] [@@bs.scope "Buffer"]
-
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_alloc_size_fill_encoding> Node.js API docs
+    @since Node.js v5.10.0
+  *)
 external alloc : 
   int ->
-  ?fill:([ `String of string | `Integer of int | `Buffer of t ] [@bs.unwrap]) ->
+  ?fill:([ `String of string | `Integer of int | `Buffer of t | `UInt8Array of Js_typed_array2.Uint8Array.t ] [@bs.unwrap]) ->
   ?encoding: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) -> 
   unit -> t = "alloc"
 [@@bs.val] [@@bs.scope "Buffer"]
 
-external allocUnsafe : int -> t = "allocUnsafe"
-[@@bs.val] [@@bs.scope "Buffer"]
+(** Allocates a new [Buffer] of size bytes. If size is larger than
+    buffer.constants.MAX_LENGTH or smaller than 0, ERR_INVALID_OPT_VALUE is thrown.
+    A zero-length Buffer is created if size is 0.
+    The underlying memory for Buffer instances created in this way is not initialized.
+    The contents of the newly created Buffer are unknown and may contain sensitive data.
+    Use [Buffer.alloc] instead to initialize [Buffer] instances with zeroes.
 
-external allocUnsafeSlow : int -> t = "allocUnsafeSlow"
-[@@bs.val] [@@bs.scope "Buffer"]
+    @param size The desired length of the new [Buffer].
 
-external byteLength : t -> int = "byteLength"
-[@@bs.get]
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_allocunsafe_size> Node.js API docs
+    @since Node.js v5.10.0
+  *)
+external allocUnsafe : int -> t = "allocUnsafe" [@@bs.val] [@@bs.scope "Buffer"]
 
-external byteOffset : t -> int = "byteOffset"
-[@@bs.get]
+(** Allocates a new Buffer of size bytes. If size is larger than
+    buffer.constants.MAX_LENGTH or smaller than 0, ERR_INVALID_OPT_VALUE is thrown.
+    A zero-length Buffer is created if size is 0.
+    The underlying memory for Buffer instances created in this way is not initialized.
+    The contents of the newly created Buffer are unknown and may contain sensitive data.
+    Use [Buffer.alloc] to initialize such [Buffer] instances with zeroes.
+    When using [Buffer.allocUnsafe] to allocate new [Buffer] instances, allocations
+    under 4KB are sliced from a single pre-allocated [Buffer]. This allows applications
+    to avoid the garbage collection overhead of creating many individually allocated
+    [Buffer] instances. This approach improves both performance and memory usage by 
+    eliminating the need to track and clean up as many persistent objects.
+    However, in the case where a developer may need to retain a small chunk of memory
+    from a pool for an indeterminate amount of time, it may be appropriate to create
+    an un-pooled [Buffer] instance using Buffer.allocUnsafeSlow() and then copying out
+    the relevant bits.
 
-external byteLengthWithEncoding : 
-  ([ `String of string | `Buffer of t ] [@bs.unwrap]) ->
-  ?encoding: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
-  unit ->
+    @param size The desired length of the new Buffer.
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_allocunsafeslow_size> Node.js API docs
+    @since Node.js v5.12.0
+  *)
+external allocUnsafeSlow : int -> t = "allocUnsafeSlow" [@@bs.val] [@@bs.scope "Buffer"]
+
+(** Returns the actual byte length of a thing. 
+    For calculating bytelength of strings, see [byteLengthOfString].
+
+    @param value Array, or Buffer-like value to calculate the length of.
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_bytelength_string_encoding> Node.js API docs
+    @since Node.js v0.1.90 
+  *)
+external byteLength : 
+  ([
+   | `Buffer of t
+   | `ArrayBuffer of Js_typed_array2.ArrayBuffer.t
+   | `DataView of Js_typed_array2.DataView.t
+   | `Int8Array of Js_typed_array2.Int8Array.t
+   | `Uint8Array of Js_typed_array2.Uint8Array.t
+   | `Uint8ClampedArray of Js_typed_array2.Uint8ClampedArray.t
+   | `Int16Array of Js_typed_array2.Int16Array.t
+   | `Uint16Array of Js_typed_array2.Uint16Array.t
+   | `Int32Array of Js_typed_array2.Int32Array.t
+   | `Uint32Array of Js_typed_array2.Uint32Array.t
+   | `Float32Array of Js_typed_array2.Float32Array.t
+   | `Float64Array of Js_typed_array2.Float64Array.t
+   ] [@bs.unwrap]) ->
   int = "byteLength"
 [@@bs.val] [@@bs.scope "Buffer"]
 
-external compare : t -> t -> int = "compare"
+(** Returns the actual byte length of a string.
+    This is not the same as String.prototype.length since that returns the number 
+    of characters in a string.
+
+    For '`base64' and '`hex', this function assumes valid input. For strings 
+    that contain non-Base64/Hex-encoded data (e.g. whitespace), the return value
+    might be greater than the length of a Buffer created from the string.
+
+    @param string A value to calculate the length of.
+    @param encoding [string]'s encoding. Default is [`utf8].
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_bytelength_string_encoding> Node.js API docs
+    @since Node.js v0.1.90
+  *)
+external byteLengthOfString :
+    string ->
+    ?encoding: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
+    unit ->
+    int = "byteLength"
 [@@bs.val] [@@bs.scope "Buffer"]
 
-external toString : t -> string = "toString" [@@bs.send]
+(** Compares buf1 to buf2 typically for the purpose of sorting arrays of [Buffer] instances. 
 
-external toStringWithEncoding : 
-  t ->
-  ?encoding: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
-  ?start: int ->
-  ?end_: int ->
-  unit -> string = "toString"
-[@@bs.send]
+    @param buf1 
+    @param buf2 
+    @return [1] if [buf1] sorts after [buf2], [0] if they are the equal, [-1] if [buf2] sorts after [buf1].
 
-external concat : t array -> t = "concat"
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_compare_buf1_buf2> Node.js API docs
+    @since Node.js v0.11.13
+  *)
+external compare : 
+  ([`Buffer of t | `Uint8Array of Js_typed_array2.Uint8Array.t ] [@bs.unwrap]) ->
+  ([`Buffer of t | `Uint8Array of Js_typed_array2.Uint8Array.t ] [@bs.unwrap]) -> 
+  int = "compare"
 [@@bs.val] [@@bs.scope "Buffer"]
 
-external concatWithTotalLength : t array -> int -> t = "concat"
-[@@bs.val] [@@bs.scope "Buffer"]
+(** Compares buf with target and returns a number indicating whether buf comes
+    before, after, or is the same as target in sort order.
+    Comparison is based on the actual sequence of bytes in each [Buffer]. 
+    
+    @param buf
+    @param target
+    @param targetStart The offset within [target] at which to begin comparison. Default: [0].
+    @param targetEnd  The offset within target at which to end comparison (not inclusive). Default: [length target].
+    @param sourceStart  The offset within buf at which to begin comparison. Default: [0].
+    @param sourceEnd  The offset within buf at which to end comparison (not inclusive). Default: [length buf].
 
-external isEncoding : string -> bool = "isEncoding"
-[@@bs.val] [@@bs.scope "Buffer"]
-
-(* TODO: How to support mutation of this value? *)
-external poolSize : int = "poolSize"
-[@@bs.val] [@@bs.scope "Buffer"]
-
-external unsafe_get : t -> int -> int = ""
-[@@bs.get_index]
-
-external unsafe_set : t -> int -> int -> unit = ""
-[@@bs.set_index]
-
-external buffer : t -> Js_typed_array2.array_buffer = "buffer"
-[@@bs.get]
-
-external compare :
+    @return [1] if [buf] sorts after [target], [0] if they are the equal, [-1] if [target] sorts after [buf].
+    
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_compare_target_targetstart_targetend_sourcestart_sourceend> Node.js API docs
+    @since Node.js v0.11.13
+  *)
+external compareRanges :
   t -> t ->
   ?targetStart: int ->
   ?targetEnd: int ->
@@ -112,122 +167,555 @@ external compare :
   unit -> int = "compare"
 [@@bs.send]
 
+(** Returns a new [Buffer] which is the result of concatenating all the [Buffer]
+    instances in the list together.
+
+    If the [list] has no items, then a new zero-length [Buffer] is returned.
+
+    @param list List of [Buffer] instances to concat.
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_concat_list_totallength> Node.js API docs
+    @since Node.js v0.7.11
+  *)
+external concat : t array -> t = "concat" [@@bs.val] [@@bs.scope "Buffer"]
+
+(** Returns a new [Buffer] which is the result of concatenating all the [Buffer]
+    instances in the list together.
+
+    If the [list] has no items, or if the totalLength is 0, then a new zero-length
+    Buffer is returned.
+    If [totalLength] is not provided, it is calculated from the [Buffer] instances
+    in [list]. This however causes an additional loop to be executed in order to
+    calculate the [totalLength], so it is faster to provide the length explicitly 
+    if it is already known.
+    If totalLength is provided, it is coerced to an unsigned integer.
+    If the combined length of the Buffers in list exceeds [totalLength], the result
+    is truncated to [totalLength].
+
+    @param list List of [Buffer] instances to concat.
+    @param totalLength Total length of the [Buffer] instances in list when concatenated.
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_concat_list_totallength> Node.js API docs
+    @since Node.js v0.7.11
+  *)
+external concatWithLength : t array -> totalLength:int -> t = "concat" [@@bs.val] [@@bs.scope "Buffer"]
+
+(** Allocates a new [Buffer] using an array of octets.
+
+    @param array Array of octets.
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_from_array> Node.js API docs
+    @since Node.js v5.10.0
+  *)
+external fromArray : int array -> t = "from" [@@bs.val] [@@bs.scope "Buffer"]
+
+(** This creates a view of the [ArrayBuffer] without copying the underlying memory.
+    For example, when passed a reference to the .buffer property of a [TypedArray]
+    instance, the newly created [Buffer] will share the same allocated memory as the
+    [TypedArray].
+
+    @param arrayBuffer Source ArrayBuffer instance.
+    @param byteOffset Index of first byte to expose. Default: [0].
+    @param length Number of bytes to expose. Default: [(length arrayBuffer) - byteOffset].
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_from_arraybuffer_byteoffset_length> Node.js API docs
+    @since Node.js v5.10.0
+  *)
+external fromArrayBuffer : 
+  Js_typed_array2.ArrayBuffer.t ->
+  ?byteOffset:int ->
+  ?length:int ->
+  unit ->
+  t = "from"
+[@@bs.val] [@@bs.scope "Buffer"]
+
+(** Copies the passed [buffer] data onto a new [Buffer] instance.
+
+    @param buffer An existing Buffer or Uint8Array from which to copy data.
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_from_buffer> Node.js API docs
+    @since Node.js v5.10.0
+  *)
+external fromBuffer : 
+  ([`Buffer of t | `Uint8Array of Js_typed_array2.Uint8Array.t ] [@bs.unwrap]) ->
+  t = "from"
+[@@bs.val] [@@bs.scope "Buffer"]
+
+(** Creates a new [Buffer] containing a [string] using [`utf8] encoding.
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_from_string_encoding> Node.js API docs
+    @since Node.js v5.10.0
+  *)
+external fromString : string -> t = "from" [@@bs.val] [@@bs.scope "Buffer"]
+
+(** Creates a new [Buffer] containing a [string]. The [encoding] parameter identifies
+    the character encoding of [string].
+    
+    @param string A string to encode
+    @param encoding The encoding of the string. Default is [`utf8]
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_from_string_encoding> Node.js API docs
+    @since Node.js v5.10.0
+  *)
+external fromStringWithEncoding : string ->
+  ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
+  t = "from"
+[@@bs.val] [@@bs.scope "Buffer"]
+
+
+(** Returns true if obj is a Buffer, false otherwise.
+
+    @param obj Value to test.
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_isbuffer_obj> Node.js API docs
+    @since Node.js v0.1.101
+*)
+external isBuffer : 'a -> bool = "isBuffer" [@@bs.val] [@@bs.scope "Buffer"]
+
+(** Returns [true] if [encoding] contains a supported character encoding, or [false] otherwise.
+
+    @param encoding String that is tested for supported encoding value.
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_isencoding_encoding> Node.js API docs
+    @since v0.9.1
+  *)
+external isEncoding : string -> bool = "isEncoding" [@@bs.val] [@@bs.scope "Buffer"]
+
+(** This is the size (in bytes) of pre-allocated internal [Buffer] instances
+    used for pooling.
+  
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_property_buffer_poolsize> Node.js API docs
+    @since Node.js v0.11.3
+  *)
+external poolSize : int = "poolSize" [@@bs.val] [@@bs.scope "Buffer"]
+
+(** Unsafe byte reading by its [index].
+    Underneath it uses index access syntax in Javascript.
+
+    @param buffer Buffer to get value from.
+    @param index Index to read from.
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_index> Node.js API docs
+  *)
+external unsafe_get : t -> int -> int = "" [@@bs.get_index]
+
+(** Unsafe byte writing by its [index].
+    Underneath it uses index access syntax in Javascript.
+
+    @param buffer Buffer to write value to.
+    @param index Index to write to.
+    @param value Value to write. The values refer to individual bytes, so the legal value range is between 0x00 and 0xFF (hex) or 0 and 255 (decimal).
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_index> Node.js API docs
+  *)
+external unsafe_set : t -> index:int -> int -> unit = "" [@@bs.set_index]
+
+(** Returns the underlying ArrayBuffer object based on which this Buffer object is created.
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_buffer> Node.js API docs
+  *)
+external buffer : t -> Js_typed_array2.ArrayBuffer.t = "buffer" [@@bs.get]
+
+(** Returns [byteOffset] on the underlying [ArrayBuffer] object based on which this
+    [Buffer] object is created.
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_byteoffset> Node.js API docs
+  *)
+external byteOffset : t -> int = "byteOffset" [@@bs.get]
+
+(** Copies data from a region of [buf] to a region in [target] even if the [target]
+    memory region overlaps with [buf].
+
+    @param buf
+    @param target
+    @param targetStart The offset within [target] at which to begin writing. Default: [0].
+    @param sourceStart The offset within [buf] from which to begin copying. Default: [0].
+    @param sourceEnd The offset within [buf] at which to stop copying (not inclusive). Default: [length buf].
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_copy_target_targetstart_sourcestart_sourceend> Node.js API docs
+    @since Node.js v0.1.90
+  *)
 external copy :
-  t -> t ->
+  t ->
+  target:t ->
   ?targetStart:int ->
   ?sourceStart:int ->
   ?sourceEnd:int ->
   unit -> int = "copy"
 [@@bs.send]
 
-external equals : t -> t -> bool = "equals"
-[@@bs.send]
+(** Returns [true] if both [buf] and [otherBuffer] have exactly the same bytes,
+    [false] otherwise.
 
+    @param buf
+    @param otherBuffer
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_equals_otherbuffer> Node.js API docs
+    @since Node.js v0.11.13
+  *)
+external equals : t -> t -> bool = "equals" [@@bs.send]
+
+(** Fills [buf] with the specified [value]. If the [offset] and [end_] are not given, 
+    the entire [buf] will be filled.
+
+    @param buf
+    @param value The value with which to fill [buf].
+    @param offset Number of bytes to skip before starting to fill [buf]. Default: [0].
+    @param end_ Where to stop filling buf (not inclusive). Default: [length buf].
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_fill_value_offset_end_encoding> Node.js API docs
+    @since Node.js v0.5.0
+ *)
 external fill :
   t ->
-  ([ `String of string | `Integer of int | `Buffer of t ] [@bs.unwrap]) ->
+  ([ `Integer of int | `Buffer of t | `Uint8Array of Js_typed_array2.Uint8Array.t ] [@bs.unwrap]) ->
+  ?offset:int ->
+  ?end_:int ->
+  unit -> t = "fill"
+[@@bs.send]
+
+(** Fills [buf] with the specified [value]. If the [offset] and [end_] are not given, 
+    the entire [buf] will be filled.
+
+    @param buf
+    @param value The value with which to fill [buf].
+    @param offset Number of bytes to skip before starting to fill [buf]. Default: [0].
+    @param end_ Where to stop filling buf (not inclusive). Default: [length buf].
+    @param encoding The encoding for value. Default: [`utf8].
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_fill_value_offset_end_encoding> Node.js API docs
+    @since Node.js v0.5.0
+ *)
+external fillWithString :
+  t ->
+  string ->
   ?offset:int ->
   ?end_:int ->
   ?encoding: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
   unit -> t = "fill"
 [@@bs.send]
 
+(** Tests, if [buf] has provided [value] looking from [byteOffset].
+
+    @param buf
+    @param value What to search for.
+    @param byteOffset Where to begin searching in [buf]. If negative, then offset is calculated from the end of [buf]. Default: [0].
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_includes_value_byteoffset_encoding> Node.js API docs
+    @since Node.js v5.3.0
+  *)
 external includes :
+  t -> 
+  ([ `Integer of int | `Buffer of t | `Uint8Array of Js_typed_array2.Uint8Array.t ] [@bs.unwrap]) ->
+  ?byteOffset:int ->
+  unit -> bool = "includes"
+[@@bs.send]
+
+(** Tests, if [buf] has provided [value] looking from [byteOffset].
+
+    @param buf
+    @param string What to search for.
+    @param byteOffset Where to begin searching in [buf]. If negative, then offset is calculated from the end of [buf]. Default: [0].
+    @param encoding Encoding of the [string]. Default is [`utf8].
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_includes_value_byteoffset_encoding> Node.js API docs
+    @since Node.js v5.3.0
+  *)
+external includesString :
   t -> 
   ?byteOffset:int ->
   ?encoding: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
   unit -> bool = "includes"
 [@@bs.send]
 
+(** Searches for first occurence of [value] in [buf].
+
+    @param buf
+    @param value What to search for.
+    @param byteOffset Where to begin searching in [buf]. If negative, then offset is calculated from the end of [buf]. Default: [0].
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_indexof_value_byteoffset_encoding> Node.js API docs
+    @since Node.js v1.5.0
+  *)
 external indexOf :
   t -> 
-  ([ `String of string | `Integer of int | `Buffer of t ] [@bs.unwrap]) ->
+  ([ `Integer of int | `Buffer of t | `Uint8Array of Js_typed_array2.Uint8Array.t ] [@bs.unwrap]) ->
+  ?byteOffset:int ->
+  unit -> int = "indexOf"
+[@@bs.send]
+
+(** Searches for first occurence of [string] in [buf].
+
+    @param buf
+    @param string What to search for.
+    @param byteOffset Where to begin searching in [buf]. If negative, then offset is calculated from the end of [buf]. Default: [0].
+    @param encoding Encoding of the [string]. Default is [`utf8].
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_indexof_value_byteoffset_encoding> Node.js API docs
+    @since Node.js v1.5.0
+  *)
+external indexOfString :
+  t -> 
+  string ->
   ?byteOffset:int ->
   ?encoding: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
   unit -> int = "indexOf"
 [@@bs.send]
 
+(** Searches for last occurence of [value] in [buf].
+
+    @param buf
+    @param value What to search for.
+    @param byteOffset Where to begin searching in [buf]. If negative, then offset is calculated from the end of [buf]. Default: [(length buf) - 1].
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_lastindexof_value_byteoffset_encoding> Node.js API docs
+    @since Node.js v6.0.0
+  *)
 external lastIndexOf :
   t -> 
-  ([ `String of string | `Integer of int | `Buffer of t ] [@bs.unwrap]) ->
+  ([ `Integer of int | `Buffer of t | `Uint8Array of Js_typed_array2.Uint8Array.t ] [@bs.unwrap]) ->
+  ?byteOffset:int ->
+  unit -> int = "lastIndexOf"
+[@@bs.send]
+
+(** Searches for last occurence of [string] in [buf].
+
+    @param buf
+    @param string What to search for.
+    @param byteOffset Where to begin searching in [buf]. If negative, then offset is calculated from the end of [buf]. Default: [(length buf) - 1].
+    @param encoding Encoding of the [string]. Default is [`utf8].
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_lastindexof_value_byteoffset_encoding> Node.js API docs
+    @since Node.js v6.0.0
+  *)
+external lastIndexOfString :
+  t -> 
+  string ->
   ?byteOffset:int ->
   ?encoding: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
   unit -> int = "lastIndexOf"
 [@@bs.send]
 
-external length : t -> int = "length" 
-[@@bs.get]
+(** Returns the amount of memory allocated for [buf] in bytes.
+    This does not necessarily reflect the amount of "usable" data within [buf].
 
-external readDoubleBE : t -> int -> float = "readDoubleBE" [@@bs.send]
-external readDoubleLE : t -> int -> float = "readDoubleLE" [@@bs.send]
-external readFloatBE : t -> int -> float = "readFloatBE" [@@bs.send]
-external readFloatLE : t -> int -> float = "readFloatLE" [@@bs.send]
+    @param buf
 
-external readInt8 : t -> int -> int = "readInt8" [@@bs.send]
-external readInt16BE : t -> int -> int = "readInt16BE" [@@bs.send]
-external readInt16LE : t -> int -> int = "readInt16LE" [@@bs.send]
-external readInt32BE : t -> int -> int = "readInt32BE" [@@bs.send]
-external readInt32LE : t -> int -> int = "readInt32LE" [@@bs.send]
-external readIntBE : t -> offset:int -> byteLength:int -> int = "readIntBE" [@@bs.send]
-external readIntLE : t -> offset:int -> byteLength:int -> int = "readIntLE" [@@bs.send]
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_length> Node.js API docs
+    @since Node.js v0.1.90
+  *)
+external length : t -> int = "length" [@@bs.get]
 
-external readUInt8 : t -> int -> int = "readUInt8" [@@bs.send]
-external readUInt16BE : t -> int -> int = "readUInt16BE" [@@bs.send]
-external readUInt16LE : t -> int -> int = "readUInt16LE" [@@bs.send]
-external readUInt32BE : t -> int -> int = "readUInt32BE" [@@bs.send]
-external readUInt32LE : t -> int -> int = "readUInt32LE" [@@bs.send]
-external readUIntBE : t -> offset:int -> byteLength:int -> int = "readUIntBE" [@@bs.send]
-external readUIntLE : t -> offset:int -> byteLength:int -> int = "readUIntLE" [@@bs.send]
 
+external readDoubleBE : t -> ?offset:int -> unit -> float = "readDoubleBE" [@@bs.send]
+external readDoubleLE : t -> ?offset:int -> unit -> float = "readDoubleLE" [@@bs.send]
+external readFloatBE : t -> ?offset:int -> unit -> float = "readFloatBE" [@@bs.send]
+external readFloatLE : t -> ?offset:int -> unit -> float = "readFloatLE" [@@bs.send]
+
+external readInt8 : t -> ?offset:int -> unit -> int = "readInt8" [@@bs.send]
+external readInt16BE : t -> ?offset:int -> unit -> int = "readInt16BE" [@@bs.send]
+external readInt16LE : t -> ?offset:int -> unit -> int = "readInt16LE" [@@bs.send]
+external readInt32BE : t -> ?offset:int -> unit -> int = "readInt32BE" [@@bs.send]
+external readInt32LE : t -> ?offset:int -> unit -> int = "readInt32LE" [@@bs.send]
+external readIntBE : t -> offset:int -> byteLength:int -> ?offset:int -> unit = "readIntBE" [@@bs.send]
+external readIntLE : t -> offset:int -> byteLength:int -> ?offset:int -> unit = "readIntLE" [@@bs.send]
+
+external readUInt8 : t -> ?offset:int -> unit -> int = "readUInt8" [@@bs.send]
+external readUInt16BE : t -> ?offset:int -> unit -> int = "readUInt16BE" [@@bs.send]
+external readUInt16LE : t -> ?offset:int -> unit -> int = "readUInt16LE" [@@bs.send]
+external readUInt32BE : t -> ?offset:int -> unit -> int = "readUInt32BE" [@@bs.send]
+external readUInt32LE : t -> ?offset:int -> unit -> int = "readUInt32LE" [@@bs.send]
+external readUIntBE : t -> offset:int -> byteLength:int -> ?offset:int -> unit = "readUIntBE" [@@bs.send]
+external readUIntLE : t -> offset:int -> byteLength:int -> ?offset:int -> unit = "readUIntLE" [@@bs.send]
+
+(** Returns a new [Buffer] that references the same memory as the original, 
+    but offset and cropped by the [start] and [end_] indices.
+
+    @param buf
+    @param start Where the new [Buffer] will start. Default: [0].
+    @param end Where the new [Buffer] will end (not inclusive). Default: [length buf].
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_subarray_start_end> Node.js API docs
+    @since Node.js v3.0.0
+  *)
 external subarray : t -> ?start: int -> ?end_: int -> unit -> t = "subarray" [@@bs.send]
+
+(** Returns a new [Buffer] that references the same memory as the original, 
+    but offset and cropped by the [start] and [end_] indices.
+
+    @param buf
+    @param start Where the new [Buffer] will start. Default: [0].
+    @param end Where the new [Buffer] will end (not inclusive). Default: [length buf].
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_slice_start_end> Node.js API docs
+    @since Node.js v0.3.0
+  *)
 external slice : t -> ?start: int -> ?end_:int -> unit -> t = "slice" [@@bs.send]
 
+(** Interprets [buf] as an array of unsigned 16-bit integers and swaps the byte order in-place.
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_swap16> Node.js API docs
+    @since Node.js v5.10.0
+  *)
 external swap16 : t -> t = "swap16" [@@bs.send]
+
+(** Interprets [buf] as an array of unsigned 32-bit integers and swaps the byte order in-place.
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_swap32> Node.js API docs
+    @since Node.js v5.10.0
+  *)
 external swap32 : t -> t = "swap32" [@@bs.send] 
+
+(** Interprets [buf] as an array of unsigned 64-bit integers and swaps the byte order in-place.
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_swap64> Node.js API docs
+    @since Node.js v6.3.0
+  *)
 external swap64 : t -> t = "swap64" [@@bs.send] 
 
+(** Returns a JSON representation of [buf]. 
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_tojson> Node.js API docs
+    @since Node.js v0.9.2
+  *)
 external toJSON : t -> Js.Json.t = "toJSON" [@@bs.send]
 
+(** Serializes [buf] to [string] using [`utf8] encoding.
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_tostring_encoding_start_end> Node.js API docs
+    @since Node.js v0.1.90
+*)
+external toString : t -> string = "toString" [@@bs.send]
+
+(** Serializes [buf] to [string] using [encoding] encoding.
+
+    @param buf
+    @param encoding Encoding of the resulting [string]. Default is [`utf8].
+    @param start The byte offset to start decoding at. Default: [0].
+    @param end_ The byte offset to stop decoding at (not inclusive). Default: [length buf].
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_tostring_encoding_start_end> Node.js API docs
+    @since Node.js v0.1.90
+*)
+external toStringWithEncoding : 
+  t ->
+  ?encoding: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
+  ?start: int ->
+  ?end_: int ->
+  unit -> 
+  string = "toString"
+[@@bs.send]
+
+(** Writes [string] to [buf] at [offset] according to the character encoding in [encoding].
+
+    @param buf
+    @param string String to write to [buf].
+    @param offset Number of bytes to skip before starting to write [string]. Default: [0].
+    @param encoding The character encoding of [string]. Default: [`utf8].
+
+    @see <https://nodejs.org/api/buffer.html#buffer_buf_write_string_offset_length_encoding> Node.js API docs
+    @since Node.js v0.1.90
+  *)
 external write :
   t ->
   string ->
   ?offset:int ->
+  ?encoding: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
+  unit ->
+  int = "write" [@@bs.send]
+
+(** Writes [string] to [buf] at [offset] according to the character encoding in [encoding].
+    The [length] parameter is the number of bytes to write.
+
+    @param buf
+    @param string String to write to [buf].
+    @param offset Number of bytes to skip before starting to write [string]. Default: [0].
+    @param length Number of bytes to write. Default: [(length buf) - offset].
+    @param encoding The character encoding of [string]. Default: [`utf8].
+
+    @see <https://nodejs.org/api/buffer.html#buffer_buf_write_string_offset_length_encoding> Node.js API docs
+    @since Node.js v0.1.90
+  *)
+external writeLength :
+  t ->
+  string ->
+  offset:int ->
   ?length:int ->
   ?encoding: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
-  unit -> int = "write" [@@bs.send]
+  unit ->
+  int = "write" [@@bs.send]
 
-external writeDoubleBE : t -> float -> offset:int -> int = "writeDoubleBE" [@@bs.send]
-external writeDoubleLE : t -> float -> offset:int -> int = "writeDoubleLE" [@@bs.send]
-external writeFloatBE : t -> float -> offset:int -> int = "writeFloatBE" [@@bs.send]
-external writeFloatLE : t -> float -> offset:int -> int = "writeFloatLE" [@@bs.send]
 
-external writeInt8 : t -> int -> offset:int -> int = "writeInt8" [@@bs.send]
-external writeInt16BE : t -> int -> offset:int -> int = "writeInt16BE" [@@bs.send]
-external writeInt16LE : t -> int -> offset:int -> int = "writeInt16LE" [@@bs.send]
-external writeInt32BE : t -> int -> offset:int -> int = "writeInt32BE" [@@bs.send]
-external writeInt32LE : t -> int -> offset:int -> int = "writeInt32LE" [@@bs.send]
+external writeDoubleBE : t -> float -> ?offset:int -> unit -> int = "writeDoubleBE" [@@bs.send]
+external writeDoubleLE : t -> float -> ?offset:int -> unit -> int = "writeDoubleLE" [@@bs.send]
+external writeFloatBE : t -> float -> ?offset:int -> unit -> int = "writeFloatBE" [@@bs.send]
+external writeFloatLE : t -> float -> ?offset:int -> unit -> int = "writeFloatLE" [@@bs.send]
+
+external writeInt8 : t -> int -> ?offset:int -> unit -> int = "writeInt8" [@@bs.send]
+external writeInt16BE : t -> int -> ?offset:int -> unit -> int = "writeInt16BE" [@@bs.send]
+external writeInt16LE : t -> int -> ?offset:int -> unit -> int = "writeInt16LE" [@@bs.send]
+external writeInt32BE : t -> int -> ?offset:int -> unit -> int = "writeInt32BE" [@@bs.send]
+external writeInt32LE : t -> int -> ?offset:int -> unit -> int = "writeInt32LE" [@@bs.send]
 external writeIntBE : t -> int -> offset:int -> byteLength:int -> int = "writeIntBE" [@@bs.send]
 external writeIntLE : t -> int -> offset:int -> byteLength:int -> int = "writeIntLE" [@@bs.send]
 
-external writeUInt8 : t -> int -> offset:int -> int = "writeUInt8" [@@bs.send]
-external writeUInt16BE : t -> int -> offset:int -> int = "writeUInt16BE" [@@bs.send]
-external writeUInt16LE : t -> int -> offset:int -> int = "writeUInt16LE" [@@bs.send]
-external writeUInt32BE : t -> int -> offset:int -> int = "writeUInt32BE" [@@bs.send]
-external writeUInt32LE : t -> int -> offset:int -> int = "writeUInt32LE" [@@bs.send]
+external writeUInt8 : t -> int -> ?offset:int -> unit -> int = "writeUInt8" [@@bs.send]
+external writeUInt16BE : t -> int -> ?offset:int -> unit -> int = "writeUInt16BE" [@@bs.send]
+external writeUInt16LE : t -> int -> ?offset:int -> unit -> int = "writeUInt16LE" [@@bs.send]
+external writeUInt32BE : t -> int -> ?offset:int -> unit -> int = "writeUInt32BE" [@@bs.send]
+external writeUInt32LE : t -> int -> ?offset:int -> unit -> int = "writeUInt32LE" [@@bs.send]
 external writeUIntBE : t -> int -> offset:int -> byteLength:int -> int = "writeUIntBE" [@@bs.send]
 external writeUIntLE : t -> int -> offset:int -> byteLength:int -> int = "writeUIntLE" [@@bs.send]
 
-external _INSPECT_MAX_BYTES : t -> int = "INSPECT_MAX_BYTES" [@@bs.get]
-external kMaxLength : t -> int = "kMaxLength" [@@bs.get]
+(** Returns the maximum number of bytes that will be returned when [buf.inspect()] is called. 
 
+    @see <https://nodejs.org/api/buffer.html#buffer_buffer_inspect_max_bytes> Node.js API docs
+    @since Node.js v0.5.4
+  *)
+external _INSPECT_MAX_BYTES : int = "INSPECT_MAX_BYTES" [@@bs.module "buffer"]
+
+(** An alias for buffer.constants.MAX_LENGTH. 
+
+    @see <https://nodejs.org/api/buffer.html#buffer_buffer_inspect_max_bytes> Node.js API docs
+    @since Node.js v3.0.0
+  *)
+external kMaxLength : int = "kMaxLength" [@@bs.module "buffer"]
+
+(** Re-encodes the given [Buffer] or [Uint8Array] instance from one character encoding to another.
+    Returns a new [Buffer] instance.
+
+    @param buffer [Buffer] or [UInt8Array] to transcode.
+    @param fromEnc The current encoding.
+    @param toEnc To target encoding.
+
+    @see <https://nodejs.org/api/buffer.html#buffer_buffer_transcode_source_fromenc_toenc> Node.js API docs
+    @since Node.js v7.1.0
+  *)
 external transcode : 
-  t ->
+  ([ `Buffer of t | `UInt8Array of Js_typed_array2.Uint8Array.t ] [@bs.unwrap]) ->
   fromEnc: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
   toEnc: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
   t = "transcode"
-[@@bs.val] [@@bs.scope "Buffer"]
+[@@bs.module "buffer"]
 
-external _MAX_LENGTH : int = "MAX_LENGTH" [@@bs.val] [@@bs.scope "Buffer.constants"]
-external _MAX_STRING_LENGTH : int = "MAX_STRING_LENGTH" [@@bs.val] [@@bs.scope "Buffer.constants"]
+(** The largest size allowed for a single [Buffer] instance.
+
+    On 32-bit architectures, this value is (2^30)-1 (~1GB). 
+    On 64-bit architectures, this value is (2^31)-1 (~2GB).
+
+    @see <https://nodejs.org/api/buffer.html#buffer_buffer_constants_max_length> Node.js API docs
+    @since Node.js v8.2.0
+  *)
+external _MAX_LENGTH : int = "MAX_LENGTH" [@@bs.module "buffer"] [@@bs.scope "constants"]
+
+(** The largest length allowed for a single [string] instance.
+
+    Represents the largest length that a [string] primitive can have, counted in UTF-16 code units.
+    This value may depend on the JS engine that is being used.
+
+    @see <https://nodejs.org/api/buffer.html#buffer_buffer_constants_max_string_length> Node.js API docs
+    @since Node.js v8.2.0
+  *)
+external _MAX_STRING_LENGTH : int = "MAX_STRING_LENGTH" [@@bs.module "buffer"] [@@bs.scope "constants"]
 
 

--- a/jscomp/others/node_buffer.ml
+++ b/jscomp/others/node_buffer.ml
@@ -22,16 +22,15 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-(** Node Buffer API *)
+(** Node Buffer API 
+
+    @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html> Node.js API Buffer module
+    *)
 
 type t = Node.buffer 
 
 (** Allocates a new [Buffer] of [size] bytes. If [fill] is not passed, the 
     [Buffer] will be zero-filled.
-
-    @param size The desired length of the new [Buffer].
-    @param fill A value to pre-fill the new [Buffer] with. Default: [0].
-    @param encoding If [fill] is a string, this is its encoding.
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_alloc_size_fill_encoding> Node.js API docs
     @since Node.js v5.10.0
@@ -43,37 +42,15 @@ external alloc :
   unit -> t = "alloc"
 [@@bs.val] [@@bs.scope "Buffer"]
 
-(** Allocates a new [Buffer] of size bytes. If size is larger than
-    buffer.constants.MAX_LENGTH or smaller than 0, ERR_INVALID_OPT_VALUE is thrown.
-    A zero-length Buffer is created if size is 0.
-    The underlying memory for Buffer instances created in this way is not initialized.
-    The contents of the newly created Buffer are unknown and may contain sensitive data.
-    Use [Buffer.alloc] instead to initialize [Buffer] instances with zeroes.
-
-    @param size The desired length of the new [Buffer].
-
+(** Allocates a new [Buffer] of [size] bytes. 
+    
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_allocunsafe_size> Node.js API docs
     @since Node.js v5.10.0
   *)
 external allocUnsafe : int -> t = "allocUnsafe" [@@bs.val] [@@bs.scope "Buffer"]
 
-(** Allocates a new Buffer of size bytes. If size is larger than
-    buffer.constants.MAX_LENGTH or smaller than 0, ERR_INVALID_OPT_VALUE is thrown.
-    A zero-length Buffer is created if size is 0.
-    The underlying memory for Buffer instances created in this way is not initialized.
-    The contents of the newly created Buffer are unknown and may contain sensitive data.
-    Use [Buffer.alloc] to initialize such [Buffer] instances with zeroes.
-    When using [Buffer.allocUnsafe] to allocate new [Buffer] instances, allocations
-    under 4KB are sliced from a single pre-allocated [Buffer]. This allows applications
-    to avoid the garbage collection overhead of creating many individually allocated
-    [Buffer] instances. This approach improves both performance and memory usage by 
-    eliminating the need to track and clean up as many persistent objects.
-    However, in the case where a developer may need to retain a small chunk of memory
-    from a pool for an indeterminate amount of time, it may be appropriate to create
-    an un-pooled [Buffer] instance using Buffer.allocUnsafeSlow() and then copying out
-    the relevant bits.
-
-    @param size The desired length of the new Buffer.
+(** Allocates a new Buffer of [size] bytes. 
+    Unpooled buffer allocation, see original docs for additional details.
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_allocunsafeslow_size> Node.js API docs
     @since Node.js v5.12.0
@@ -81,9 +58,6 @@ external allocUnsafe : int -> t = "allocUnsafe" [@@bs.val] [@@bs.scope "Buffer"]
 external allocUnsafeSlow : int -> t = "allocUnsafeSlow" [@@bs.val] [@@bs.scope "Buffer"]
 
 (** Returns the actual byte length of a thing. 
-    For calculating bytelength of strings, see [byteLengthOfString].
-
-    @param value Array, or Buffer-like value to calculate the length of.
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_bytelength_string_encoding> Node.js API docs
     @since Node.js v0.1.90 
@@ -107,15 +81,6 @@ external byteLength :
 [@@bs.val] [@@bs.scope "Buffer"]
 
 (** Returns the actual byte length of a string.
-    This is not the same as String.prototype.length since that returns the number 
-    of characters in a string.
-
-    For '`base64' and '`hex', this function assumes valid input. For strings 
-    that contain non-Base64/Hex-encoded data (e.g. whitespace), the return value
-    might be greater than the length of a Buffer created from the string.
-
-    @param string A value to calculate the length of.
-    @param encoding [string]'s encoding. Default is [`utf8].
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_bytelength_string_encoding> Node.js API docs
     @since Node.js v0.1.90
@@ -127,11 +92,7 @@ external byteLengthOfString :
     int = "byteLength"
 [@@bs.val] [@@bs.scope "Buffer"]
 
-(** Compares buf1 to buf2 typically for the purpose of sorting arrays of [Buffer] instances. 
-
-    @param buf1 
-    @param buf2 
-    @return [1] if [buf1] sorts after [buf2], [0] if they are the equal, [-1] if [buf2] sorts after [buf1].
+(** Compares buf1 to buf2 for the purpose of sorting.  
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_compare_buf1_buf2> Node.js API docs
     @since Node.js v0.11.13
@@ -142,18 +103,7 @@ external compare :
   int = "compare"
 [@@bs.val] [@@bs.scope "Buffer"]
 
-(** Compares buf with target and returns a number indicating whether buf comes
-    before, after, or is the same as target in sort order.
-    Comparison is based on the actual sequence of bytes in each [Buffer]. 
-    
-    @param buf
-    @param target
-    @param targetStart The offset within [target] at which to begin comparison. Default: [0].
-    @param targetEnd  The offset within target at which to end comparison (not inclusive). Default: [length target].
-    @param sourceStart  The offset within buf at which to begin comparison. Default: [0].
-    @param sourceEnd  The offset within buf at which to end comparison (not inclusive). Default: [length buf].
-
-    @return [1] if [buf] sorts after [target], [0] if they are the equal, [-1] if [target] sorts after [buf].
+(** Compares buf with target and returns a number indicating sorting order.
     
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_compare_target_targetstart_targetend_sourcestart_sourceend> Node.js API docs
     @since Node.js v0.11.13
@@ -170,10 +120,6 @@ external compareRanges :
 (** Returns a new [Buffer] which is the result of concatenating all the [Buffer]
     instances in the list together.
 
-    If the [list] has no items, then a new zero-length [Buffer] is returned.
-
-    @param list List of [Buffer] instances to concat.
-
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_concat_list_totallength> Node.js API docs
     @since Node.js v0.7.11
   *)
@@ -182,27 +128,14 @@ external concat : t array -> t = "concat" [@@bs.val] [@@bs.scope "Buffer"]
 (** Returns a new [Buffer] which is the result of concatenating all the [Buffer]
     instances in the list together.
 
-    If the [list] has no items, or if the totalLength is 0, then a new zero-length
-    Buffer is returned.
-    If [totalLength] is not provided, it is calculated from the [Buffer] instances
-    in [list]. This however causes an additional loop to be executed in order to
-    calculate the [totalLength], so it is faster to provide the length explicitly 
-    if it is already known.
-    If totalLength is provided, it is coerced to an unsigned integer.
-    If the combined length of the Buffers in list exceeds [totalLength], the result
-    is truncated to [totalLength].
-
-    @param list List of [Buffer] instances to concat.
-    @param totalLength Total length of the [Buffer] instances in list when concatenated.
+    Passing [totalLength] explicitly removes additional loop over list of buffers.
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_concat_list_totallength> Node.js API docs
     @since Node.js v0.7.11
   *)
 external concatWithLength : t array -> totalLength:int -> t = "concat" [@@bs.val] [@@bs.scope "Buffer"]
 
-(** Allocates a new [Buffer] using an array of octets.
-
-    @param array Array of octets.
+(** Allocates a new [Buffer] using from an array of octets.
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_from_array> Node.js API docs
     @since Node.js v5.10.0
@@ -210,13 +143,6 @@ external concatWithLength : t array -> totalLength:int -> t = "concat" [@@bs.val
 external fromArray : int array -> t = "from" [@@bs.val] [@@bs.scope "Buffer"]
 
 (** This creates a view of the [ArrayBuffer] without copying the underlying memory.
-    For example, when passed a reference to the .buffer property of a [TypedArray]
-    instance, the newly created [Buffer] will share the same allocated memory as the
-    [TypedArray].
-
-    @param arrayBuffer Source ArrayBuffer instance.
-    @param byteOffset Index of first byte to expose. Default: [0].
-    @param length Number of bytes to expose. Default: [(length arrayBuffer) - byteOffset].
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_from_arraybuffer_byteoffset_length> Node.js API docs
     @since Node.js v5.10.0
@@ -230,8 +156,6 @@ external fromArrayBuffer :
 [@@bs.val] [@@bs.scope "Buffer"]
 
 (** Copies the passed [buffer] data onto a new [Buffer] instance.
-
-    @param buffer An existing Buffer or Uint8Array from which to copy data.
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_from_buffer> Node.js API docs
     @since Node.js v5.10.0
@@ -248,12 +172,9 @@ external fromBuffer :
   *)
 external fromString : string -> t = "from" [@@bs.val] [@@bs.scope "Buffer"]
 
-(** Creates a new [Buffer] containing a [string]. The [encoding] parameter identifies
+(** Creates a new [Buffer] from a [string]. The [encoding] parameter specifies
     the character encoding of [string].
     
-    @param string A string to encode
-    @param encoding The encoding of the string. Default is [`utf8]
-
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_from_string_encoding> Node.js API docs
     @since Node.js v5.10.0
   *)
@@ -263,9 +184,7 @@ external fromStringWithEncoding : string ->
 [@@bs.val] [@@bs.scope "Buffer"]
 
 
-(** Returns true if obj is a Buffer, false otherwise.
-
-    @param obj Value to test.
+(** Returns true if value is a [Buffer], [false] otherwise.
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_isbuffer_obj> Node.js API docs
     @since Node.js v0.1.101
@@ -273,8 +192,6 @@ external fromStringWithEncoding : string ->
 external isBuffer : 'a -> bool = "isBuffer" [@@bs.val] [@@bs.scope "Buffer"]
 
 (** Returns [true] if [encoding] contains a supported character encoding, or [false] otherwise.
-
-    @param encoding String that is tested for supported encoding value.
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_class_method_buffer_isencoding_encoding> Node.js API docs
     @since v0.9.1
@@ -292,9 +209,6 @@ external poolSize : int = "poolSize" [@@bs.val] [@@bs.scope "Buffer"]
 (** Unsafe byte reading by its [index].
     Underneath it uses index access syntax in Javascript.
 
-    @param buffer Buffer to get value from.
-    @param index Index to read from.
-
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_index> Node.js API docs
   *)
 external unsafe_get : t -> int -> int = "" [@@bs.get_index]
@@ -302,35 +216,23 @@ external unsafe_get : t -> int -> int = "" [@@bs.get_index]
 (** Unsafe byte writing by its [index].
     Underneath it uses index access syntax in Javascript.
 
-    @param buffer Buffer to write value to.
-    @param index Index to write to.
-    @param value Value to write. The values refer to individual bytes, so the legal value range is between 0x00 and 0xFF (hex) or 0 and 255 (decimal).
-
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_index> Node.js API docs
   *)
 external unsafe_set : t -> index:int -> int -> unit = "" [@@bs.set_index]
 
-(** Returns the underlying ArrayBuffer object based on which this Buffer object is created.
+(** Returns the underlying ArrayBuffer object.
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_buffer> Node.js API docs
   *)
 external buffer : t -> Js_typed_array2.ArrayBuffer.t = "buffer" [@@bs.get]
 
-(** Returns [byteOffset] on the underlying [ArrayBuffer] object based on which this
-    [Buffer] object is created.
+(** Returns [byteOffset] on the underlying [ArrayBuffer] object.
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_byteoffset> Node.js API docs
   *)
 external byteOffset : t -> int = "byteOffset" [@@bs.get]
 
-(** Copies data from a region of [buf] to a region in [target] even if the [target]
-    memory region overlaps with [buf].
-
-    @param buf
-    @param target
-    @param targetStart The offset within [target] at which to begin writing. Default: [0].
-    @param sourceStart The offset within [buf] from which to begin copying. Default: [0].
-    @param sourceEnd The offset within [buf] at which to stop copying (not inclusive). Default: [length buf].
+(** Copies data from a region of [buf] to a region in [target].
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_copy_target_targetstart_sourcestart_sourceend> Node.js API docs
     @since Node.js v0.1.90
@@ -344,24 +246,14 @@ external copy :
   unit -> int = "copy"
 [@@bs.send]
 
-(** Returns [true] if both [buf] and [otherBuffer] have exactly the same bytes,
-    [false] otherwise.
-
-    @param buf
-    @param otherBuffer
+(** Returns [true] if both [buf] and [otherBuffer] have exactly the same bytes.
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_equals_otherbuffer> Node.js API docs
     @since Node.js v0.11.13
   *)
 external equals : t -> t -> bool = "equals" [@@bs.send]
 
-(** Fills [buf] with the specified [value]. If the [offset] and [end_] are not given, 
-    the entire [buf] will be filled.
-
-    @param buf
-    @param value The value with which to fill [buf].
-    @param offset Number of bytes to skip before starting to fill [buf]. Default: [0].
-    @param end_ Where to stop filling buf (not inclusive). Default: [length buf].
+(** Fills [buf] with the specified [value].
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_fill_value_offset_end_encoding> Node.js API docs
     @since Node.js v0.5.0
@@ -374,14 +266,7 @@ external fill :
   unit -> t = "fill"
 [@@bs.send]
 
-(** Fills [buf] with the specified [value]. If the [offset] and [end_] are not given, 
-    the entire [buf] will be filled.
-
-    @param buf
-    @param value The value with which to fill [buf].
-    @param offset Number of bytes to skip before starting to fill [buf]. Default: [0].
-    @param end_ Where to stop filling buf (not inclusive). Default: [length buf].
-    @param encoding The encoding for value. Default: [`utf8].
+(** Fills [buf] with the specified [string].
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_fill_value_offset_end_encoding> Node.js API docs
     @since Node.js v0.5.0
@@ -395,11 +280,7 @@ external fillWithString :
   unit -> t = "fill"
 [@@bs.send]
 
-(** Tests, if [buf] has provided [value] looking from [byteOffset].
-
-    @param buf
-    @param value What to search for.
-    @param byteOffset Where to begin searching in [buf]. If negative, then offset is calculated from the end of [buf]. Default: [0].
+(** Tests, if [buf] has provided [value], starting looking from [byteOffset].
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_includes_value_byteoffset_encoding> Node.js API docs
     @since Node.js v5.3.0
@@ -411,12 +292,7 @@ external includes :
   unit -> bool = "includes"
 [@@bs.send]
 
-(** Tests, if [buf] has provided [value] looking from [byteOffset].
-
-    @param buf
-    @param string What to search for.
-    @param byteOffset Where to begin searching in [buf]. If negative, then offset is calculated from the end of [buf]. Default: [0].
-    @param encoding Encoding of the [string]. Default is [`utf8].
+(** Tests, if [buf] has provided [value], starting looking from [byteOffset].
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_includes_value_byteoffset_encoding> Node.js API docs
     @since Node.js v5.3.0
@@ -431,10 +307,6 @@ external includesString :
 
 (** Searches for first occurence of [value] in [buf].
 
-    @param buf
-    @param value What to search for.
-    @param byteOffset Where to begin searching in [buf]. If negative, then offset is calculated from the end of [buf]. Default: [0].
-
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_indexof_value_byteoffset_encoding> Node.js API docs
     @since Node.js v1.5.0
   *)
@@ -446,11 +318,6 @@ external indexOf :
 [@@bs.send]
 
 (** Searches for first occurence of [string] in [buf].
-
-    @param buf
-    @param string What to search for.
-    @param byteOffset Where to begin searching in [buf]. If negative, then offset is calculated from the end of [buf]. Default: [0].
-    @param encoding Encoding of the [string]. Default is [`utf8].
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_indexof_value_byteoffset_encoding> Node.js API docs
     @since Node.js v1.5.0
@@ -465,10 +332,6 @@ external indexOfString :
 
 (** Searches for last occurence of [value] in [buf].
 
-    @param buf
-    @param value What to search for.
-    @param byteOffset Where to begin searching in [buf]. If negative, then offset is calculated from the end of [buf]. Default: [(length buf) - 1].
-
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_lastindexof_value_byteoffset_encoding> Node.js API docs
     @since Node.js v6.0.0
   *)
@@ -480,11 +343,6 @@ external lastIndexOf :
 [@@bs.send]
 
 (** Searches for last occurence of [string] in [buf].
-
-    @param buf
-    @param string What to search for.
-    @param byteOffset Where to begin searching in [buf]. If negative, then offset is calculated from the end of [buf]. Default: [(length buf) - 1].
-    @param encoding Encoding of the [string]. Default is [`utf8].
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_lastindexof_value_byteoffset_encoding> Node.js API docs
     @since Node.js v6.0.0
@@ -498,9 +356,6 @@ external lastIndexOfString :
 [@@bs.send]
 
 (** Returns the amount of memory allocated for [buf] in bytes.
-    This does not necessarily reflect the amount of "usable" data within [buf].
-
-    @param buf
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_length> Node.js API docs
     @since Node.js v0.1.90
@@ -532,10 +387,6 @@ external readUIntLE : t -> offset:int -> byteLength:int -> ?offset:int -> unit =
 (** Returns a new [Buffer] that references the same memory as the original, 
     but offset and cropped by the [start] and [end_] indices.
 
-    @param buf
-    @param start Where the new [Buffer] will start. Default: [0].
-    @param end Where the new [Buffer] will end (not inclusive). Default: [length buf].
-
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_subarray_start_end> Node.js API docs
     @since Node.js v3.0.0
   *)
@@ -543,10 +394,6 @@ external subarray : t -> ?start: int -> ?end_: int -> unit -> t = "subarray" [@@
 
 (** Returns a new [Buffer] that references the same memory as the original, 
     but offset and cropped by the [start] and [end_] indices.
-
-    @param buf
-    @param start Where the new [Buffer] will start. Default: [0].
-    @param end Where the new [Buffer] will end (not inclusive). Default: [length buf].
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_slice_start_end> Node.js API docs
     @since Node.js v0.3.0
@@ -588,12 +435,7 @@ external toJSON : t -> Js.Json.t = "toJSON" [@@bs.send]
 *)
 external toString : t -> string = "toString" [@@bs.send]
 
-(** Serializes [buf] to [string] using [encoding] encoding.
-
-    @param buf
-    @param encoding Encoding of the resulting [string]. Default is [`utf8].
-    @param start The byte offset to start decoding at. Default: [0].
-    @param end_ The byte offset to stop decoding at (not inclusive). Default: [length buf].
+(** Serializes [buf] to [string] using [encoding].
 
     @see <https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html#buffer_buf_tostring_encoding_start_end> Node.js API docs
     @since Node.js v0.1.90
@@ -607,12 +449,7 @@ external toStringWithEncoding :
   string = "toString"
 [@@bs.send]
 
-(** Writes [string] to [buf] at [offset] according to the character encoding in [encoding].
-
-    @param buf
-    @param string String to write to [buf].
-    @param offset Number of bytes to skip before starting to write [string]. Default: [0].
-    @param encoding The character encoding of [string]. Default: [`utf8].
+(** Writes [string] to [buf] at [offset] according to the character [encoding].
 
     @see <https://nodejs.org/api/buffer.html#buffer_buf_write_string_offset_length_encoding> Node.js API docs
     @since Node.js v0.1.90
@@ -625,14 +462,8 @@ external write :
   unit ->
   int = "write" [@@bs.send]
 
-(** Writes [string] to [buf] at [offset] according to the character encoding in [encoding].
+(** Writes [string] to [buf] at [offset] according to the character [encoding].
     The [length] parameter is the number of bytes to write.
-
-    @param buf
-    @param string String to write to [buf].
-    @param offset Number of bytes to skip before starting to write [string]. Default: [0].
-    @param length Number of bytes to write. Default: [(length buf) - offset].
-    @param encoding The character encoding of [string]. Default: [`utf8].
 
     @see <https://nodejs.org/api/buffer.html#buffer_buf_write_string_offset_length_encoding> Node.js API docs
     @since Node.js v0.1.90
@@ -682,12 +513,7 @@ external _INSPECT_MAX_BYTES : int = "INSPECT_MAX_BYTES" [@@bs.module "buffer"]
   *)
 external kMaxLength : int = "kMaxLength" [@@bs.module "buffer"]
 
-(** Re-encodes the given [Buffer] or [Uint8Array] instance from one character encoding to another.
-    Returns a new [Buffer] instance.
-
-    @param buffer [Buffer] or [UInt8Array] to transcode.
-    @param fromEnc The current encoding.
-    @param toEnc To target encoding.
+(** Encodes the given [Buffer] or [Uint8Array] instance from one [fromEnc] encoding to [toEnc] encoding.
 
     @see <https://nodejs.org/api/buffer.html#buffer_buffer_transcode_source_fromenc_toenc> Node.js API docs
     @since Node.js v7.1.0
@@ -701,18 +527,12 @@ external transcode :
 
 (** The largest size allowed for a single [Buffer] instance.
 
-    On 32-bit architectures, this value is (2^30)-1 (~1GB). 
-    On 64-bit architectures, this value is (2^31)-1 (~2GB).
-
     @see <https://nodejs.org/api/buffer.html#buffer_buffer_constants_max_length> Node.js API docs
     @since Node.js v8.2.0
   *)
 external _MAX_LENGTH : int = "MAX_LENGTH" [@@bs.module "buffer"] [@@bs.scope "constants"]
 
 (** The largest length allowed for a single [string] instance.
-
-    Represents the largest length that a [string] primitive can have, counted in UTF-16 code units.
-    This value may depend on the JS engine that is being used.
 
     @see <https://nodejs.org/api/buffer.html#buffer_buffer_constants_max_string_length> Node.js API docs
     @since Node.js v8.2.0

--- a/jscomp/others/node_buffer.ml
+++ b/jscomp/others/node_buffer.ml
@@ -26,17 +26,208 @@
 
 type t = Node.buffer 
 
-external isBuffer : 'a -> bool = "Buffer.isBuffer" 
-[@@bs.val]
+external isBuffer : 'a -> bool = "isBuffer" [@@bs.val] [@@bs.scope "Buffer"]
 
-external fromString : string -> t = "Buffer.from"
-[@@bs.val]
+external fromString : string -> t = "from" [@@bs.val] [@@bs.scope "Buffer"]
 
-external fromStringWithEncoding : string -> ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary  | `hex ] [@bs.string]) -> t = "from"
+external fromArray : int array -> t = "from" [@@bs.val] [@@bs.scope "Buffer"]
+
+external fromBuffer : t -> t = "from" [@@bs.val] [@@bs.scope "Buffer"]
+
+external fromArrayBuffer : Js_typed_array2.array_buffer -> ?offset:int -> ?length:int -> unit -> t = "from" [@@bs.val] [@@bs.scope "Buffer"]
+
+external fromStringWithEncoding :
+  string ->
+  ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string])
+  -> t = "from"
+ [@@bs.val] [@@bs.scope "Buffer"]
+
+external alloc : 
+  int ->
+  ?fill:([ `String of string | `Integer of int | `Buffer of t ] [@bs.unwrap]) ->
+  ?encoding: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) -> 
+  unit -> t = "alloc"
 [@@bs.val] [@@bs.scope "Buffer"]
 
-external toString : t -> string = "toString"
+external allocUnsafe : int -> t = "allocUnsafe"
+[@@bs.val] [@@bs.scope "Buffer"]
+
+external allocUnsafeSlow : int -> t = "allocUnsafeSlow"
+[@@bs.val] [@@bs.scope "Buffer"]
+
+external byteLength : t -> int = "byteLength"
+[@@bs.get]
+
+external byteOffset : t -> int = "byteOffset"
+[@@bs.get]
+
+external byteLengthWithEncoding : 
+  ([ `String of string | `Buffer of t ] [@bs.unwrap]) ->
+  ?encoding: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
+  unit ->
+  int = "byteLength"
+[@@bs.val] [@@bs.scope "Buffer"]
+
+external compare : t -> t -> int = "compare"
+[@@bs.val] [@@bs.scope "Buffer"]
+
+external toString : t -> string = "toString" [@@bs.send]
+
+external toStringWithEncoding : 
+  t ->
+  ?encoding: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
+  ?start: int ->
+  ?end_: int ->
+  unit -> string = "toString"
 [@@bs.send]
 
-external concat : t array -> t = "Buffer.concat"
-[@@bs.val]
+external concat : t array -> t = "concat"
+[@@bs.val] [@@bs.scope "Buffer"]
+
+external concatWithTotalLength : t array -> int -> t = "concat"
+[@@bs.val] [@@bs.scope "Buffer"]
+
+external isEncoding : string -> bool = "isEncoding"
+[@@bs.val] [@@bs.scope "Buffer"]
+
+(* TODO: How to support mutation of this value? *)
+external poolSize : int = "poolSize"
+[@@bs.val] [@@bs.scope "Buffer"]
+
+external unsafe_get : t -> int -> int = ""
+[@@bs.get_index]
+
+external unsafe_set : t -> int -> int -> unit = ""
+[@@bs.set_index]
+
+external buffer : t -> Js_typed_array2.array_buffer = "buffer"
+[@@bs.get]
+
+external compare :
+  t -> t ->
+  ?targetStart: int ->
+  ?targetEnd: int ->
+  ?sourceStart: int ->
+  ?sourceEnd: int ->
+  unit -> int = "compare"
+[@@bs.send]
+
+external copy :
+  t -> t ->
+  ?targetStart:int ->
+  ?sourceStart:int ->
+  ?sourceEnd:int ->
+  unit -> int = "copy"
+[@@bs.send]
+
+external equals : t -> t -> bool = "equals"
+[@@bs.send]
+
+external fill :
+  t ->
+  ([ `String of string | `Integer of int | `Buffer of t ] [@bs.unwrap]) ->
+  ?offset:int ->
+  ?end_:int ->
+  ?encoding: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
+  unit -> t = "fill"
+[@@bs.send]
+
+external includes :
+  t -> 
+  ?byteOffset:int ->
+  ?encoding: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
+  unit -> bool = "includes"
+[@@bs.send]
+
+external indexOf :
+  t -> 
+  ([ `String of string | `Integer of int | `Buffer of t ] [@bs.unwrap]) ->
+  ?byteOffset:int ->
+  ?encoding: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
+  unit -> int = "indexOf"
+[@@bs.send]
+
+external lastIndexOf :
+  t -> 
+  ([ `String of string | `Integer of int | `Buffer of t ] [@bs.unwrap]) ->
+  ?byteOffset:int ->
+  ?encoding: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
+  unit -> int = "lastIndexOf"
+[@@bs.send]
+
+external length : t -> int = "length" 
+[@@bs.get]
+
+external readDoubleBE : t -> int -> float = "readDoubleBE" [@@bs.send]
+external readDoubleLE : t -> int -> float = "readDoubleLE" [@@bs.send]
+external readFloatBE : t -> int -> float = "readFloatBE" [@@bs.send]
+external readFloatLE : t -> int -> float = "readFloatLE" [@@bs.send]
+
+external readInt8 : t -> int -> int = "readInt8" [@@bs.send]
+external readInt16BE : t -> int -> int = "readInt16BE" [@@bs.send]
+external readInt16LE : t -> int -> int = "readInt16LE" [@@bs.send]
+external readInt32BE : t -> int -> int = "readInt32BE" [@@bs.send]
+external readInt32LE : t -> int -> int = "readInt32LE" [@@bs.send]
+external readIntBE : t -> offset:int -> byteLength:int -> int = "readIntBE" [@@bs.send]
+external readIntLE : t -> offset:int -> byteLength:int -> int = "readIntLE" [@@bs.send]
+
+external readUInt8 : t -> int -> int = "readUInt8" [@@bs.send]
+external readUInt16BE : t -> int -> int = "readUInt16BE" [@@bs.send]
+external readUInt16LE : t -> int -> int = "readUInt16LE" [@@bs.send]
+external readUInt32BE : t -> int -> int = "readUInt32BE" [@@bs.send]
+external readUInt32LE : t -> int -> int = "readUInt32LE" [@@bs.send]
+external readUIntBE : t -> offset:int -> byteLength:int -> int = "readUIntBE" [@@bs.send]
+external readUIntLE : t -> offset:int -> byteLength:int -> int = "readUIntLE" [@@bs.send]
+
+external subarray : t -> ?start: int -> ?end_: int -> unit -> t = "subarray" [@@bs.send]
+external slice : t -> ?start: int -> ?end_:int -> unit -> t = "slice" [@@bs.send]
+
+external swap16 : t -> t = "swap16" [@@bs.send]
+external swap32 : t -> t = "swap32" [@@bs.send] 
+external swap64 : t -> t = "swap64" [@@bs.send] 
+
+external toJSON : t -> Js.Json.t = "toJSON" [@@bs.send]
+
+external write :
+  t ->
+  string ->
+  ?offset:int ->
+  ?length:int ->
+  ?encoding: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
+  unit -> int = "write" [@@bs.send]
+
+external writeDoubleBE : t -> float -> offset:int -> int = "writeDoubleBE" [@@bs.send]
+external writeDoubleLE : t -> float -> offset:int -> int = "writeDoubleLE" [@@bs.send]
+external writeFloatBE : t -> float -> offset:int -> int = "writeFloatBE" [@@bs.send]
+external writeFloatLE : t -> float -> offset:int -> int = "writeFloatLE" [@@bs.send]
+
+external writeInt8 : t -> int -> offset:int -> int = "writeInt8" [@@bs.send]
+external writeInt16BE : t -> int -> offset:int -> int = "writeInt16BE" [@@bs.send]
+external writeInt16LE : t -> int -> offset:int -> int = "writeInt16LE" [@@bs.send]
+external writeInt32BE : t -> int -> offset:int -> int = "writeInt32BE" [@@bs.send]
+external writeInt32LE : t -> int -> offset:int -> int = "writeInt32LE" [@@bs.send]
+external writeIntBE : t -> int -> offset:int -> byteLength:int -> int = "writeIntBE" [@@bs.send]
+external writeIntLE : t -> int -> offset:int -> byteLength:int -> int = "writeIntLE" [@@bs.send]
+
+external writeUInt8 : t -> int -> offset:int -> int = "writeUInt8" [@@bs.send]
+external writeUInt16BE : t -> int -> offset:int -> int = "writeUInt16BE" [@@bs.send]
+external writeUInt16LE : t -> int -> offset:int -> int = "writeUInt16LE" [@@bs.send]
+external writeUInt32BE : t -> int -> offset:int -> int = "writeUInt32BE" [@@bs.send]
+external writeUInt32LE : t -> int -> offset:int -> int = "writeUInt32LE" [@@bs.send]
+external writeUIntBE : t -> int -> offset:int -> byteLength:int -> int = "writeUIntBE" [@@bs.send]
+external writeUIntLE : t -> int -> offset:int -> byteLength:int -> int = "writeUIntLE" [@@bs.send]
+
+external _INSPECT_MAX_BYTES : t -> int = "INSPECT_MAX_BYTES" [@@bs.get]
+external kMaxLength : t -> int = "kMaxLength" [@@bs.get]
+
+external transcode : 
+  t ->
+  fromEnc: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
+  toEnc: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
+  t = "transcode"
+[@@bs.val] [@@bs.scope "Buffer"]
+
+external _MAX_LENGTH : int = "MAX_LENGTH" [@@bs.val] [@@bs.scope "Buffer.constants"]
+external _MAX_STRING_LENGTH : int = "MAX_STRING_LENGTH" [@@bs.val] [@@bs.scope "Buffer.constants"]
+
+

--- a/jscomp/others/node_buffer.ml
+++ b/jscomp/others/node_buffer.ml
@@ -520,8 +520,8 @@ external kMaxLength : int = "kMaxLength" [@@bs.module "buffer"]
   *)
 external transcode : 
   ([ `Buffer of t | `Uint8Array of Js_typed_array2.Uint8Array.t ] [@bs.unwrap]) ->
-  fromEnc: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
-  toEnc: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
+  fromEnc: ([ `ascii | `utf8  | `utf16le  | `usc2  | `latin1 | `binary ] [@bs.string]) ->
+  toEnc: ([ `ascii | `utf8  | `utf16le  | `usc2  | `latin1 | `binary ] [@bs.string]) ->
   t = "transcode"
 [@@bs.module "buffer"]
 

--- a/jscomp/others/node_buffer.ml
+++ b/jscomp/others/node_buffer.ml
@@ -37,7 +37,7 @@ type t = Node.buffer
   *)
 external alloc : 
   int ->
-  ?fill:([ `String of string | `Integer of int | `Buffer of t | `UInt8Array of Js_typed_array2.Uint8Array.t ] [@bs.unwrap]) ->
+  ?fill:([ `String of string | `Integer of int | `Buffer of t | `Uint8Array of Js_typed_array2.Uint8Array.t ] [@bs.unwrap]) ->
   ?encoding: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) -> 
   unit -> t = "alloc"
 [@@bs.val] [@@bs.scope "Buffer"]
@@ -376,13 +376,13 @@ external readInt32LE : t -> ?offset:int -> unit -> int = "readInt32LE" [@@bs.sen
 external readIntBE : t -> offset:int -> byteLength:int -> ?offset:int -> unit = "readIntBE" [@@bs.send]
 external readIntLE : t -> offset:int -> byteLength:int -> ?offset:int -> unit = "readIntLE" [@@bs.send]
 
-external readUInt8 : t -> ?offset:int -> unit -> int = "readUInt8" [@@bs.send]
-external readUInt16BE : t -> ?offset:int -> unit -> int = "readUInt16BE" [@@bs.send]
-external readUInt16LE : t -> ?offset:int -> unit -> int = "readUInt16LE" [@@bs.send]
-external readUInt32BE : t -> ?offset:int -> unit -> int = "readUInt32BE" [@@bs.send]
-external readUInt32LE : t -> ?offset:int -> unit -> int = "readUInt32LE" [@@bs.send]
-external readUIntBE : t -> offset:int -> byteLength:int -> ?offset:int -> unit = "readUIntBE" [@@bs.send]
-external readUIntLE : t -> offset:int -> byteLength:int -> ?offset:int -> unit = "readUIntLE" [@@bs.send]
+external readUint8 : t -> ?offset:int -> unit -> int = "readUInt8" [@@bs.send]
+external readUint16BE : t -> ?offset:int -> unit -> int = "readUInt16BE" [@@bs.send]
+external readUint16LE : t -> ?offset:int -> unit -> int = "readUInt16LE" [@@bs.send]
+external readUint32BE : t -> ?offset:int -> unit -> int = "readUInt32BE" [@@bs.send]
+external readUint32LE : t -> ?offset:int -> unit -> int = "readUInt32LE" [@@bs.send]
+external readUintBE : t -> offset:int -> byteLength:int -> ?offset:int -> unit = "readUIntBE" [@@bs.send]
+external readUintLE : t -> offset:int -> byteLength:int -> ?offset:int -> unit = "readUIntLE" [@@bs.send]
 
 (** Returns a new [Buffer] that references the same memory as the original, 
     but offset and cropped by the [start] and [end_] indices.
@@ -491,13 +491,13 @@ external writeInt32LE : t -> int -> ?offset:int -> unit -> int = "writeInt32LE" 
 external writeIntBE : t -> int -> offset:int -> byteLength:int -> int = "writeIntBE" [@@bs.send]
 external writeIntLE : t -> int -> offset:int -> byteLength:int -> int = "writeIntLE" [@@bs.send]
 
-external writeUInt8 : t -> int -> ?offset:int -> unit -> int = "writeUInt8" [@@bs.send]
-external writeUInt16BE : t -> int -> ?offset:int -> unit -> int = "writeUInt16BE" [@@bs.send]
-external writeUInt16LE : t -> int -> ?offset:int -> unit -> int = "writeUInt16LE" [@@bs.send]
-external writeUInt32BE : t -> int -> ?offset:int -> unit -> int = "writeUInt32BE" [@@bs.send]
-external writeUInt32LE : t -> int -> ?offset:int -> unit -> int = "writeUInt32LE" [@@bs.send]
-external writeUIntBE : t -> int -> offset:int -> byteLength:int -> int = "writeUIntBE" [@@bs.send]
-external writeUIntLE : t -> int -> offset:int -> byteLength:int -> int = "writeUIntLE" [@@bs.send]
+external writeUint8 : t -> int -> ?offset:int -> unit -> int = "writeUInt8" [@@bs.send]
+external writeUint16BE : t -> int -> ?offset:int -> unit -> int = "writeUInt16BE" [@@bs.send]
+external writeUint16LE : t -> int -> ?offset:int -> unit -> int = "writeUInt16LE" [@@bs.send]
+external writeUint32BE : t -> int -> ?offset:int -> unit -> int = "writeUInt32BE" [@@bs.send]
+external writeUint32LE : t -> int -> ?offset:int -> unit -> int = "writeUInt32LE" [@@bs.send]
+external writeUintBE : t -> int -> offset:int -> byteLength:int -> int = "writeUIntBE" [@@bs.send]
+external writeUintLE : t -> int -> offset:int -> byteLength:int -> int = "writeUIntLE" [@@bs.send]
 
 (** Returns the maximum number of bytes that will be returned when [buf.inspect()] is called. 
 
@@ -519,7 +519,7 @@ external kMaxLength : int = "kMaxLength" [@@bs.module "buffer"]
     @since Node.js v7.1.0
   *)
 external transcode : 
-  ([ `Buffer of t | `UInt8Array of Js_typed_array2.Uint8Array.t ] [@bs.unwrap]) ->
+  ([ `Buffer of t | `Uint8Array of Js_typed_array2.Uint8Array.t ] [@bs.unwrap]) ->
   fromEnc: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
   toEnc: ([ `ascii  | `utf8  | `utf16le  | `usc2  | `base64  | `latin1 | `binary | `hex ] [@bs.string]) ->
   t = "transcode"

--- a/jscomp/others/release.ninja
+++ b/jscomp/others/release.ninja
@@ -140,7 +140,7 @@ build others/belt_internalSetString.cmi others/belt_internalSetString.cmj : cc o
 build others/dom.cmi others/dom.cmj : cc others/dom.ml | others/dom_storage.cmj others/dom_storage2.cmj js_pkg runtime
 build others/dom_storage.cmi others/dom_storage.cmj : cc others/dom_storage.ml | others/dom_storage2.cmj js_pkg runtime
 build others/dom_storage2.cmi others/dom_storage2.cmj : cc others/dom_storage2.ml | runtime
-build others/node_buffer.cmi others/node_buffer.cmj : cc others/node_buffer.ml | others/node.cmi others/node.cmj js_pkg runtime
+build others/node_buffer.cmi others/node_buffer.cmj : cc others/node_buffer.ml | others/js_typed_array2.cmj others/node.cmi others/node.cmj js_pkg runtime
 build others/node_child_process.cmi others/node_child_process.cmj : cc others/node_child_process.ml | others/node.cmi others/node.cmj js_pkg runtime
 build others/node_fs.cmi others/node_fs.cmj : cc others/node_fs.ml | others/js_string.cmj others/node.cmi others/node.cmj js_pkg runtime
 build others/node_module.cmi others/node_module.cmj : cc others/node_module.ml | others/js_dict.cmj others/node.cmi others/node.cmj js_pkg runtime

--- a/jscomp/test/build.ninja
+++ b/jscomp/test/build.ninja
@@ -433,6 +433,7 @@ build test/nested_obj_literal.cmi test/nested_obj_literal.cmj : cc test/nested_o
 build test/nested_obj_test.cmi test/nested_obj_test.cmj : cc test/nested_obj_test.ml | $stdlib
 build test/nested_pattern_match_test.cmi test/nested_pattern_match_test.cmj : cc test/nested_pattern_match_test.ml | $stdlib
 build test/noassert.cmi test/noassert.cmj : cc test/noassert.ml | $stdlib
+build test/node_buffer_test.cmi test/node_buffer_test.cmj : cc test/node_buffer_test.ml | test/mt.cmj $stdlib
 build test/node_fs_test.cmi test/node_fs_test.cmj : cc test/node_fs_test.ml | $stdlib
 build test/node_path_test.cmi test/node_path_test.cmj : cc test/node_path_test.ml | $stdlib
 build test/number_lexer.cmi test/number_lexer.cmj : cc test/number_lexer.ml | $stdlib

--- a/jscomp/test/node_buffer_test.js
+++ b/jscomp/test/node_buffer_test.js
@@ -2,6 +2,7 @@
 
 var Mt = require("./mt.js");
 var Block = require("../../lib/js/block.js");
+var $$Buffer = require("buffer");
 
 var suites_000 = /* tuple */[
   "alloc returns an object",
@@ -464,7 +465,357 @@ var suites_001 = /* :: */[
                                                                                               ]);
                                                                                     })
                                                                                 ],
-                                                                                /* [] */0
+                                                                                /* :: */[
+                                                                                  /* tuple */[
+                                                                                    "fillWithString fills existing buffer with provided string",
+                                                                                    (function (param) {
+                                                                                        var buf = Buffer.from("xxxxx");
+                                                                                        var buf$1 = buf.fill("YWJj", 2, 4, "base64");
+                                                                                        return /* Eq */Block.__(0, [
+                                                                                                  buf$1.toString(),
+                                                                                                  "xxabx"
+                                                                                                ]);
+                                                                                      })
+                                                                                  ],
+                                                                                  /* :: */[
+                                                                                    /* tuple */[
+                                                                                      "includes tests for presence of value starting from 'byteOffset' (value included)",
+                                                                                      (function (param) {
+                                                                                          var buf = Buffer.from("aabcbb");
+                                                                                          return /* Ok */Block.__(4, [buf.includes(99, 3)]);
+                                                                                        })
+                                                                                    ],
+                                                                                    /* :: */[
+                                                                                      /* tuple */[
+                                                                                        "includes tests for presence of value starting from 'byteOffset' (value included before offset)",
+                                                                                        (function (param) {
+                                                                                            var buf = Buffer.from("aabcbb");
+                                                                                            return /* Ok */Block.__(4, [!buf.includes(99, 4)]);
+                                                                                          })
+                                                                                      ],
+                                                                                      /* :: */[
+                                                                                        /* tuple */[
+                                                                                          "includesString tests for presence of value starting from 'byteOffset' (value included)",
+                                                                                          (function (param) {
+                                                                                              var buf = Buffer.from("aabcbb");
+                                                                                              return /* Ok */Block.__(4, [buf.includes("Yw==", 3, "base64")]);
+                                                                                            })
+                                                                                        ],
+                                                                                        /* :: */[
+                                                                                          /* tuple */[
+                                                                                            "includesString tests for presence of value starting from 'byteOffset' (value included before offset)",
+                                                                                            (function (param) {
+                                                                                                var buf = Buffer.from("aabcbb");
+                                                                                                return /* Ok */Block.__(4, [!buf.includes("Yw==", 4, "base64")]);
+                                                                                              })
+                                                                                          ],
+                                                                                          /* :: */[
+                                                                                            /* tuple */[
+                                                                                              "indexOf tests for presence of value starting from 'byteOffset' (value included)",
+                                                                                              (function (param) {
+                                                                                                  var buf = Buffer.from("aabcbb");
+                                                                                                  return /* Eq */Block.__(0, [
+                                                                                                            buf.indexOf(99, 3),
+                                                                                                            3
+                                                                                                          ]);
+                                                                                                })
+                                                                                            ],
+                                                                                            /* :: */[
+                                                                                              /* tuple */[
+                                                                                                "indexOf tests for presence of value starting from 'byteOffset' (value included before offset)",
+                                                                                                (function (param) {
+                                                                                                    var buf = Buffer.from("aabcbb");
+                                                                                                    return /* Eq */Block.__(0, [
+                                                                                                              buf.indexOf(99, 4),
+                                                                                                              -1
+                                                                                                            ]);
+                                                                                                  })
+                                                                                              ],
+                                                                                              /* :: */[
+                                                                                                /* tuple */[
+                                                                                                  "indexOfString tests for presence of value starting from 'byteOffset' (value included)",
+                                                                                                  (function (param) {
+                                                                                                      var buf = Buffer.from("aabcbb");
+                                                                                                      return /* Eq */Block.__(0, [
+                                                                                                                buf.indexOf("Yw==", 3, "base64"),
+                                                                                                                3
+                                                                                                              ]);
+                                                                                                    })
+                                                                                                ],
+                                                                                                /* :: */[
+                                                                                                  /* tuple */[
+                                                                                                    "indexOfString tests for presence of value starting from 'byteOffset' (value included before offset)",
+                                                                                                    (function (param) {
+                                                                                                        var buf = Buffer.from("aabcbb");
+                                                                                                        return /* Eq */Block.__(0, [
+                                                                                                                  buf.indexOf("Yw==", 4, "base64"),
+                                                                                                                  -1
+                                                                                                                ]);
+                                                                                                      })
+                                                                                                  ],
+                                                                                                  /* :: */[
+                                                                                                    /* tuple */[
+                                                                                                      "lastIndexOf tests for presence of value starting from 'byteOffset' (value included)",
+                                                                                                      (function (param) {
+                                                                                                          var buf = Buffer.from("aabcbb");
+                                                                                                          return /* Eq */Block.__(0, [
+                                                                                                                    buf.lastIndexOf(99, 3),
+                                                                                                                    3
+                                                                                                                  ]);
+                                                                                                        })
+                                                                                                    ],
+                                                                                                    /* :: */[
+                                                                                                      /* tuple */[
+                                                                                                        "lastIndexOf tests for presence of value starting from 'byteOffset' (value included before offset)",
+                                                                                                        (function (param) {
+                                                                                                            var buf = Buffer.from("aabcbb");
+                                                                                                            return /* Eq */Block.__(0, [
+                                                                                                                      buf.lastIndexOf(99, 2),
+                                                                                                                      -1
+                                                                                                                    ]);
+                                                                                                          })
+                                                                                                      ],
+                                                                                                      /* :: */[
+                                                                                                        /* tuple */[
+                                                                                                          "lastIndexOfString tests for presence of value starting from 'byteOffset' (value included)",
+                                                                                                          (function (param) {
+                                                                                                              var buf = Buffer.from("aabcbb");
+                                                                                                              return /* Eq */Block.__(0, [
+                                                                                                                        buf.lastIndexOf("Yw==", 3, "base64"),
+                                                                                                                        3
+                                                                                                                      ]);
+                                                                                                            })
+                                                                                                        ],
+                                                                                                        /* :: */[
+                                                                                                          /* tuple */[
+                                                                                                            "lastIndexOfString tests for presence of value starting from 'byteOffset' (value included before offset)",
+                                                                                                            (function (param) {
+                                                                                                                var buf = Buffer.from("aabcbb");
+                                                                                                                return /* Eq */Block.__(0, [
+                                                                                                                          buf.lastIndexOf("Yw==", 2, "base64"),
+                                                                                                                          -1
+                                                                                                                        ]);
+                                                                                                              })
+                                                                                                          ],
+                                                                                                          /* :: */[
+                                                                                                            /* tuple */[
+                                                                                                              "length returns buffer length in bytes",
+                                                                                                              (function (param) {
+                                                                                                                  return /* Eq */Block.__(0, [
+                                                                                                                            Buffer.from("abc").length,
+                                                                                                                            3
+                                                                                                                          ]);
+                                                                                                                })
+                                                                                                            ],
+                                                                                                            /* :: */[
+                                                                                                              /* tuple */[
+                                                                                                                "subarray returns piece of buffer",
+                                                                                                                (function (param) {
+                                                                                                                    var buf = Buffer.from("abcd");
+                                                                                                                    return /* Eq */Block.__(0, [
+                                                                                                                              buf.subarray(1, 3).toString(),
+                                                                                                                              "bc"
+                                                                                                                            ]);
+                                                                                                                  })
+                                                                                                              ],
+                                                                                                              /* :: */[
+                                                                                                                /* tuple */[
+                                                                                                                  "slice returns piece of buffer",
+                                                                                                                  (function (param) {
+                                                                                                                      var buf = Buffer.from("abcd");
+                                                                                                                      return /* Eq */Block.__(0, [
+                                                                                                                                buf.slice(1, 3).toString(),
+                                                                                                                                "bc"
+                                                                                                                              ]);
+                                                                                                                    })
+                                                                                                                ],
+                                                                                                                /* :: */[
+                                                                                                                  /* tuple */[
+                                                                                                                    "swap16 swaps byte order as for int16",
+                                                                                                                    (function (param) {
+                                                                                                                        var buf = Buffer.from(/* array */[
+                                                                                                                                1,
+                                                                                                                                2,
+                                                                                                                                3,
+                                                                                                                                4
+                                                                                                                              ]).swap16();
+                                                                                                                        return /* Ok */Block.__(4, [buf[0] === 2 && buf[1] === 1 && buf[2] === 4 && buf[3] === 3]);
+                                                                                                                      })
+                                                                                                                  ],
+                                                                                                                  /* :: */[
+                                                                                                                    /* tuple */[
+                                                                                                                      "swap32 swaps byte order as for int32",
+                                                                                                                      (function (param) {
+                                                                                                                          var buf = Buffer.from(/* array */[
+                                                                                                                                  1,
+                                                                                                                                  2,
+                                                                                                                                  3,
+                                                                                                                                  4
+                                                                                                                                ]).swap32();
+                                                                                                                          return /* Ok */Block.__(4, [buf[0] === 4 && buf[1] === 3 && buf[2] === 2 && buf[3] === 1]);
+                                                                                                                        })
+                                                                                                                    ],
+                                                                                                                    /* :: */[
+                                                                                                                      /* tuple */[
+                                                                                                                        "swap64 swaps byte order as for int64",
+                                                                                                                        (function (param) {
+                                                                                                                            var buf = Buffer.from(/* array */[
+                                                                                                                                    1,
+                                                                                                                                    2,
+                                                                                                                                    3,
+                                                                                                                                    4,
+                                                                                                                                    5,
+                                                                                                                                    6,
+                                                                                                                                    7,
+                                                                                                                                    8
+                                                                                                                                  ]).swap64();
+                                                                                                                            return /* Ok */Block.__(4, [buf[0] === 8 && buf[1] === 7 && buf[2] === 6 && buf[3] === 5 && buf[4] === 4 && buf[5] === 3 && buf[6] === 2 && buf[7] === 1]);
+                                                                                                                          })
+                                                                                                                      ],
+                                                                                                                      /* :: */[
+                                                                                                                        /* tuple */[
+                                                                                                                          "toJSON",
+                                                                                                                          (function (param) {
+                                                                                                                              var json = Buffer.from(/* array */[
+                                                                                                                                      1,
+                                                                                                                                      2,
+                                                                                                                                      3
+                                                                                                                                    ]).toJSON();
+                                                                                                                              return /* Eq */Block.__(0, [
+                                                                                                                                        JSON.stringify(json),
+                                                                                                                                        "{\"type\":\"Buffer\",\"data\":[1,2,3]}"
+                                                                                                                                      ]);
+                                                                                                                            })
+                                                                                                                        ],
+                                                                                                                        /* :: */[
+                                                                                                                          /* tuple */[
+                                                                                                                            "toString converts buffer to string",
+                                                                                                                            (function (param) {
+                                                                                                                                var source = "abc";
+                                                                                                                                var target = Buffer.from(source).toString();
+                                                                                                                                return /* Eq */Block.__(0, [
+                                                                                                                                          source,
+                                                                                                                                          target
+                                                                                                                                        ]);
+                                                                                                                              })
+                                                                                                                          ],
+                                                                                                                          /* :: */[
+                                                                                                                            /* tuple */[
+                                                                                                                              "toString with encoding uses encoding for string conversion",
+                                                                                                                              (function (param) {
+                                                                                                                                  var target = Buffer.from("abc").toString("base64", undefined, undefined);
+                                                                                                                                  return /* Eq */Block.__(0, [
+                                                                                                                                            target,
+                                                                                                                                            "YWJj"
+                                                                                                                                          ]);
+                                                                                                                                })
+                                                                                                                            ],
+                                                                                                                            /* :: */[
+                                                                                                                              /* tuple */[
+                                                                                                                                "write",
+                                                                                                                                (function (param) {
+                                                                                                                                    var buf = Buffer.from("xxxxxxxx");
+                                                                                                                                    buf.write("YWJj", 2, "base64");
+                                                                                                                                    return /* Eq */Block.__(0, [
+                                                                                                                                              buf.toString(),
+                                                                                                                                              "xxabcxxx"
+                                                                                                                                            ]);
+                                                                                                                                  })
+                                                                                                                              ],
+                                                                                                                              /* :: */[
+                                                                                                                                /* tuple */[
+                                                                                                                                  "writeLength",
+                                                                                                                                  (function (param) {
+                                                                                                                                      var buf = Buffer.from("xxxxxxxx");
+                                                                                                                                      buf.write("YWJj", 2, 2, "base64");
+                                                                                                                                      return /* Eq */Block.__(0, [
+                                                                                                                                                buf.toString(),
+                                                                                                                                                "xxabxxxx"
+                                                                                                                                              ]);
+                                                                                                                                    })
+                                                                                                                                ],
+                                                                                                                                /* :: */[
+                                                                                                                                  /* tuple */[
+                                                                                                                                    "_INSPECT_MAX_BYTES",
+                                                                                                                                    (function (param) {
+                                                                                                                                        return /* Eq */Block.__(0, [
+                                                                                                                                                  typeof $$Buffer.INSPECT_MAX_BYTES,
+                                                                                                                                                  "number"
+                                                                                                                                                ]);
+                                                                                                                                      })
+                                                                                                                                  ],
+                                                                                                                                  /* :: */[
+                                                                                                                                    /* tuple */[
+                                                                                                                                      "kMaxLength",
+                                                                                                                                      (function (param) {
+                                                                                                                                          return /* Eq */Block.__(0, [
+                                                                                                                                                    typeof $$Buffer.kMaxLength,
+                                                                                                                                                    "number"
+                                                                                                                                                  ]);
+                                                                                                                                        })
+                                                                                                                                    ],
+                                                                                                                                    /* :: */[
+                                                                                                                                      /* tuple */[
+                                                                                                                                        "transcode",
+                                                                                                                                        (function (param) {
+                                                                                                                                            var buf = Buffer.from("€");
+                                                                                                                                            var buf2 = $$Buffer.transcode(buf, "utf8", "ascii");
+                                                                                                                                            return /* Eq */Block.__(0, [
+                                                                                                                                                      buf2.toString(),
+                                                                                                                                                      "?"
+                                                                                                                                                    ]);
+                                                                                                                                          })
+                                                                                                                                      ],
+                                                                                                                                      /* :: */[
+                                                                                                                                        /* tuple */[
+                                                                                                                                          "_MAX_LENGTH",
+                                                                                                                                          (function (param) {
+                                                                                                                                              return /* Eq */Block.__(0, [
+                                                                                                                                                        typeof $$Buffer.constants.MAX_LENGTH,
+                                                                                                                                                        "number"
+                                                                                                                                                      ]);
+                                                                                                                                            })
+                                                                                                                                        ],
+                                                                                                                                        /* :: */[
+                                                                                                                                          /* tuple */[
+                                                                                                                                            "_MAX_STRING_LENGTH",
+                                                                                                                                            (function (param) {
+                                                                                                                                                return /* Eq */Block.__(0, [
+                                                                                                                                                          typeof $$Buffer.constants.MAX_STRING_LENGTH,
+                                                                                                                                                          "number"
+                                                                                                                                                        ]);
+                                                                                                                                              })
+                                                                                                                                          ],
+                                                                                                                                          /* [] */0
+                                                                                                                                        ]
+                                                                                                                                      ]
+                                                                                                                                    ]
+                                                                                                                                  ]
+                                                                                                                                ]
+                                                                                                                              ]
+                                                                                                                            ]
+                                                                                                                          ]
+                                                                                                                        ]
+                                                                                                                      ]
+                                                                                                                    ]
+                                                                                                                  ]
+                                                                                                                ]
+                                                                                                              ]
+                                                                                                            ]
+                                                                                                          ]
+                                                                                                        ]
+                                                                                                      ]
+                                                                                                    ]
+                                                                                                  ]
+                                                                                                ]
+                                                                                              ]
+                                                                                            ]
+                                                                                          ]
+                                                                                        ]
+                                                                                      ]
+                                                                                    ]
+                                                                                  ]
+                                                                                ]
                                                                               ]
                                                                             ]
                                                                           ]

--- a/jscomp/test/node_buffer_test.js
+++ b/jscomp/test/node_buffer_test.js
@@ -609,184 +609,670 @@ var suites_001 = /* :: */[
                                                                                                             ],
                                                                                                             /* :: */[
                                                                                                               /* tuple */[
-                                                                                                                "subarray returns piece of buffer",
+                                                                                                                "readDoubleBE",
                                                                                                                 (function (param) {
-                                                                                                                    var buf = Buffer.from("abcd");
                                                                                                                     return /* Eq */Block.__(0, [
-                                                                                                                              buf.subarray(1, 3).toString(),
-                                                                                                                              "bc"
+                                                                                                                              String(Buffer.from(/* array */[
+                                                                                                                                          1,
+                                                                                                                                          2,
+                                                                                                                                          3,
+                                                                                                                                          4,
+                                                                                                                                          5,
+                                                                                                                                          6,
+                                                                                                                                          7,
+                                                                                                                                          8,
+                                                                                                                                          9,
+                                                                                                                                          10,
+                                                                                                                                          11,
+                                                                                                                                          12,
+                                                                                                                                          13,
+                                                                                                                                          14,
+                                                                                                                                          15
+                                                                                                                                        ]).readDoubleBE(1)),
+                                                                                                                              "5.678932010640861e-299"
                                                                                                                             ]);
                                                                                                                   })
                                                                                                               ],
                                                                                                               /* :: */[
                                                                                                                 /* tuple */[
-                                                                                                                  "slice returns piece of buffer",
+                                                                                                                  "readDoubleLE",
                                                                                                                   (function (param) {
-                                                                                                                      var buf = Buffer.from("abcd");
                                                                                                                       return /* Eq */Block.__(0, [
-                                                                                                                                buf.slice(1, 3).toString(),
-                                                                                                                                "bc"
+                                                                                                                                String(Buffer.from(/* array */[
+                                                                                                                                            1,
+                                                                                                                                            2,
+                                                                                                                                            3,
+                                                                                                                                            4,
+                                                                                                                                            5,
+                                                                                                                                            6,
+                                                                                                                                            7,
+                                                                                                                                            8,
+                                                                                                                                            9,
+                                                                                                                                            10,
+                                                                                                                                            11,
+                                                                                                                                            12,
+                                                                                                                                            13,
+                                                                                                                                            14,
+                                                                                                                                            15
+                                                                                                                                          ]).readDoubleLE(1)),
+                                                                                                                                "3.7258146895053074e-265"
                                                                                                                               ]);
                                                                                                                     })
                                                                                                                 ],
                                                                                                                 /* :: */[
                                                                                                                   /* tuple */[
-                                                                                                                    "swap16 swaps byte order as for int16",
+                                                                                                                    "readFloatBE",
                                                                                                                     (function (param) {
-                                                                                                                        var buf = Buffer.from(/* array */[
-                                                                                                                                1,
-                                                                                                                                2,
-                                                                                                                                3,
-                                                                                                                                4
-                                                                                                                              ]).swap16();
-                                                                                                                        return /* Ok */Block.__(4, [buf[0] === 2 && buf[1] === 1 && buf[2] === 4 && buf[3] === 3]);
+                                                                                                                        return /* Eq */Block.__(0, [
+                                                                                                                                  String(Buffer.from(/* array */[
+                                                                                                                                              1,
+                                                                                                                                              2,
+                                                                                                                                              3,
+                                                                                                                                              4,
+                                                                                                                                              5,
+                                                                                                                                              6,
+                                                                                                                                              7,
+                                                                                                                                              8,
+                                                                                                                                              9,
+                                                                                                                                              10,
+                                                                                                                                              11,
+                                                                                                                                              12,
+                                                                                                                                              13,
+                                                                                                                                              14,
+                                                                                                                                              15
+                                                                                                                                            ]).readFloatBE(1)),
+                                                                                                                                  "9.625513546253311e-38"
+                                                                                                                                ]);
                                                                                                                       })
                                                                                                                   ],
                                                                                                                   /* :: */[
                                                                                                                     /* tuple */[
-                                                                                                                      "swap32 swaps byte order as for int32",
+                                                                                                                      "readFloatLE",
                                                                                                                       (function (param) {
-                                                                                                                          var buf = Buffer.from(/* array */[
-                                                                                                                                  1,
-                                                                                                                                  2,
-                                                                                                                                  3,
-                                                                                                                                  4
-                                                                                                                                ]).swap32();
-                                                                                                                          return /* Ok */Block.__(4, [buf[0] === 4 && buf[1] === 3 && buf[2] === 2 && buf[3] === 1]);
+                                                                                                                          return /* Eq */Block.__(0, [
+                                                                                                                                    String(Buffer.from(/* array */[
+                                                                                                                                                1,
+                                                                                                                                                2,
+                                                                                                                                                3,
+                                                                                                                                                4,
+                                                                                                                                                5,
+                                                                                                                                                6,
+                                                                                                                                                7,
+                                                                                                                                                8,
+                                                                                                                                                9,
+                                                                                                                                                10,
+                                                                                                                                                11,
+                                                                                                                                                12,
+                                                                                                                                                13,
+                                                                                                                                                14,
+                                                                                                                                                15
+                                                                                                                                              ]).readFloatLE(1)),
+                                                                                                                                    "6.207162620248253e-36"
+                                                                                                                                  ]);
                                                                                                                         })
                                                                                                                     ],
                                                                                                                     /* :: */[
                                                                                                                       /* tuple */[
-                                                                                                                        "swap64 swaps byte order as for int64",
+                                                                                                                        "readInt8",
                                                                                                                         (function (param) {
-                                                                                                                            var buf = Buffer.from(/* array */[
-                                                                                                                                    1,
-                                                                                                                                    2,
-                                                                                                                                    3,
-                                                                                                                                    4,
-                                                                                                                                    5,
-                                                                                                                                    6,
-                                                                                                                                    7,
-                                                                                                                                    8
-                                                                                                                                  ]).swap64();
-                                                                                                                            return /* Ok */Block.__(4, [buf[0] === 8 && buf[1] === 7 && buf[2] === 6 && buf[3] === 5 && buf[4] === 4 && buf[5] === 3 && buf[6] === 2 && buf[7] === 1]);
+                                                                                                                            return /* Eq */Block.__(0, [
+                                                                                                                                      String(Buffer.from(/* array */[
+                                                                                                                                                  1,
+                                                                                                                                                  2,
+                                                                                                                                                  3,
+                                                                                                                                                  4,
+                                                                                                                                                  5,
+                                                                                                                                                  6,
+                                                                                                                                                  7,
+                                                                                                                                                  8,
+                                                                                                                                                  9,
+                                                                                                                                                  10,
+                                                                                                                                                  11,
+                                                                                                                                                  12,
+                                                                                                                                                  13,
+                                                                                                                                                  14,
+                                                                                                                                                  15
+                                                                                                                                                ]).readInt8(1)),
+                                                                                                                                      "2"
+                                                                                                                                    ]);
                                                                                                                           })
                                                                                                                       ],
                                                                                                                       /* :: */[
                                                                                                                         /* tuple */[
-                                                                                                                          "toJSON",
+                                                                                                                          "readInt16BE",
                                                                                                                           (function (param) {
-                                                                                                                              var json = Buffer.from(/* array */[
-                                                                                                                                      1,
-                                                                                                                                      2,
-                                                                                                                                      3
-                                                                                                                                    ]).toJSON();
                                                                                                                               return /* Eq */Block.__(0, [
-                                                                                                                                        JSON.stringify(json),
-                                                                                                                                        "{\"type\":\"Buffer\",\"data\":[1,2,3]}"
+                                                                                                                                        String(Buffer.from(/* array */[
+                                                                                                                                                    1,
+                                                                                                                                                    2,
+                                                                                                                                                    3,
+                                                                                                                                                    4,
+                                                                                                                                                    5,
+                                                                                                                                                    6,
+                                                                                                                                                    7,
+                                                                                                                                                    8,
+                                                                                                                                                    9,
+                                                                                                                                                    10,
+                                                                                                                                                    11,
+                                                                                                                                                    12,
+                                                                                                                                                    13,
+                                                                                                                                                    14,
+                                                                                                                                                    15
+                                                                                                                                                  ]).readInt16BE(1)),
+                                                                                                                                        "515"
                                                                                                                                       ]);
                                                                                                                             })
                                                                                                                         ],
                                                                                                                         /* :: */[
                                                                                                                           /* tuple */[
-                                                                                                                            "toString converts buffer to string",
+                                                                                                                            "readInt16LE",
                                                                                                                             (function (param) {
-                                                                                                                                var source = "abc";
-                                                                                                                                var target = Buffer.from(source).toString();
                                                                                                                                 return /* Eq */Block.__(0, [
-                                                                                                                                          source,
-                                                                                                                                          target
+                                                                                                                                          String(Buffer.from(/* array */[
+                                                                                                                                                      1,
+                                                                                                                                                      2,
+                                                                                                                                                      3,
+                                                                                                                                                      4,
+                                                                                                                                                      5,
+                                                                                                                                                      6,
+                                                                                                                                                      7,
+                                                                                                                                                      8,
+                                                                                                                                                      9,
+                                                                                                                                                      10,
+                                                                                                                                                      11,
+                                                                                                                                                      12,
+                                                                                                                                                      13,
+                                                                                                                                                      14,
+                                                                                                                                                      15
+                                                                                                                                                    ]).readInt16LE(1)),
+                                                                                                                                          "770"
                                                                                                                                         ]);
                                                                                                                               })
                                                                                                                           ],
                                                                                                                           /* :: */[
                                                                                                                             /* tuple */[
-                                                                                                                              "toString with encoding uses encoding for string conversion",
+                                                                                                                              "readInt32BE",
                                                                                                                               (function (param) {
-                                                                                                                                  var target = Buffer.from("abc").toString("base64", undefined, undefined);
                                                                                                                                   return /* Eq */Block.__(0, [
-                                                                                                                                            target,
-                                                                                                                                            "YWJj"
+                                                                                                                                            String(Buffer.from(/* array */[
+                                                                                                                                                        1,
+                                                                                                                                                        2,
+                                                                                                                                                        3,
+                                                                                                                                                        4,
+                                                                                                                                                        5,
+                                                                                                                                                        6,
+                                                                                                                                                        7,
+                                                                                                                                                        8,
+                                                                                                                                                        9,
+                                                                                                                                                        10,
+                                                                                                                                                        11,
+                                                                                                                                                        12,
+                                                                                                                                                        13,
+                                                                                                                                                        14,
+                                                                                                                                                        15
+                                                                                                                                                      ]).readInt32BE(1)),
+                                                                                                                                            "33752069"
                                                                                                                                           ]);
                                                                                                                                 })
                                                                                                                             ],
                                                                                                                             /* :: */[
                                                                                                                               /* tuple */[
-                                                                                                                                "write",
+                                                                                                                                "readInt32LE",
                                                                                                                                 (function (param) {
-                                                                                                                                    var buf = Buffer.from("xxxxxxxx");
-                                                                                                                                    buf.write("YWJj", 2, "base64");
                                                                                                                                     return /* Eq */Block.__(0, [
-                                                                                                                                              buf.toString(),
-                                                                                                                                              "xxabcxxx"
+                                                                                                                                              String(Buffer.from(/* array */[
+                                                                                                                                                          1,
+                                                                                                                                                          2,
+                                                                                                                                                          3,
+                                                                                                                                                          4,
+                                                                                                                                                          5,
+                                                                                                                                                          6,
+                                                                                                                                                          7,
+                                                                                                                                                          8,
+                                                                                                                                                          9,
+                                                                                                                                                          10,
+                                                                                                                                                          11,
+                                                                                                                                                          12,
+                                                                                                                                                          13,
+                                                                                                                                                          14,
+                                                                                                                                                          15
+                                                                                                                                                        ]).readInt32LE(1)),
+                                                                                                                                              "84148994"
                                                                                                                                             ]);
                                                                                                                                   })
                                                                                                                               ],
                                                                                                                               /* :: */[
                                                                                                                                 /* tuple */[
-                                                                                                                                  "writeLength",
+                                                                                                                                  "readIntBE",
                                                                                                                                   (function (param) {
-                                                                                                                                      var buf = Buffer.from("xxxxxxxx");
-                                                                                                                                      buf.write("YWJj", 2, 2, "base64");
                                                                                                                                       return /* Eq */Block.__(0, [
-                                                                                                                                                buf.toString(),
-                                                                                                                                                "xxabxxxx"
+                                                                                                                                                String(Buffer.from(/* array */[
+                                                                                                                                                            1,
+                                                                                                                                                            2,
+                                                                                                                                                            3,
+                                                                                                                                                            4,
+                                                                                                                                                            5,
+                                                                                                                                                            6,
+                                                                                                                                                            7,
+                                                                                                                                                            8,
+                                                                                                                                                            9,
+                                                                                                                                                            10,
+                                                                                                                                                            11,
+                                                                                                                                                            12,
+                                                                                                                                                            13,
+                                                                                                                                                            14,
+                                                                                                                                                            15
+                                                                                                                                                          ]).readIntBE(1, 4)),
+                                                                                                                                                "33752069"
                                                                                                                                               ]);
                                                                                                                                     })
                                                                                                                                 ],
                                                                                                                                 /* :: */[
                                                                                                                                   /* tuple */[
-                                                                                                                                    "_INSPECT_MAX_BYTES",
+                                                                                                                                    "readIntLE",
                                                                                                                                     (function (param) {
                                                                                                                                         return /* Eq */Block.__(0, [
-                                                                                                                                                  typeof $$Buffer.INSPECT_MAX_BYTES,
-                                                                                                                                                  "number"
+                                                                                                                                                  String(Buffer.from(/* array */[
+                                                                                                                                                              1,
+                                                                                                                                                              2,
+                                                                                                                                                              3,
+                                                                                                                                                              4,
+                                                                                                                                                              5,
+                                                                                                                                                              6,
+                                                                                                                                                              7,
+                                                                                                                                                              8,
+                                                                                                                                                              9,
+                                                                                                                                                              10,
+                                                                                                                                                              11,
+                                                                                                                                                              12,
+                                                                                                                                                              13,
+                                                                                                                                                              14,
+                                                                                                                                                              15
+                                                                                                                                                            ]).readIntLE(1, 4)),
+                                                                                                                                                  "84148994"
                                                                                                                                                 ]);
                                                                                                                                       })
                                                                                                                                   ],
                                                                                                                                   /* :: */[
                                                                                                                                     /* tuple */[
-                                                                                                                                      "kMaxLength",
+                                                                                                                                      "readUint8",
                                                                                                                                       (function (param) {
                                                                                                                                           return /* Eq */Block.__(0, [
-                                                                                                                                                    typeof $$Buffer.kMaxLength,
-                                                                                                                                                    "number"
+                                                                                                                                                    String(Buffer.from(/* array */[
+                                                                                                                                                                1,
+                                                                                                                                                                2,
+                                                                                                                                                                3,
+                                                                                                                                                                4,
+                                                                                                                                                                5,
+                                                                                                                                                                6,
+                                                                                                                                                                7,
+                                                                                                                                                                8,
+                                                                                                                                                                9,
+                                                                                                                                                                10,
+                                                                                                                                                                11,
+                                                                                                                                                                12,
+                                                                                                                                                                13,
+                                                                                                                                                                14,
+                                                                                                                                                                15
+                                                                                                                                                              ]).readUInt8(1)),
+                                                                                                                                                    "2"
                                                                                                                                                   ]);
                                                                                                                                         })
                                                                                                                                     ],
                                                                                                                                     /* :: */[
                                                                                                                                       /* tuple */[
-                                                                                                                                        "transcode",
+                                                                                                                                        "readUint16BE",
                                                                                                                                         (function (param) {
-                                                                                                                                            var buf = Buffer.from("€");
-                                                                                                                                            var buf2 = $$Buffer.transcode(buf, "utf8", "ascii");
                                                                                                                                             return /* Eq */Block.__(0, [
-                                                                                                                                                      buf2.toString(),
-                                                                                                                                                      "?"
+                                                                                                                                                      String(Buffer.from(/* array */[
+                                                                                                                                                                  1,
+                                                                                                                                                                  2,
+                                                                                                                                                                  3,
+                                                                                                                                                                  4,
+                                                                                                                                                                  5,
+                                                                                                                                                                  6,
+                                                                                                                                                                  7,
+                                                                                                                                                                  8,
+                                                                                                                                                                  9,
+                                                                                                                                                                  10,
+                                                                                                                                                                  11,
+                                                                                                                                                                  12,
+                                                                                                                                                                  13,
+                                                                                                                                                                  14,
+                                                                                                                                                                  15
+                                                                                                                                                                ]).readUInt16BE(1)),
+                                                                                                                                                      "515"
                                                                                                                                                     ]);
                                                                                                                                           })
                                                                                                                                       ],
                                                                                                                                       /* :: */[
                                                                                                                                         /* tuple */[
-                                                                                                                                          "_MAX_LENGTH",
+                                                                                                                                          "readUint16LE",
                                                                                                                                           (function (param) {
                                                                                                                                               return /* Eq */Block.__(0, [
-                                                                                                                                                        typeof $$Buffer.constants.MAX_LENGTH,
-                                                                                                                                                        "number"
+                                                                                                                                                        String(Buffer.from(/* array */[
+                                                                                                                                                                    1,
+                                                                                                                                                                    2,
+                                                                                                                                                                    3,
+                                                                                                                                                                    4,
+                                                                                                                                                                    5,
+                                                                                                                                                                    6,
+                                                                                                                                                                    7,
+                                                                                                                                                                    8,
+                                                                                                                                                                    9,
+                                                                                                                                                                    10,
+                                                                                                                                                                    11,
+                                                                                                                                                                    12,
+                                                                                                                                                                    13,
+                                                                                                                                                                    14,
+                                                                                                                                                                    15
+                                                                                                                                                                  ]).readUInt16LE(1)),
+                                                                                                                                                        "770"
                                                                                                                                                       ]);
                                                                                                                                             })
                                                                                                                                         ],
                                                                                                                                         /* :: */[
                                                                                                                                           /* tuple */[
-                                                                                                                                            "_MAX_STRING_LENGTH",
+                                                                                                                                            "readUint32BE",
                                                                                                                                             (function (param) {
                                                                                                                                                 return /* Eq */Block.__(0, [
-                                                                                                                                                          typeof $$Buffer.constants.MAX_STRING_LENGTH,
-                                                                                                                                                          "number"
+                                                                                                                                                          String(Buffer.from(/* array */[
+                                                                                                                                                                      1,
+                                                                                                                                                                      2,
+                                                                                                                                                                      3,
+                                                                                                                                                                      4,
+                                                                                                                                                                      5,
+                                                                                                                                                                      6,
+                                                                                                                                                                      7,
+                                                                                                                                                                      8,
+                                                                                                                                                                      9,
+                                                                                                                                                                      10,
+                                                                                                                                                                      11,
+                                                                                                                                                                      12,
+                                                                                                                                                                      13,
+                                                                                                                                                                      14,
+                                                                                                                                                                      15
+                                                                                                                                                                    ]).readUInt32BE(1)),
+                                                                                                                                                          "33752069"
                                                                                                                                                         ]);
                                                                                                                                               })
                                                                                                                                           ],
-                                                                                                                                          /* [] */0
+                                                                                                                                          /* :: */[
+                                                                                                                                            /* tuple */[
+                                                                                                                                              "readUint32LE",
+                                                                                                                                              (function (param) {
+                                                                                                                                                  return /* Eq */Block.__(0, [
+                                                                                                                                                            String(Buffer.from(/* array */[
+                                                                                                                                                                        1,
+                                                                                                                                                                        2,
+                                                                                                                                                                        3,
+                                                                                                                                                                        4,
+                                                                                                                                                                        5,
+                                                                                                                                                                        6,
+                                                                                                                                                                        7,
+                                                                                                                                                                        8,
+                                                                                                                                                                        9,
+                                                                                                                                                                        10,
+                                                                                                                                                                        11,
+                                                                                                                                                                        12,
+                                                                                                                                                                        13,
+                                                                                                                                                                        14,
+                                                                                                                                                                        15
+                                                                                                                                                                      ]).readUInt32LE(1)),
+                                                                                                                                                            "84148994"
+                                                                                                                                                          ]);
+                                                                                                                                                })
+                                                                                                                                            ],
+                                                                                                                                            /* :: */[
+                                                                                                                                              /* tuple */[
+                                                                                                                                                "readUintBE",
+                                                                                                                                                (function (param) {
+                                                                                                                                                    return /* Eq */Block.__(0, [
+                                                                                                                                                              String(Buffer.from(/* array */[
+                                                                                                                                                                          1,
+                                                                                                                                                                          2,
+                                                                                                                                                                          3,
+                                                                                                                                                                          4,
+                                                                                                                                                                          5,
+                                                                                                                                                                          6,
+                                                                                                                                                                          7,
+                                                                                                                                                                          8,
+                                                                                                                                                                          9,
+                                                                                                                                                                          10,
+                                                                                                                                                                          11,
+                                                                                                                                                                          12,
+                                                                                                                                                                          13,
+                                                                                                                                                                          14,
+                                                                                                                                                                          15
+                                                                                                                                                                        ]).readUIntBE(1, 4)),
+                                                                                                                                                              "33752069"
+                                                                                                                                                            ]);
+                                                                                                                                                  })
+                                                                                                                                              ],
+                                                                                                                                              /* :: */[
+                                                                                                                                                /* tuple */[
+                                                                                                                                                  "readUintLE",
+                                                                                                                                                  (function (param) {
+                                                                                                                                                      return /* Eq */Block.__(0, [
+                                                                                                                                                                String(Buffer.from(/* array */[
+                                                                                                                                                                            1,
+                                                                                                                                                                            2,
+                                                                                                                                                                            3,
+                                                                                                                                                                            4,
+                                                                                                                                                                            5,
+                                                                                                                                                                            6,
+                                                                                                                                                                            7,
+                                                                                                                                                                            8,
+                                                                                                                                                                            9,
+                                                                                                                                                                            10,
+                                                                                                                                                                            11,
+                                                                                                                                                                            12,
+                                                                                                                                                                            13,
+                                                                                                                                                                            14,
+                                                                                                                                                                            15
+                                                                                                                                                                          ]).readUIntLE(1, 4)),
+                                                                                                                                                                "84148994"
+                                                                                                                                                              ]);
+                                                                                                                                                    })
+                                                                                                                                                ],
+                                                                                                                                                /* :: */[
+                                                                                                                                                  /* tuple */[
+                                                                                                                                                    "subarray returns piece of buffer",
+                                                                                                                                                    (function (param) {
+                                                                                                                                                        var buf = Buffer.from("abcd");
+                                                                                                                                                        return /* Eq */Block.__(0, [
+                                                                                                                                                                  buf.subarray(1, 3).toString(),
+                                                                                                                                                                  "bc"
+                                                                                                                                                                ]);
+                                                                                                                                                      })
+                                                                                                                                                  ],
+                                                                                                                                                  /* :: */[
+                                                                                                                                                    /* tuple */[
+                                                                                                                                                      "slice returns piece of buffer",
+                                                                                                                                                      (function (param) {
+                                                                                                                                                          var buf = Buffer.from("abcd");
+                                                                                                                                                          return /* Eq */Block.__(0, [
+                                                                                                                                                                    buf.slice(1, 3).toString(),
+                                                                                                                                                                    "bc"
+                                                                                                                                                                  ]);
+                                                                                                                                                        })
+                                                                                                                                                    ],
+                                                                                                                                                    /* :: */[
+                                                                                                                                                      /* tuple */[
+                                                                                                                                                        "swap16 swaps byte order as for int16",
+                                                                                                                                                        (function (param) {
+                                                                                                                                                            var buf = Buffer.from(/* array */[
+                                                                                                                                                                    1,
+                                                                                                                                                                    2,
+                                                                                                                                                                    3,
+                                                                                                                                                                    4
+                                                                                                                                                                  ]).swap16();
+                                                                                                                                                            return /* Ok */Block.__(4, [buf[0] === 2 && buf[1] === 1 && buf[2] === 4 && buf[3] === 3]);
+                                                                                                                                                          })
+                                                                                                                                                      ],
+                                                                                                                                                      /* :: */[
+                                                                                                                                                        /* tuple */[
+                                                                                                                                                          "swap32 swaps byte order as for int32",
+                                                                                                                                                          (function (param) {
+                                                                                                                                                              var buf = Buffer.from(/* array */[
+                                                                                                                                                                      1,
+                                                                                                                                                                      2,
+                                                                                                                                                                      3,
+                                                                                                                                                                      4
+                                                                                                                                                                    ]).swap32();
+                                                                                                                                                              return /* Ok */Block.__(4, [buf[0] === 4 && buf[1] === 3 && buf[2] === 2 && buf[3] === 1]);
+                                                                                                                                                            })
+                                                                                                                                                        ],
+                                                                                                                                                        /* :: */[
+                                                                                                                                                          /* tuple */[
+                                                                                                                                                            "swap64 swaps byte order as for int64",
+                                                                                                                                                            (function (param) {
+                                                                                                                                                                var buf = Buffer.from(/* array */[
+                                                                                                                                                                        1,
+                                                                                                                                                                        2,
+                                                                                                                                                                        3,
+                                                                                                                                                                        4,
+                                                                                                                                                                        5,
+                                                                                                                                                                        6,
+                                                                                                                                                                        7,
+                                                                                                                                                                        8
+                                                                                                                                                                      ]).swap64();
+                                                                                                                                                                return /* Ok */Block.__(4, [buf[0] === 8 && buf[1] === 7 && buf[2] === 6 && buf[3] === 5 && buf[4] === 4 && buf[5] === 3 && buf[6] === 2 && buf[7] === 1]);
+                                                                                                                                                              })
+                                                                                                                                                          ],
+                                                                                                                                                          /* :: */[
+                                                                                                                                                            /* tuple */[
+                                                                                                                                                              "toJSON",
+                                                                                                                                                              (function (param) {
+                                                                                                                                                                  var json = Buffer.from(/* array */[
+                                                                                                                                                                          1,
+                                                                                                                                                                          2,
+                                                                                                                                                                          3
+                                                                                                                                                                        ]).toJSON();
+                                                                                                                                                                  return /* Eq */Block.__(0, [
+                                                                                                                                                                            JSON.stringify(json),
+                                                                                                                                                                            "{\"type\":\"Buffer\",\"data\":[1,2,3]}"
+                                                                                                                                                                          ]);
+                                                                                                                                                                })
+                                                                                                                                                            ],
+                                                                                                                                                            /* :: */[
+                                                                                                                                                              /* tuple */[
+                                                                                                                                                                "toString converts buffer to string",
+                                                                                                                                                                (function (param) {
+                                                                                                                                                                    var source = "abc";
+                                                                                                                                                                    var target = Buffer.from(source).toString();
+                                                                                                                                                                    return /* Eq */Block.__(0, [
+                                                                                                                                                                              source,
+                                                                                                                                                                              target
+                                                                                                                                                                            ]);
+                                                                                                                                                                  })
+                                                                                                                                                              ],
+                                                                                                                                                              /* :: */[
+                                                                                                                                                                /* tuple */[
+                                                                                                                                                                  "toString with encoding uses encoding for string conversion",
+                                                                                                                                                                  (function (param) {
+                                                                                                                                                                      var target = Buffer.from("abc").toString("base64", undefined, undefined);
+                                                                                                                                                                      return /* Eq */Block.__(0, [
+                                                                                                                                                                                target,
+                                                                                                                                                                                "YWJj"
+                                                                                                                                                                              ]);
+                                                                                                                                                                    })
+                                                                                                                                                                ],
+                                                                                                                                                                /* :: */[
+                                                                                                                                                                  /* tuple */[
+                                                                                                                                                                    "write",
+                                                                                                                                                                    (function (param) {
+                                                                                                                                                                        var buf = Buffer.from("xxxxxxxx");
+                                                                                                                                                                        buf.write("YWJj", 2, "base64");
+                                                                                                                                                                        return /* Eq */Block.__(0, [
+                                                                                                                                                                                  buf.toString(),
+                                                                                                                                                                                  "xxabcxxx"
+                                                                                                                                                                                ]);
+                                                                                                                                                                      })
+                                                                                                                                                                  ],
+                                                                                                                                                                  /* :: */[
+                                                                                                                                                                    /* tuple */[
+                                                                                                                                                                      "writeLength",
+                                                                                                                                                                      (function (param) {
+                                                                                                                                                                          var buf = Buffer.from("xxxxxxxx");
+                                                                                                                                                                          buf.write("YWJj", 2, 2, "base64");
+                                                                                                                                                                          return /* Eq */Block.__(0, [
+                                                                                                                                                                                    buf.toString(),
+                                                                                                                                                                                    "xxabxxxx"
+                                                                                                                                                                                  ]);
+                                                                                                                                                                        })
+                                                                                                                                                                    ],
+                                                                                                                                                                    /* :: */[
+                                                                                                                                                                      /* tuple */[
+                                                                                                                                                                        "_INSPECT_MAX_BYTES",
+                                                                                                                                                                        (function (param) {
+                                                                                                                                                                            return /* Eq */Block.__(0, [
+                                                                                                                                                                                      typeof $$Buffer.INSPECT_MAX_BYTES,
+                                                                                                                                                                                      "number"
+                                                                                                                                                                                    ]);
+                                                                                                                                                                          })
+                                                                                                                                                                      ],
+                                                                                                                                                                      /* :: */[
+                                                                                                                                                                        /* tuple */[
+                                                                                                                                                                          "kMaxLength",
+                                                                                                                                                                          (function (param) {
+                                                                                                                                                                              return /* Eq */Block.__(0, [
+                                                                                                                                                                                        typeof $$Buffer.kMaxLength,
+                                                                                                                                                                                        "number"
+                                                                                                                                                                                      ]);
+                                                                                                                                                                            })
+                                                                                                                                                                        ],
+                                                                                                                                                                        /* :: */[
+                                                                                                                                                                          /* tuple */[
+                                                                                                                                                                            "transcode",
+                                                                                                                                                                            (function (param) {
+                                                                                                                                                                                var buf = Buffer.from("€");
+                                                                                                                                                                                var buf2 = $$Buffer.transcode(buf, "utf8", "ascii");
+                                                                                                                                                                                return /* Eq */Block.__(0, [
+                                                                                                                                                                                          buf2.toString(),
+                                                                                                                                                                                          "?"
+                                                                                                                                                                                        ]);
+                                                                                                                                                                              })
+                                                                                                                                                                          ],
+                                                                                                                                                                          /* :: */[
+                                                                                                                                                                            /* tuple */[
+                                                                                                                                                                              "_MAX_LENGTH",
+                                                                                                                                                                              (function (param) {
+                                                                                                                                                                                  return /* Eq */Block.__(0, [
+                                                                                                                                                                                            typeof $$Buffer.constants.MAX_LENGTH,
+                                                                                                                                                                                            "number"
+                                                                                                                                                                                          ]);
+                                                                                                                                                                                })
+                                                                                                                                                                            ],
+                                                                                                                                                                            /* :: */[
+                                                                                                                                                                              /* tuple */[
+                                                                                                                                                                                "_MAX_STRING_LENGTH",
+                                                                                                                                                                                (function (param) {
+                                                                                                                                                                                    return /* Eq */Block.__(0, [
+                                                                                                                                                                                              typeof $$Buffer.constants.MAX_STRING_LENGTH,
+                                                                                                                                                                                              "number"
+                                                                                                                                                                                            ]);
+                                                                                                                                                                                  })
+                                                                                                                                                                              ],
+                                                                                                                                                                              /* [] */0
+                                                                                                                                                                            ]
+                                                                                                                                                                          ]
+                                                                                                                                                                        ]
+                                                                                                                                                                      ]
+                                                                                                                                                                    ]
+                                                                                                                                                                  ]
+                                                                                                                                                                ]
+                                                                                                                                                              ]
+                                                                                                                                                            ]
+                                                                                                                                                          ]
+                                                                                                                                                        ]
+                                                                                                                                                      ]
+                                                                                                                                                    ]
+                                                                                                                                                  ]
+                                                                                                                                                ]
+                                                                                                                                              ]
+                                                                                                                                            ]
+                                                                                                                                          ]
                                                                                                                                         ]
                                                                                                                                       ]
                                                                                                                                     ]

--- a/jscomp/test/node_buffer_test.js
+++ b/jscomp/test/node_buffer_test.js
@@ -1,0 +1,517 @@
+'use strict';
+
+var Mt = require("./mt.js");
+var Block = require("../../lib/js/block.js");
+
+var suites_000 = /* tuple */[
+  "alloc returns an object",
+  (function (param) {
+      var buf = Buffer.alloc(0, undefined, undefined);
+      return /* Eq */Block.__(0, [
+                typeof buf,
+                "object"
+              ]);
+    })
+];
+
+var suites_001 = /* :: */[
+  /* tuple */[
+    "alloc returns buffer of specified length",
+    (function (param) {
+        var buf = Buffer.alloc(3, undefined, undefined);
+        return /* Eq */Block.__(0, [
+                  buf.length,
+                  3
+                ]);
+      })
+  ],
+  /* :: */[
+    /* tuple */[
+      "alloc takes optional fill parameter to fill buffer (String)",
+      (function (param) {
+          var buf = Buffer.alloc(3, "a", undefined);
+          return /* Eq */Block.__(0, [
+                    buf.toString(),
+                    "aaa"
+                  ]);
+        })
+    ],
+    /* :: */[
+      /* tuple */[
+        "alloc takes optional fill parameter to fill buffer (Integer)",
+        (function (param) {
+            var buf = Buffer.alloc(3, 98, undefined);
+            return /* Eq */Block.__(0, [
+                      buf.toString(),
+                      "bbb"
+                    ]);
+          })
+      ],
+      /* :: */[
+        /* tuple */[
+          "alloc takes optional fill parameter to fill buffer (Buffer)",
+          (function (param) {
+              var fill_buffer = Buffer.alloc(3, "abc", undefined);
+              var buf = Buffer.alloc(6, fill_buffer, undefined);
+              return /* Eq */Block.__(0, [
+                        buf.toString(),
+                        "abcabc"
+                      ]);
+            })
+        ],
+        /* :: */[
+          /* tuple */[
+            "alloc takes optional fill parameter to fill buffer (Uint8Array)",
+            (function (param) {
+                var fill_arr = new Uint8Array(/* array */[
+                      97,
+                      98,
+                      99
+                    ]);
+                var buf = Buffer.alloc(9, fill_arr, undefined);
+                return /* Eq */Block.__(0, [
+                          buf.toString(),
+                          "abcabcabc"
+                        ]);
+              })
+          ],
+          /* :: */[
+            /* tuple */[
+              "alloc takes optional encoding parameter to spec fill encoding",
+              (function (param) {
+                  var buf = Buffer.alloc(3, "YWJj", "base64");
+                  return /* Eq */Block.__(0, [
+                            buf.toString(),
+                            "abc"
+                          ]);
+                })
+            ],
+            /* :: */[
+              /* tuple */[
+                "allocUnsafe returns an object",
+                (function (param) {
+                    var buf = Buffer.allocUnsafe(4);
+                    return /* Eq */Block.__(0, [
+                              typeof buf,
+                              "object"
+                            ]);
+                  })
+              ],
+              /* :: */[
+                /* tuple */[
+                  "allocUnsafe returns buffer of specified length",
+                  (function (param) {
+                      var buf = Buffer.allocUnsafe(4);
+                      return /* Eq */Block.__(0, [
+                                buf.length,
+                                4
+                              ]);
+                    })
+                ],
+                /* :: */[
+                  /* tuple */[
+                    "allocUnsafeSlow returns an object",
+                    (function (param) {
+                        var buf = Buffer.allocUnsafeSlow(4);
+                        return /* Eq */Block.__(0, [
+                                  typeof buf,
+                                  "object"
+                                ]);
+                      })
+                  ],
+                  /* :: */[
+                    /* tuple */[
+                      "allocUnsafeSlow returns buffer of specified length",
+                      (function (param) {
+                          var buf = Buffer.allocUnsafeSlow(4);
+                          return /* Eq */Block.__(0, [
+                                    buf.length,
+                                    4
+                                  ]);
+                        })
+                    ],
+                    /* :: */[
+                      /* tuple */[
+                        "byteLength returns byte length of value - Buffer",
+                        (function (param) {
+                            var buf = Buffer.alloc(4, undefined, undefined);
+                            return /* Eq */Block.__(0, [
+                                      Buffer.byteLength(buf),
+                                      4
+                                    ]);
+                          })
+                      ],
+                      /* :: */[
+                        /* tuple */[
+                          "byteLength returns byte length of value - Int32Array",
+                          (function (param) {
+                              var arr = new Int32Array(3);
+                              return /* Eq */Block.__(0, [
+                                        Buffer.byteLength(arr),
+                                        12
+                                      ]);
+                            })
+                        ],
+                        /* :: */[
+                          /* tuple */[
+                            "byteLengthOfString returns byte length of string",
+                            (function (param) {
+                                return /* Eq */Block.__(0, [
+                                          Buffer.byteLength("abc", undefined),
+                                          3
+                                        ]);
+                              })
+                          ],
+                          /* :: */[
+                            /* tuple */[
+                              "byteLengthOfString returns byte length of string",
+                              (function (param) {
+                                  return /* Eq */Block.__(0, [
+                                            Buffer.byteLength("YWJj", "base64"),
+                                            3
+                                          ]);
+                                })
+                            ],
+                            /* :: */[
+                              /* tuple */[
+                                "compare returns -1 if first param sorts before second",
+                                (function (param) {
+                                    var buf1 = Buffer.from("a");
+                                    var buf2 = Buffer.from("b");
+                                    return /* Eq */Block.__(0, [
+                                              Buffer.compare(buf1, buf2),
+                                              -1
+                                            ]);
+                                  })
+                              ],
+                              /* :: */[
+                                /* tuple */[
+                                  "compare returns 0 if first param equals to second",
+                                  (function (param) {
+                                      var buf1 = Buffer.from("a");
+                                      var buf2 = Buffer.from("a");
+                                      return /* Eq */Block.__(0, [
+                                                Buffer.compare(buf1, buf2),
+                                                0
+                                              ]);
+                                    })
+                                ],
+                                /* :: */[
+                                  /* tuple */[
+                                    "compare returns 1 if first param sorts after second",
+                                    (function (param) {
+                                        var buf1 = Buffer.from("b");
+                                        var buf2 = Buffer.from("a");
+                                        return /* Eq */Block.__(0, [
+                                                  Buffer.compare(buf1, buf2),
+                                                  1
+                                                ]);
+                                      })
+                                  ],
+                                  /* :: */[
+                                    /* tuple */[
+                                      "compareRanges compares values from two buffers",
+                                      (function (param) {
+                                          var buf1 = Buffer.from("bbbabcbbb");
+                                          var buf2 = Buffer.from("babcbbb");
+                                          return /* Eq */Block.__(0, [
+                                                    buf1.compare(buf2, 1, 3, 3, 5),
+                                                    0
+                                                  ]);
+                                        })
+                                    ],
+                                    /* :: */[
+                                      /* tuple */[
+                                        "concat returns contactenated buffer from array of buffers",
+                                        (function (param) {
+                                            var buf1 = Buffer.from("a");
+                                            var buf2 = Buffer.from("b");
+                                            var concatenated = Buffer.concat(/* array */[
+                                                  buf1,
+                                                  buf2
+                                                ]);
+                                            return /* Eq */Block.__(0, [
+                                                      concatenated.toString(),
+                                                      "ab"
+                                                    ]);
+                                          })
+                                      ],
+                                      /* :: */[
+                                        /* tuple */[
+                                          "concatWithLength returns contactenated buffer from array of buffers",
+                                          (function (param) {
+                                              var buf1 = Buffer.from("a");
+                                              var buf2 = Buffer.from("bc");
+                                              var concatenated = Buffer.concat(/* array */[
+                                                    buf1,
+                                                    buf2
+                                                  ], 3);
+                                              return /* Eq */Block.__(0, [
+                                                        concatenated.toString(),
+                                                        "abc"
+                                                      ]);
+                                            })
+                                        ],
+                                        /* :: */[
+                                          /* tuple */[
+                                            "fromArray",
+                                            (function (param) {
+                                                var buf = Buffer.from(/* array */[
+                                                      97,
+                                                      98
+                                                    ]);
+                                                return /* Eq */Block.__(0, [
+                                                          buf.toString(),
+                                                          "ab"
+                                                        ]);
+                                              })
+                                          ],
+                                          /* :: */[
+                                            /* tuple */[
+                                              "fromArrayBuffer",
+                                              (function (param) {
+                                                  var buf = Buffer.from(new ArrayBuffer(4), undefined, undefined);
+                                                  return /* Eq */Block.__(0, [
+                                                            buf.length,
+                                                            4
+                                                          ]);
+                                                })
+                                            ],
+                                            /* :: */[
+                                              /* tuple */[
+                                                "fromArrayBuffer supports optional byteOffset param",
+                                                (function (param) {
+                                                    var buf = Buffer.from(new ArrayBuffer(4), 2, undefined);
+                                                    return /* Eq */Block.__(0, [
+                                                              buf.length,
+                                                              2
+                                                            ]);
+                                                  })
+                                              ],
+                                              /* :: */[
+                                                /* tuple */[
+                                                  "fromArrayBuffer supports optional byteOffset and length param ",
+                                                  (function (param) {
+                                                      var buf = Buffer.from(new ArrayBuffer(4), 2, 1);
+                                                      return /* Eq */Block.__(0, [
+                                                                buf.length,
+                                                                1
+                                                              ]);
+                                                    })
+                                                ],
+                                                /* :: */[
+                                                  /* tuple */[
+                                                    "fromBuffer makes buffer from another Buffer",
+                                                    (function (param) {
+                                                        var source = Buffer.from("abc");
+                                                        var target = Buffer.from(source);
+                                                        return /* Eq */Block.__(0, [
+                                                                  target.toString(),
+                                                                  "abc"
+                                                                ]);
+                                                      })
+                                                  ],
+                                                  /* :: */[
+                                                    /* tuple */[
+                                                      "fromString makes buffer from string value",
+                                                      (function (param) {
+                                                          var buf = Buffer.from("abc");
+                                                          return /* Eq */Block.__(0, [
+                                                                    buf.toString(),
+                                                                    "abc"
+                                                                  ]);
+                                                        })
+                                                    ],
+                                                    /* :: */[
+                                                      /* tuple */[
+                                                        "fromStringWithEncoding supports specifying string encoding",
+                                                        (function (param) {
+                                                            var buf = Buffer.from("YWJj", "base64");
+                                                            return /* Eq */Block.__(0, [
+                                                                      buf.toString(),
+                                                                      "abc"
+                                                                    ]);
+                                                          })
+                                                      ],
+                                                      /* :: */[
+                                                        /* tuple */[
+                                                          "isBuffer returns true for buffer values",
+                                                          (function (param) {
+                                                              var buf = Buffer.from("abc");
+                                                              return /* Ok */Block.__(4, [Buffer.isBuffer(buf)]);
+                                                            })
+                                                        ],
+                                                        /* :: */[
+                                                          /* tuple */[
+                                                            "isBuffer returns false for non-buffer values",
+                                                            (function (param) {
+                                                                return /* Ok */Block.__(4, [!Buffer.isBuffer("abc")]);
+                                                              })
+                                                          ],
+                                                          /* :: */[
+                                                            /* tuple */[
+                                                              "isEncoding returns true for valid encoding strings",
+                                                              (function (param) {
+                                                                  return /* Ok */Block.__(4, [Buffer.isEncoding("binary")]);
+                                                                })
+                                                            ],
+                                                            /* :: */[
+                                                              /* tuple */[
+                                                                "isEncoding returns false for valid encoding string",
+                                                                (function (param) {
+                                                                    return /* Ok */Block.__(4, [!Buffer.isEncoding("some-arbitraty-string")]);
+                                                                  })
+                                                              ],
+                                                              /* :: */[
+                                                                /* tuple */[
+                                                                  "poolSize returns internal Buffer pool size",
+                                                                  (function (param) {
+                                                                      return /* Eq */Block.__(0, [
+                                                                                typeof Buffer.poolSize,
+                                                                                "number"
+                                                                              ]);
+                                                                    })
+                                                                ],
+                                                                /* :: */[
+                                                                  /* tuple */[
+                                                                    "unsafe_get allows direct buffer reading by position",
+                                                                    (function (param) {
+                                                                        var buf = Buffer.from("abc");
+                                                                        return /* Eq */Block.__(0, [
+                                                                                  buf[0],
+                                                                                  97
+                                                                                ]);
+                                                                      })
+                                                                  ],
+                                                                  /* :: */[
+                                                                    /* tuple */[
+                                                                      "unsafe_set allows direct buffer modification by position",
+                                                                      (function (param) {
+                                                                          var buf = Buffer.from("abc");
+                                                                          buf[0] = 98;
+                                                                          return /* Eq */Block.__(0, [
+                                                                                    buf.toString(),
+                                                                                    "bbc"
+                                                                                  ]);
+                                                                        })
+                                                                    ],
+                                                                    /* :: */[
+                                                                      /* tuple */[
+                                                                        "buffer returns underlying ArrayBuffer",
+                                                                        (function (param) {
+                                                                            var buf = Buffer.from("abc");
+                                                                            var buf2 = Buffer.from("bbc");
+                                                                            var ab = buf.buffer;
+                                                                            var ab2 = buf2.buffer;
+                                                                            return /* Eq */Block.__(0, [
+                                                                                      ab,
+                                                                                      ab2
+                                                                                    ]);
+                                                                          })
+                                                                      ],
+                                                                      /* :: */[
+                                                                        /* tuple */[
+                                                                          "byteOffset reurns buffer offset in underlying ArrayBuffer",
+                                                                          (function (param) {
+                                                                              var buf = Buffer.from("abc");
+                                                                              var offset = buf.byteOffset;
+                                                                              return /* Eq */Block.__(0, [
+                                                                                        typeof offset,
+                                                                                        "number"
+                                                                                      ]);
+                                                                            })
+                                                                        ],
+                                                                        /* :: */[
+                                                                          /* tuple */[
+                                                                            "copy transfers one buffer region to another",
+                                                                            (function (param) {
+                                                                                var buf = Buffer.from("abc");
+                                                                                var buf2 = Buffer.from("xxxxx");
+                                                                                buf.copy(buf2, 1, 1, 3);
+                                                                                return /* Eq */Block.__(0, [
+                                                                                          buf2.toString(),
+                                                                                          "xbcxx"
+                                                                                        ]);
+                                                                              })
+                                                                          ],
+                                                                          /* :: */[
+                                                                            /* tuple */[
+                                                                              "equals returns true if two buffers share same bytes",
+                                                                              (function (param) {
+                                                                                  var buf = Buffer.from("abc");
+                                                                                  var buf2 = Buffer.from("abc");
+                                                                                  return /* Ok */Block.__(4, [buf.equals(buf2)]);
+                                                                                })
+                                                                            ],
+                                                                            /* :: */[
+                                                                              /* tuple */[
+                                                                                "equals returns true if two buffers not share same bytes",
+                                                                                (function (param) {
+                                                                                    var buf = Buffer.from("abc");
+                                                                                    var buf2 = Buffer.from("abd");
+                                                                                    return /* Ok */Block.__(4, [!buf.equals(buf2)]);
+                                                                                  })
+                                                                              ],
+                                                                              /* :: */[
+                                                                                /* tuple */[
+                                                                                  "fill fills existing buffer with provided value",
+                                                                                  (function (param) {
+                                                                                      var buf = Buffer.from("aaaaa");
+                                                                                      var buf$1 = buf.fill(98, 2, 4);
+                                                                                      return /* Eq */Block.__(0, [
+                                                                                                buf$1.toString(),
+                                                                                                "aabba"
+                                                                                              ]);
+                                                                                    })
+                                                                                ],
+                                                                                /* [] */0
+                                                                              ]
+                                                                            ]
+                                                                          ]
+                                                                        ]
+                                                                      ]
+                                                                    ]
+                                                                  ]
+                                                                ]
+                                                              ]
+                                                            ]
+                                                          ]
+                                                        ]
+                                                      ]
+                                                    ]
+                                                  ]
+                                                ]
+                                              ]
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  ]
+];
+
+var suites = /* :: */[
+  suites_000,
+  suites_001
+];
+
+Mt.from_pair_suites("Node_buffer_test", suites);
+
+exports.suites = suites;
+/*  Not a pure module */

--- a/jscomp/test/node_buffer_test.ml
+++ b/jscomp/test/node_buffer_test.ml
@@ -1,0 +1,214 @@
+
+let suites = Mt.[
+  "alloc returns an object", (fun _ -> 
+    let buf = Node.Buffer.alloc 0 () in
+    Eq(Js.typeof buf, "object")
+  );
+  "alloc returns buffer of specified length", (fun _ -> 
+    let buf = Node.Buffer.alloc 3 () in
+    Eq(Node.Buffer.length buf, 3)
+  );
+  "alloc takes optional fill parameter to fill buffer (String)", (fun _ -> 
+    let buf = Node.Buffer.alloc 3 ~fill:(`String "a") () in
+    Eq(Node.Buffer.toString buf, "aaa")
+  );
+  "alloc takes optional fill parameter to fill buffer (Integer)", (fun _ -> 
+    let buf = Node.Buffer.alloc 3 ~fill:(`Integer 98) () in
+    Eq(Node.Buffer.toString buf, "bbb")
+  );
+  "alloc takes optional fill parameter to fill buffer (Buffer)", (fun _ -> 
+    let fill_buffer = Node.Buffer.alloc 3 ~fill:(`String "abc") () in
+    let buf = Node.Buffer.alloc 6 ~fill:(`Buffer fill_buffer) () in
+    Eq(Node.Buffer.toString buf, "abcabc")
+  );
+  "alloc takes optional fill parameter to fill buffer (Uint8Array)", (fun _ -> 
+    let fill_arr = Js_typed_array2.Uint8Array.make [|97;98;99|] in
+    let buf = Node.Buffer.alloc 9 ~fill:(`Uint8Array fill_arr) () in
+    Eq(Node.Buffer.toString buf, "abcabcabc")
+  );
+  "alloc takes optional encoding parameter to spec fill encoding", (fun _ -> 
+    let str = "YWJj" in 
+    let buf = Node.Buffer.alloc 3 ~fill:(`String str) ~encoding:`base64 () in
+    Eq(Node.Buffer.toString buf, "abc")
+  );
+
+  "allocUnsafe returns an object", (fun _ -> 
+    let buf = Node.Buffer.allocUnsafe 4 in
+    Eq(Js.typeof buf, "object")
+  );
+  "allocUnsafe returns buffer of specified length", (fun _ -> 
+    let buf = Node.Buffer.allocUnsafe 4 in
+    Eq(Node.Buffer.length buf, 4)
+  );
+
+  "allocUnsafeSlow returns an object", (fun _ -> 
+    let buf = Node.Buffer.allocUnsafeSlow 4 in
+    Eq(Js.typeof buf, "object")
+  );
+  "allocUnsafeSlow returns buffer of specified length", (fun _ -> 
+    let buf = Node.Buffer.allocUnsafeSlow 4 in
+    Eq(Node.Buffer.length buf, 4)
+  );
+
+  "byteLength returns byte length of value - Buffer", (fun _ ->
+    let buf = Node.Buffer.alloc 4 () in
+    Eq(Node.Buffer.byteLength (`Buffer buf), 4)
+  );
+  "byteLength returns byte length of value - Int32Array", (fun _ ->
+    let arr = Js.TypedArray2.Int32Array.fromLength 3 in
+    Eq(Node.Buffer.byteLength (`Int32Array arr), 3 * 4)
+  );
+
+  "byteLengthOfString returns byte length of string", (fun _ -> 
+    Eq(Node.Buffer.byteLengthOfString "abc" (), 3)
+  );
+  "byteLengthOfString returns byte length of string", (fun _ -> 
+    Eq(Node.Buffer.byteLengthOfString "YWJj" ~encoding:`base64 (), 3)
+  );
+
+  "compare returns -1 if first param sorts before second", (fun _ -> 
+    let buf1 = Node.Buffer.fromString "a"
+    and buf2 = Node.Buffer.fromString "b" in
+    Eq(Node.Buffer.compare (`Buffer buf1) (`Buffer buf2), -1)
+  );
+  "compare returns 0 if first param equals to second", (fun _ -> 
+    let buf1 = Node.Buffer.fromString "a"
+    and buf2 = Node.Buffer.fromString "a" in
+    Eq(Node.Buffer.compare (`Buffer buf1) (`Buffer buf2), 0)
+  );
+  "compare returns 1 if first param sorts after second", (fun _ -> 
+    let buf1 = Node.Buffer.fromString "b"
+    and buf2 = Node.Buffer.fromString "a" in
+    Eq(Node.Buffer.compare (`Buffer buf1) (`Buffer buf2), 1)
+  );
+
+  "compareRanges compares values from two buffers", (fun _ ->
+    let buf1 = Node.Buffer.fromString "bbbabcbbb"
+    and buf2 = Node.Buffer.fromString "babcbbb" in
+    Eq(Node.Buffer.compareRanges buf1 buf2 ~targetStart:1 ~targetEnd:3 ~sourceStart:3 ~sourceEnd:5 (), 0)
+  );
+
+  "concat returns contactenated buffer from array of buffers", (fun _ -> 
+    let buf1 = Node.Buffer.fromString "a"
+    and buf2 = Node.Buffer.fromString "b" in
+    let concatenated = Node.Buffer.concat [|buf1; buf2|] in
+    Eq(Node.Buffer.toString concatenated, "ab")
+  );
+
+  "concatWithLength returns contactenated buffer from array of buffers", (fun _ -> 
+    let buf1 = Node.Buffer.fromString "a"
+    and buf2 = Node.Buffer.fromString "bc" in
+    let concatenated = Node.Buffer.concatWithLength [|buf1; buf2|] 3 in
+    Eq(Node.Buffer.toString concatenated, "abc")
+  );
+
+  "fromArray", (fun _ -> 
+    let buf = Node.Buffer.fromArray [|97;98|] in
+    Eq(Node.Buffer.toString buf, "ab")
+  );
+
+  "fromArrayBuffer", (fun _ -> 
+    let buf = Node.Buffer.fromArrayBuffer (Js.TypedArray2.ArrayBuffer.make 4) () in
+    Eq(Node.Buffer.length buf, 4)
+  );
+  "fromArrayBuffer supports optional byteOffset param", (fun _ -> 
+    let buf = Node.Buffer.fromArrayBuffer (Js.TypedArray2.ArrayBuffer.make 4) ~byteOffset:2 () in
+    Eq(Node.Buffer.length buf, 2)
+  );
+  "fromArrayBuffer supports optional byteOffset and length param ", (fun _ -> 
+    let buf = Node.Buffer.fromArrayBuffer (Js.TypedArray2.ArrayBuffer.make 4) ~byteOffset:2 ~length:1 () in
+    Eq(Node.Buffer.length buf, 1)
+  );
+
+  "fromBuffer makes buffer from another Buffer", (fun _ -> 
+    let source = Node.Buffer.fromString "abc" in
+    let target = Node.Buffer.fromBuffer (`Buffer source) in
+    Eq(Node.Buffer.toString target, "abc")
+  );
+
+  "fromString makes buffer from string value", (fun _ ->
+    let buf = Node.Buffer.fromString "abc" in
+    Eq(Node.Buffer.toString buf, "abc")
+  );
+
+  "fromStringWithEncoding supports specifying string encoding", (fun _ -> 
+    let buf = Node.Buffer.fromStringWithEncoding "YWJj" `base64 in
+    Eq(Node.Buffer.toString buf, "abc")
+  );
+
+  "isBuffer returns true for buffer values", (fun _ ->
+    let buf = Node.Buffer.fromString "abc" in
+    Ok(Node.Buffer.isBuffer buf)
+  );
+
+  "isBuffer returns false for non-buffer values", (fun _ -> 
+    let value = "abc" in
+    Ok(not (Node.Buffer.isBuffer value))
+  );
+
+  "isEncoding returns true for valid encoding strings", (fun _ -> 
+    Ok(Node.Buffer.isEncoding "binary")
+  );
+
+  "isEncoding returns false for valid encoding string", (fun _ ->
+    Ok(not (Node.Buffer.isEncoding "some-arbitraty-string"))
+  );
+    
+  "poolSize returns internal Buffer pool size", (fun _ ->
+    Eq(Js.typeof (Node.Buffer.poolSize), "number")
+  );
+
+  "unsafe_get allows direct buffer reading by position", (fun _ ->
+    let buf = Node.Buffer.fromString "abc" in
+    Eq(Node.Buffer.unsafe_get buf 0, 97)
+  );
+
+  "unsafe_set allows direct buffer modification by position", (fun _ ->
+    let buf = Node.Buffer.fromString "abc" in
+    let () = Node.Buffer.unsafe_set buf ~index:0 98 in
+    Eq(Node.Buffer.toString buf, "bbc")
+  );
+
+  "buffer returns underlying ArrayBuffer", (fun _ ->
+    let buf = Node.Buffer.fromString "abc" in
+    let buf2 = Node.Buffer.fromString "bbc" in
+    let ab = Node.Buffer.buffer buf in
+    let ab2 = Node.Buffer.buffer buf2 in
+    (* default allocation is buffered so two buffers share same ArrayBuffer *)
+    Eq(ab, ab2)
+  );
+
+  "byteOffset reurns buffer offset in underlying ArrayBuffer", (fun _ -> 
+    let buf = Node.Buffer.fromString "abc" in
+    let offset = Node.Buffer.byteOffset buf in
+    Eq(Js.typeof offset, "number")
+  );
+
+  "copy transfers one buffer region to another", (fun _ ->
+    let buf = Node.Buffer.fromString "abc" in
+    let buf2 = Node.Buffer.fromString "xxxxx" in
+    let () = ignore (Node.Buffer.copy buf ~target:buf2 ~targetStart:1 ~sourceStart:1 ~sourceEnd:3 ()) in
+    Eq(Node.Buffer.toString buf2, "xbcxx")
+  );
+
+  "equals returns true if two buffers share same bytes", (fun _ ->
+    let buf = Node.Buffer.fromString "abc" in
+    let buf2 = Node.Buffer.fromString "abc" in
+    Ok(Node.Buffer.equals buf buf2)
+  );
+
+  "equals returns true if two buffers not share same bytes", (fun _ ->
+    let buf = Node.Buffer.fromString "abc" in
+    let buf2 = Node.Buffer.fromString "abd" in
+    Ok(not (Node.Buffer.equals buf buf2))
+  );
+
+  "fill fills existing buffer with provided value", (fun _ ->
+    let buf = Node.Buffer.fromString "aaaaa" in
+    let buf = Node.Buffer.fill buf (`Integer 98) ~offset:2 ~end_:4 () in
+    Eq(Node.Buffer.toString buf, "aabba")
+  );
+
+]
+
+;; Mt.from_pair_suites __MODULE__ suites

--- a/jscomp/test/node_buffer_test.ml
+++ b/jscomp/test/node_buffer_test.ml
@@ -279,6 +279,170 @@ let suites = Mt.[
     Eq("abc" |. Node.Buffer.fromString |. Node.Buffer.length, 3)
   );
 
+  "readDoubleBE", (fun _ ->
+    Eq(
+      [|1;2;3;4;5;6;7;8;9;10;11;12;13;14;15|]
+      |. Node.Buffer.fromArray
+      |. Node.Buffer.readDoubleBE ~offset:1 ()
+      |. Belt.Float.toString,
+      "5.678932010640861e-299"     
+    ) 
+  );
+  "readDoubleLE", (fun _ ->
+    Eq(
+      [|1;2;3;4;5;6;7;8;9;10;11;12;13;14;15|]
+      |. Node.Buffer.fromArray
+      |. Node.Buffer.readDoubleLE ~offset:1 ()
+      |. Belt.Float.toString,
+      "3.7258146895053074e-265"
+    ) 
+  );
+  "readFloatBE", (fun _ ->
+    Eq(
+      [|1;2;3;4;5;6;7;8;9;10;11;12;13;14;15|]
+      |. Node.Buffer.fromArray
+      |. Node.Buffer.readFloatBE ~offset:1 ()
+      |. Belt.Float.toString,
+      "9.625513546253311e-38"
+    ) 
+  );
+  "readFloatLE", (fun _ ->
+    Eq(
+      [|1;2;3;4;5;6;7;8;9;10;11;12;13;14;15|]
+      |. Node.Buffer.fromArray
+      |. Node.Buffer.readFloatLE ~offset:1 ()
+      |. Belt.Float.toString,
+      "6.207162620248253e-36"
+    )
+  );
+
+  "readInt8", (fun _ ->
+    Eq(
+      [|1;2;3;4;5;6;7;8;9;10;11;12;13;14;15|]
+      |. Node.Buffer.fromArray
+      |. Node.Buffer.readInt8 ~offset:1 ()
+      |. Belt.Int.toString,
+      "2"
+    )
+  );
+  "readInt16BE", (fun _ ->
+    Eq(
+      [|1;2;3;4;5;6;7;8;9;10;11;12;13;14;15|]
+      |. Node.Buffer.fromArray
+      |. Node.Buffer.readInt16BE ~offset:1 ()
+      |. Belt.Int.toString,
+      "515"
+    )
+  );
+  "readInt16LE", (fun _ ->
+    Eq(
+      [|1;2;3;4;5;6;7;8;9;10;11;12;13;14;15|]
+      |. Node.Buffer.fromArray
+      |. Node.Buffer.readInt16LE ~offset:1 ()
+      |. Belt.Int.toString,
+      "770"
+    )
+  );
+  "readInt32BE", (fun _ ->
+    Eq(
+      [|1;2;3;4;5;6;7;8;9;10;11;12;13;14;15|]
+      |. Node.Buffer.fromArray
+      |. Node.Buffer.readInt32BE ~offset:1 ()
+      |. Belt.Int.toString,
+      "33752069"
+    )
+  );
+  "readInt32LE", (fun _ ->
+    Eq(
+      [|1;2;3;4;5;6;7;8;9;10;11;12;13;14;15|]
+      |. Node.Buffer.fromArray
+      |. Node.Buffer.readInt32LE ~offset:1 ()
+      |. Belt.Int.toString,
+      "84148994"
+    )
+  );
+  "readIntBE", (fun _ ->
+    Eq(
+      [|1;2;3;4;5;6;7;8;9;10;11;12;13;14;15|]
+      |. Node.Buffer.fromArray
+      |. Node.Buffer.readIntBE ~offset:1 ~byteLength:4
+      |. Belt.Int.toString,
+      "33752069"
+    )
+  );
+  "readIntLE", (fun _ ->
+    Eq(
+      [|1;2;3;4;5;6;7;8;9;10;11;12;13;14;15|]
+      |. Node.Buffer.fromArray
+      |. Node.Buffer.readIntLE ~offset:1 ~byteLength:4
+      |. Belt.Int.toString,
+      "84148994"
+    )
+  );
+  "readUint8", (fun _ ->
+    Eq(
+      [|1;2;3;4;5;6;7;8;9;10;11;12;13;14;15|]
+      |. Node.Buffer.fromArray
+      |. Node.Buffer.readUint8 ~offset:1 ()
+      |. Belt.Int.toString,
+      "2"
+    )
+  );
+  "readUint16BE", (fun _ ->
+    Eq(
+      [|1;2;3;4;5;6;7;8;9;10;11;12;13;14;15|]
+      |. Node.Buffer.fromArray
+      |. Node.Buffer.readUint16BE ~offset:1 ()
+      |. Belt.Int.toString,
+      "515"
+    )
+  );
+  "readUint16LE", (fun _ ->
+    Eq(
+      [|1;2;3;4;5;6;7;8;9;10;11;12;13;14;15|]
+      |. Node.Buffer.fromArray
+      |. Node.Buffer.readUint16LE ~offset:1 ()
+      |. Belt.Int.toString,
+      "770"
+    )
+  );
+  "readUint32BE", (fun _ ->
+    Eq(
+      [|1;2;3;4;5;6;7;8;9;10;11;12;13;14;15|]
+      |. Node.Buffer.fromArray
+      |. Node.Buffer.readUint32BE ~offset:1 ()
+      |. Belt.Int.toString,
+      "33752069"
+    )
+  );
+  "readUint32LE", (fun _ ->
+    Eq(
+      [|1;2;3;4;5;6;7;8;9;10;11;12;13;14;15|]
+      |. Node.Buffer.fromArray
+      |. Node.Buffer.readUint32LE ~offset:1 ()
+      |. Belt.Int.toString,
+      "84148994"
+    )
+  );
+  "readUintBE", (fun _ ->
+    Eq(
+      [|1;2;3;4;5;6;7;8;9;10;11;12;13;14;15|]
+      |. Node.Buffer.fromArray
+      |. Node.Buffer.readUintBE ~offset:1 ~byteLength:4
+      |. Belt.Int.toString,
+      "33752069"
+    )
+  );
+  "readUintLE", (fun _ ->
+    Eq(
+      [|1;2;3;4;5;6;7;8;9;10;11;12;13;14;15|]
+      |. Node.Buffer.fromArray
+      |. Node.Buffer.readUintLE ~offset:1 ~byteLength:4
+      |. Belt.Int.toString,
+      "84148994"
+    )
+  );
+
   "subarray returns piece of buffer", (fun _ ->
     let buf = Node.Buffer.fromString "abcd" in
     Eq(Node.Buffer.toString (Node.Buffer.subarray buf ~start:1 ~end_:3 ()), "bc")
@@ -385,6 +549,8 @@ let suites = Mt.[
   "_MAX_STRING_LENGTH", (fun _ -> 
     Eq(Node.Buffer._MAX_STRING_LENGTH |. Js.typeof, "number")
   );
+
+
 
 ]
 

--- a/jscomp/test/node_buffer_test.ml
+++ b/jscomp/test/node_buffer_test.ml
@@ -187,7 +187,7 @@ let suites = Mt.[
   "copy transfers one buffer region to another", (fun _ ->
     let buf = Node.Buffer.fromString "abc" in
     let buf2 = Node.Buffer.fromString "xxxxx" in
-    let () = ignore (Node.Buffer.copy buf ~target:buf2 ~targetStart:1 ~sourceStart:1 ~sourceEnd:3 ()) in
+    Node.Buffer.copy buf ~target:buf2 ~targetStart:1 ~sourceStart:1 ~sourceEnd:3 () |. ignore;
     Eq(Node.Buffer.toString buf2, "xbcxx")
   );
 
@@ -207,6 +207,183 @@ let suites = Mt.[
     let buf = Node.Buffer.fromString "aaaaa" in
     let buf = Node.Buffer.fill buf (`Integer 98) ~offset:2 ~end_:4 () in
     Eq(Node.Buffer.toString buf, "aabba")
+  );
+
+  "fillWithString fills existing buffer with provided string", (fun _ ->
+    let buf = Node.Buffer.fromString "xxxxx" in
+    let buf = Node.Buffer.fillWithString buf "YWJj" ~encoding:`base64 ~offset:2 ~end_:4 () in
+    Eq(Node.Buffer.toString buf, "xxabx")
+  );
+
+  "includes tests for presence of value starting from 'byteOffset' (value included)", (fun _ ->
+    let buf = Node.Buffer.fromString "aabcbb" in
+    Ok(Node.Buffer.includes buf (`Integer 99) ~byteOffset:3 ())
+  );
+
+  "includes tests for presence of value starting from 'byteOffset' (value included before offset)", (fun _ ->
+    let buf = Node.Buffer.fromString "aabcbb" in
+    Ok(not (Node.Buffer.includes buf (`Integer 99) ~byteOffset:4 ()))
+  );
+
+  "includesString tests for presence of value starting from 'byteOffset' (value included)", (fun _ ->
+    let buf = Node.Buffer.fromString "aabcbb" in
+    Ok(Node.Buffer.includesString buf "Yw==" ~byteOffset:3 ~encoding:`base64 ())
+  );
+
+  "includesString tests for presence of value starting from 'byteOffset' (value included before offset)", (fun _ ->
+    let buf = Node.Buffer.fromString "aabcbb" in
+    Ok(not (Node.Buffer.includesString buf "Yw==" ~byteOffset:4 ~encoding:`base64 ()))
+  );
+
+  "indexOf tests for presence of value starting from 'byteOffset' (value included)", (fun _ ->
+    let buf = Node.Buffer.fromString "aabcbb" in
+    Eq(Node.Buffer.indexOf buf (`Integer 99) ~byteOffset:3 (), 3)
+  );
+
+  "indexOf tests for presence of value starting from 'byteOffset' (value included before offset)", (fun _ ->
+    let buf = Node.Buffer.fromString "aabcbb" in
+    Eq(Node.Buffer.indexOf buf (`Integer 99) ~byteOffset:4 (), -1)
+  );
+
+  "indexOfString tests for presence of value starting from 'byteOffset' (value included)", (fun _ ->
+    let buf = Node.Buffer.fromString "aabcbb" in
+    Eq(Node.Buffer.indexOfString buf "Yw==" ~byteOffset:3 ~encoding:`base64 (), 3)
+  );
+
+  "indexOfString tests for presence of value starting from 'byteOffset' (value included before offset)", (fun _ ->
+    let buf = Node.Buffer.fromString "aabcbb" in
+    Eq(Node.Buffer.indexOfString buf "Yw==" ~byteOffset:4 ~encoding:`base64 (), -1)
+  );
+
+  "lastIndexOf tests for presence of value starting from 'byteOffset' (value included)", (fun _ ->
+    let buf = Node.Buffer.fromString "aabcbb" in
+    Eq(Node.Buffer.lastIndexOf buf (`Integer 99) ~byteOffset:3 (), 3)
+  );
+
+  "lastIndexOf tests for presence of value starting from 'byteOffset' (value included before offset)", (fun _ ->
+    let buf = Node.Buffer.fromString "aabcbb" in
+    Eq(Node.Buffer.lastIndexOf buf (`Integer 99) ~byteOffset:2 (), -1)
+  );
+
+  "lastIndexOfString tests for presence of value starting from 'byteOffset' (value included)", (fun _ ->
+    let buf = Node.Buffer.fromString "aabcbb" in
+    Eq(Node.Buffer.lastIndexOfString buf "Yw==" ~byteOffset:3 ~encoding:`base64 (), 3)
+  );
+
+  "lastIndexOfString tests for presence of value starting from 'byteOffset' (value included before offset)", (fun _ ->
+    let buf = Node.Buffer.fromString "aabcbb" in
+    Eq(Node.Buffer.lastIndexOfString buf "Yw==" ~byteOffset:2 ~encoding:`base64 (), -1)
+  );
+
+  "length returns buffer length in bytes", (fun _ -> 
+    Eq("abc" |. Node.Buffer.fromString |. Node.Buffer.length, 3)
+  );
+
+  "subarray returns piece of buffer", (fun _ ->
+    let buf = Node.Buffer.fromString "abcd" in
+    Eq(Node.Buffer.toString (Node.Buffer.subarray buf ~start:1 ~end_:3 ()), "bc")
+  );
+
+  "slice returns piece of buffer", (fun _ ->
+    let buf = Node.Buffer.fromString "abcd" in
+    Eq(Node.Buffer.toString (Node.Buffer.slice buf ~start:1 ~end_:3 ()), "bc")
+  );
+
+  "swap16 swaps byte order as for int16", (fun _ ->
+    let buf = [|1;2;3;4|]
+      |. Node.Buffer.fromArray
+      |. Node.Buffer.swap16 
+    in
+    Ok(
+      (Node.Buffer.unsafe_get buf 0) = 2 &&
+      (Node.Buffer.unsafe_get buf 1) = 1 &&
+      (Node.Buffer.unsafe_get buf 2) = 4 &&
+      (Node.Buffer.unsafe_get buf 3) = 3 
+    )
+  );
+
+  "swap32 swaps byte order as for int32", (fun _ ->
+    let buf = [|1;2;3;4|]
+      |. Node.Buffer.fromArray
+      |. Node.Buffer.swap32 
+    in
+    Ok(
+      (Node.Buffer.unsafe_get buf 0) = 4 &&
+      (Node.Buffer.unsafe_get buf 1) = 3 &&
+      (Node.Buffer.unsafe_get buf 2) = 2 &&
+      (Node.Buffer.unsafe_get buf 3) = 1 
+    )
+  );
+
+  "swap64 swaps byte order as for int64", (fun _ ->
+    let buf = [|1;2;3;4;5;6;7;8|]
+      |. Node.Buffer.fromArray
+      |. Node.Buffer.swap64
+    in
+    Ok(
+      (Node.Buffer.unsafe_get buf 0) = 8 &&
+      (Node.Buffer.unsafe_get buf 1) = 7 &&
+      (Node.Buffer.unsafe_get buf 2) = 6 &&
+      (Node.Buffer.unsafe_get buf 3) = 5 &&
+      (Node.Buffer.unsafe_get buf 4) = 4 &&
+      (Node.Buffer.unsafe_get buf 5) = 3 &&
+      (Node.Buffer.unsafe_get buf 6) = 2 &&
+      (Node.Buffer.unsafe_get buf 7) = 1 
+    )
+  );
+  
+  "toJSON", (fun _ ->
+    let json = 
+      [|1;2;3|]
+      |. Node.Buffer.fromArray 
+      |. Node.Buffer.toJSON in
+    Eq(Js.Json.stringify json, "{\"type\":\"Buffer\",\"data\":[1,2,3]}")
+  );
+
+  "toString converts buffer to string", (fun _ -> 
+    let source = "abc" in
+    let target = source |. Node.Buffer.fromString |. Node.Buffer.toString in
+    Eq(source, target)
+  );
+
+  "toString with encoding uses encoding for string conversion", (fun _ ->
+    let source = "abc" in
+    let target = source |. Node.Buffer.fromString |. Node.Buffer.toStringWithEncoding ~encoding:`base64 () in
+    Eq(target, "YWJj")
+  );
+
+  "write", (fun _ -> 
+    let buf = Node.Buffer.fromString "xxxxxxxx" in
+    Node.Buffer.write buf "YWJj" ~encoding:`base64 ~offset:2 () |. ignore;
+    Eq(Node.Buffer.toString buf, "xxabcxxx")
+  );
+
+  "writeLength", (fun _ -> 
+    let buf = Node.Buffer.fromString "xxxxxxxx" in
+    Node.Buffer.writeLength buf "YWJj" ~offset:2 ~encoding:`base64 ~length:2 () |. ignore;
+    Eq(Node.Buffer.toString buf, "xxabxxxx")
+  );
+
+  "_INSPECT_MAX_BYTES", (fun _ ->
+    Eq(Node.Buffer._INSPECT_MAX_BYTES |. Js.typeof, "number")
+  );
+
+  "kMaxLength", (fun _ ->
+    Eq(Node.Buffer.kMaxLength |. Js.typeof, "number")
+  );
+
+  "transcode", (fun _ ->
+    let buf = Node.Buffer.fromString {j|€|j} in
+    let buf2 = Node.Buffer.transcode (`Buffer buf) ~fromEnc:`utf8 ~toEnc:`ascii in
+    Eq(Node.Buffer.toString buf2, "?")
+  );
+
+  "_MAX_LENGTH", (fun _ -> 
+    Eq(Node.Buffer._MAX_LENGTH |. Js.typeof, "number")
+  );
+
+  "_MAX_STRING_LENGTH", (fun _ -> 
+    Eq(Node.Buffer._MAX_STRING_LENGTH |. Js.typeof, "number")
   );
 
 ]


### PR DESCRIPTION
Looks like Node.js bindings were not received much attention in last time, so I am trying to make them more complete.

This is the first PR on one of the Node.js core modules – "Buffer". It's based on Node.Buffer module API reference https://nodejs.org/dist/latest-v13.x/docs/api/buffer.html (current at the moment of writing).

A few notes:
1. No existing API was changed, but it looks like it might be right thing to do, using more optional params and [polymorphic variants with `@bs.unwrap`](https://bucklescript.github.io/docs/en/function#trick-2-polymorphic-variant-bsunwrap). For new APIs added, I used `@bs.unwrap` to model contract of Node API as closely as possible.
2. ~There is no docs in comments, since I am not sure, that main point of this PR is actually good (it is my first contribution). I'll add them to this PR as soon as there will be some positive feedback or review.~ **Fixed**.
3. ~Some definitions lack of proper support of Uint8Arrays when Buffer's API allows them to use interchangeably with Buffer. Probably should add them later.~ **Fixed**.

Note: I am opening this PR here, not on `bs-node` repo, since last one looks a bit abandoned for now.

Hope to hear criticism and comments.