### PR TITLE
[not merge-able] Add default support for monadic sugar with promises.

### DIFF
--- a/jscomp/others/js_promise.ml
+++ b/jscomp/others/js_promise.ml
@@ -49,7 +49,8 @@ external race : 'a t array -> 'a t = "race" [@@bs.val] [@@bs.scope "Promise"]
 
 external then_ : ('a -> 'b t [@bs.uncurry]) -> 'b t = "then" [@@bs.send.pipe: 'a t]
 
-
+let (let.async) (promise : 'a t) (callback : 'a -> 'b t) =
+  (promise |> (then_ callback) : 'b t)
 
 external catch : (error -> 'a t [@bs.uncurry]) -> 'a t = "catch" [@@bs.send.pipe: 'a t]
 (* [ p|> catch handler]


### PR DESCRIPTION
This is obviously not ready to be merged yet. But my hope is that, once https://github.com/facebook/reason/pull/2487 is merged, we can get default support for monadic sugar with JS promises in Reason. Expected usage would be like this:

```reason
open Js.Promise;

{
    let.async name = resolve("amazeface");
    Js.log2("The user's name  is " ++ name); 
}
```

Except, I just realized that I don't think this will work, because the source file is in OCaml syntax, and (let.async) isn't valid OCaml syntax. So this PR may not even be possible.

Would you consider the possibility of changing the js_promise bindings source file to be a Reason file after #2748 is merged? I can see that you might be trying to keep Reason out of the source so that pure OCaml users of Bucklescript don't have to mess with Reason. But according to my understanding bsb should be able to compile both Reason and OCaml files in the same project without an issue, right?