### PR TITLE
[Playground] Expose bundle properties in module.exports instead of window object

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -229,22 +229,27 @@ node scripts/ninja.js config && node scripts/ninja.js build
 BS_PLAYGROUND=../playground node scripts/repl.js
 ```
 
+For the playground bundle to include the Reason parser, use the `-refmt` flag with the same script:
+```
+BS_PLAYGROUND=../playground node scripts/repl.js -refmt
+```
+
 _Troubleshooting: if ninja build step failed with `Error: cannot find file '+runtime.js'`, make sure `ocamlfind` is installed with `opam install ocamlfind`._
 
 **You should now find following files:**
 
-- `playground/exports.js` -> This is the BuckleScript compiler, which binds the BuckleScript API to the `window` object
+- `playground/exports.js` -> This is the BuckleScript compiler, which binds the BuckleScript API to the `module.exports` object
 - `playground/stdlib/*.js` -> All the BuckleScript runtime files
 
 You can now use the `exports.js` file either directly by using a `<script src="/path/to/exports.js"/>` inside a html file, use a browser bundler infrastructure to optimize it, or you can even use it with `nodejs`:
 
 ```
 $ node
-> require("./exports.js");
+> let compiler = require("./exports.js");
 undefined
-> let compile_result = ocaml.compile(`Js.log Sys.ocaml_version`); // You can change the code here
+> let compile_result = compiler.ocaml.compile(`Js.log Sys.ocaml_version`); // You can change the code here
 undefined
-> eval(compile_result);
+> eval(compile_result.js_code);
 4.06.2+BS
 undefined
 ```
@@ -253,7 +258,7 @@ undefined
 
 As soon as the bundle is loaded, you will get access to following functions (as seen in [`jsoo_main.ml`](jscomp/main/jsoo_main.ml)):
 
-- `window.ocaml`:
+- `ocaml`:
   - `compile(code: string)`: Compiles given code
   - `shake_compile(code: string)`: Compiles given code with tree-shaking
   - `compile_super_errors(code: string)`: Compiles given code and outputs `super_errors` related messages on `console.error`
@@ -367,7 +372,7 @@ You should now have the newest `refmt` binary for the actual compiler, and for t
 
 **Important:** Always verify that the updated Reason version is in sync in the
 `refmt.exe` and the playground bundle. Use `lib/bsrefmt --version` and for the
-playground API `window.reason.version` (not final) to get the bundled
+playground API `reason.version` (not final) to get the bundled
 version.
 
 ## Contributing to the Documentation

--- a/jscomp/main/jsoo_common.ml
+++ b/jscomp/main/jsoo_common.ml
@@ -19,6 +19,9 @@ module Js = struct
   external to_string : js_string t -> string = "caml_js_to_string"
   external create_file : js_string t -> js_string t -> unit = "caml_create_file"
   external to_bytestring : js_string t -> string = "caml_js_to_byte_string"
+  external get_export_var : unit -> < .. > t = "caml_js_export_var"
+  let export_js (field : js_string t) x = Unsafe.set (get_export_var ()) field x
+  let export field x = export_js (string field) x
 end
 
 let mk_js_error (loc: Location.t) (msg: string) = 

--- a/jscomp/main/jsoo_common.mli
+++ b/jscomp/main/jsoo_common.mli
@@ -27,6 +27,7 @@ module Js :
     external create_file : js_string t -> js_string t -> unit
       = "caml_create_file"
     external to_bytestring : js_string t -> string = "caml_js_to_byte_string"
+    val export : string -> 'a -> unit
   end
 
 (*

--- a/jscomp/refmt/jsoo_refmt_main.ml
+++ b/jscomp/refmt/jsoo_refmt_main.ml
@@ -121,7 +121,7 @@ let shake_compile ~prefix ~use_super_errors ?react_ppx_version impl =
       cmj_name (lazy (Js_cmj_format.from_string cmj_content)) *)
 
 let export (field : string) v =
-  Js.Unsafe.set (Js.Unsafe.global) field v
+  Js.export field v
 ;;
 
 (* To add a directory to the load path *)

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -35,10 +35,16 @@ function prepare() {
   e(`hash hash js_of_ocaml 2>/dev/null || { echo >&2 "js_of_ocaml not found on path. Please install version 3.5.1 (with opam switch ${ocamlVersion}), and put it on your path."; exit 1; }
 `);
 
-  e(
-    `ocamlc.opt -w -30-40 -no-check-prims -I ${jsRefmtCompDir} ${jsRefmtCompDir}/js_compiler.mli ${jsRefmtCompDir}/js_compiler.ml -o jsc.byte && js_of_ocaml jsc.byte -o exports.js`
-  );
-
+  if (process.argv.includes("-refmt")) {
+    e(
+      `ocamlc.opt -w -30-40 -no-check-prims -I ${jsRefmtCompDir} ${jsRefmtCompDir}/js_refmt_compiler.mli ${jsRefmtCompDir}/js_refmt_compiler.ml -o jsc.byte && js_of_ocaml jsc.byte -o exports.js`
+    );
+  } else {
+    e(
+      `ocamlc.opt -w -30-40 -no-check-prims -I ${jsRefmtCompDir} ${jsRefmtCompDir}/js_compiler.mli ${jsRefmtCompDir}/js_compiler.ml -o jsc.byte && js_of_ocaml jsc.byte -o exports.js`
+    );
+  }
+    
   e(`cp ../lib/js/*.js ${playground}/stdlib`);
   e(`mv ./exports.js ${playground}`)
 }


### PR DESCRIPTION
So JS consumers can do:

```js
let compiler = require("./exports.js");
```

js_of_ocaml will use `module.exports` [if it is defined](http://ocsigen.org/js_of_ocaml/3.5.1/manual/rev-bindings).

Tested in a local Webpack setup and it works fine. I think this is a more subtle way to expose the compiler as a JS library to consumers, but not sure if there are any downsides? cc @ryyppy @thangngoc89 