### PR TITLE
When building form source w esy, set CI flag 

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -41,7 +41,8 @@
       ["node", "./scripts/ninja.js", "build"]
     ],
     "buildEnv": {
-      "ESY": "true"
+      "ESY": "true",
+      "BS_TRAVIS_CI": "1"
     },
     "exportedEnv": {
       "CAML_LD_LIBRARY_PATH": {

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -47,7 +47,7 @@ function provideNinja() {
       cwd: ninja_source_dir,
       stdio: [0, 1, 2]
     });
-    fs.copyFileSync(path.join(ninja_source_dir, "ninja"), ninja_bin_output);
+    cp.execSync("cp " + path.join(ninja_source_dir, "ninja") + " " + ninja_bin_output);
     console.log("ninja binary is ready: ", ninja_bin_output);
   }
 

--- a/scripts/installUtils.js
+++ b/scripts/installUtils.js
@@ -3,6 +3,7 @@
 var fs = require("fs");
 var path = require("path");
 var assert = require("assert");
+var cp = require("child_process");
 /**
  *
  * @param {string} src
@@ -17,7 +18,7 @@ function installDirBy(src, dest, filter) {
           var x = path.join(src, file);
           var y = path.join(dest, file);
           // console.log(x, '----->', y )
-          fs.copyFile(x, y, err => assert.equal(err, null));
+          cp.execSync("cp " + x + " " + y);
         }
       });
     } else {


### PR DESCRIPTION
This is necessary to get the stdlib to be copied over.
Also use a cp that works with older node.