### PR TITLE
React ppx: enable spread for dom elements children

### DIFF
--- a/jscomp/syntax/reactjs_jsx_ppx.cppo.ml
+++ b/jscomp/syntax/reactjs_jsx_ppx.cppo.ml
@@ -396,16 +396,7 @@ let jsxMapper () =
       let (children, nonChildrenProps) = extractChildren ~loc callArguments in
       let componentNameExpr = constantString ~loc id in
       let childrenExpr = transformChildrenIfList ~loc ~mapper children in
-      let createElementCall = match children with
-        (* [@JSX] div(~children=[a]), coming from <div> a </div> *)
-        | {
-            pexp_desc =
-             Pexp_construct ({txt = Lident "::"}, Some {pexp_desc = Pexp_tuple _ })
-             | Pexp_construct ({txt = Lident "[]"}, None)
-          } -> "createDOMElementVariadic"
-        (* [@JSX] div(~children= value), coming from <div> ...(value) </div> *)
-        | _ -> raise (Invalid_argument "A spread as a DOM element's \
-          children don't make sense written together. You can simply remove the spread.")
+      let createElementCall = "createDOMElementVariadic"
       in
       let args = match nonChildrenProps with
         | [_justTheUnitArgumentAtEnd] ->


### PR DESCRIPTION
@rickyvetter The error raised when using spread with DOM elements prevents sharing components code that can be compiled with both [tyxml](https://github.com/ocsigen/tyxml) and reason-react.

This error was useful when migrating from JSX2, but I hope ReasonReact users are not running into it these days as the spread operator has been mostly removed from JSX3 documentation, so I hope the change is ok.

This is an example of element that compiles fine with tyxml and succeeds after these change with ReasonReact as well:

```reason
module MyComponent = {
  [@react.component]
  let make = () =>
    <a>
      ...{
        Array.map(
          x => <li> x </li>,
          [|
            <a href="/foo"> {React.string("Foo")} </a>,
            <a href="/bar"> {React.string("Bar")} </a>,
          |],
        )
        ->React.array
      }
    </a>;
};
```