### PR TITLE
Fix broken ocaml build on macOS

### DIFF
--- a/scripts/buildocaml.js
+++ b/scripts/buildocaml.js
@@ -64,7 +64,7 @@ function build(config) {
     if (config) {
       var { make } = require("./config.js");
       cp.execSync(
-        "./configure -flambda -prefix " +
+        "./configure -cc \"gcc -Wno-implicit-function-declaration\" -flambda -prefix " +
           prefix +
           ` -no-ocamlbuild  -no-curses -no-graph -no-pthread -no-debugger && ${make} clean`,
         { cwd: ocamlSrcDir, stdio: [0, 1, 2] }


### PR DESCRIPTION
See here: https://discuss.ocaml.org/t/ocaml-4-07-1-fails-to-build-with-apple-xcode-12/6441/19

tldr one of XCode's gcc's warning turned into an error, which made the build configuration go wrong.

The solution is either this diff, which silences that error, or use ocaml 4.08's newer `configure` which is apparently more resilient.