### PR TITLE
get rid of variable interoplation, precompute everything

### DIFF
--- a/jscomp/bsb/bsb_build_schemas.ml
+++ b/jscomp/bsb/bsb_build_schemas.ml
@@ -62,7 +62,7 @@ let export_all = "all"
 let export_none = "none"
 
 
-let g_lib_incls = "g_lib_incls"
+
 let use_stdlib = "use-stdlib"
 let reason = "reason"
 let react_jsx = "react-jsx"

--- a/jscomp/bsb/bsb_config.ml
+++ b/jscomp/bsb/bsb_config.ml
@@ -62,8 +62,7 @@ let rev_lib_bs_prefix p = rev_lib_bs // p
 
 let ocaml_bin_install_prefix p = lib_ocaml // p
 
-let lazy_src_root_dir = "$src_root_dir" 
-let proj_rel path = lazy_src_root_dir // path
+let proj_rel path = Bsb_ninja_global_vars.lazy_src_root_dir // path
 
 (** it may not be a bad idea to hard code the binary path 
     of bsb in configuration time

--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -143,7 +143,7 @@ let output_ninja_and_namespace_map
 
         (* The path to [bsb_heler.exe] *)
         Bsb_ninja_global_vars.bsdep, (Ext_filename.maybe_quote Bsb_global_paths.vendor_bsdep) ;
-        Bsb_ninja_global_vars.warnings, warnings;
+
         Bsb_ninja_global_vars.bsc_flags,  bsc_flags;
         Bsb_ninja_global_vars.ppx_flags, ppx_flags;
 
@@ -202,6 +202,7 @@ let output_ninja_and_namespace_map
       ~digest
       ~package_name
       ~bsc:bsc_path
+      ~warnings
       generators in   
   emit_bsc_lib_includes bs_dependencies source_dirs.lib external_includes namespace oc;
   output_static_resources static_resources rules.copy_resources oc ;

--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -122,9 +122,6 @@ let output_ninja_and_namespace_map
   let cwd_lib_bs = per_proj_dir // lib_artifacts_dir in 
   let ppx_flags = Bsb_build_util.ppx_flags ppx_files in
   let oc = open_out_bin (cwd_lib_bs // Literals.build_ninja) in          
-  let g_pkg_flg  =     
-      Ext_string.inter2 "-bs-package-name" package_name
-  in  
   let warnings = Bsb_warning.to_bsb_string ~toplevel warning in
   let bsc_flags = (get_bsc_flags bsc_flags) in 
   let () = 
@@ -139,7 +136,7 @@ let output_ninja_and_namespace_map
       );    
     Bsb_ninja_targets.output_kvs
       [|
-        Bsb_ninja_global_vars.g_pkg_flg, g_pkg_flg ; 
+
         Bsb_ninja_global_vars.src_root_dir, per_proj_dir (* TODO: need check its integrity -- allow relocate or not? *);
         (* The path to [bsc.exe] independent of config  *)
         Bsb_ninja_global_vars.bsc, (Ext_filename.maybe_quote Bsb_global_paths.vendor_bsc);
@@ -202,6 +199,7 @@ let output_ninja_and_namespace_map
       ~package_specs
       ~namespace
       ~digest
+      ~package_name
       generators in   
   emit_bsc_lib_includes bs_dependencies source_dirs.lib external_includes namespace oc;
   output_static_resources static_resources rules.copy_resources oc ;

--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -127,16 +127,13 @@ let output_ninja_and_namespace_map
   let dpkg_incls  =  (Bsb_build_util.include_dirs_by
                         bs_dev_dependencies
                         (fun x -> x.package_install_path)) in 
+  
   let () = 
     Ext_option.iter pp_file (fun flag ->
         Bsb_ninja_targets.output_kv Bsb_ninja_global_vars.pp_flags
           (Bsb_build_util.pp_flag flag) oc 
       );
-    Ext_option.iter gentype_config (fun x -> 
-        (* resolved earlier *)
-        Bsb_ninja_targets.output_kv Bsb_ninja_global_vars.gentypeconfig
-          ("-bs-gentype " ^ x.path) oc
-      );    
+
     Bsb_ninja_targets.output_kv      
       Bsb_ninja_global_vars.src_root_dir per_proj_dir                 
       oc 
@@ -176,7 +173,7 @@ let output_ninja_and_namespace_map
   let rules : Bsb_ninja_rule.builtin = 
       Bsb_ninja_rule.make_custom_rules 
       ~refmt
-      ~has_gentype:(gentype_config <> None)
+      ~gentype_config
       ~has_postbuild:js_post_build_cmd 
       ~has_pp:(pp_file <> None)
       ~has_builtin:(built_in_dependency <> None)

--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -125,6 +125,7 @@ let output_ninja_and_namespace_map
   let warnings = Bsb_warning.to_bsb_string ~toplevel warning in
   let bsc_flags = (get_bsc_flags bsc_flags) in 
   let bsc_path = (Ext_filename.maybe_quote Bsb_global_paths.vendor_bsc) in      
+  let bs_dep = (Ext_filename.maybe_quote Bsb_global_paths.vendor_bsdep) in 
   let () = 
     Ext_option.iter pp_file (fun flag ->
         Bsb_ninja_targets.output_kv Bsb_ninja_global_vars.pp_flags
@@ -141,8 +142,7 @@ let output_ninja_and_namespace_map
         Bsb_ninja_global_vars.src_root_dir, per_proj_dir (* TODO: need check its integrity -- allow relocate or not? *);
         (* The path to [bsc.exe] independent of config  *)
 
-        (* The path to [bsb_heler.exe] *)
-        Bsb_ninja_global_vars.bsdep, (Ext_filename.maybe_quote Bsb_global_paths.vendor_bsdep) ;
+
 
         Bsb_ninja_global_vars.bsc_flags,  bsc_flags;
         Bsb_ninja_global_vars.ppx_flags, ppx_flags;
@@ -203,6 +203,7 @@ let output_ninja_and_namespace_map
       ~package_name
       ~bsc:bsc_path
       ~warnings
+      ~bs_dep
       generators in   
   emit_bsc_lib_includes bs_dependencies source_dirs.lib external_includes namespace oc;
   output_static_resources static_resources rules.copy_resources oc ;

--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -145,7 +145,7 @@ let output_ninja_and_namespace_map
 
 
         Bsb_ninja_global_vars.bsc_flags,  bsc_flags;
-        Bsb_ninja_global_vars.ppx_flags, ppx_flags;
+        
 
         Bsb_ninja_global_vars.g_dpkg_incls, 
         (Bsb_build_util.include_dirs_by
@@ -193,7 +193,6 @@ let output_ninja_and_namespace_map
       ~refmt
       ~has_gentype:(gentype_config <> None)
       ~has_postbuild:js_post_build_cmd 
-      ~has_ppx:(ppx_files <> [])
       ~has_pp:(pp_file <> None)
       ~has_builtin:(built_in_dependency <> None)
       ~reason_react_jsx
@@ -204,6 +203,7 @@ let output_ninja_and_namespace_map
       ~bsc:bsc_path
       ~warnings
       ~bs_dep
+      ~ppx_flags
       generators in   
   emit_bsc_lib_includes bs_dependencies source_dirs.lib external_includes namespace oc;
   output_static_resources static_resources rules.copy_resources oc ;

--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -169,11 +169,8 @@ let output_ninja_and_namespace_map
        if Map_string.mem lib k  then 
          raise (Bsb_db_util.conflict_module_info k a (Map_string.find_exn lib k))
     ) ;
-  if source_dirs.dev <> [] then
-    Bsb_ninja_targets.output_kv 
-      Bsb_ninja_global_vars.g_dev_incls
-      (Bsb_build_util.include_dirs source_dirs.dev) oc
-  ;
+  let dev_incls = 
+      (Bsb_build_util.include_dirs source_dirs.dev) in 
   let digest = Bsb_db_encode.write_build_cache ~dir:cwd_lib_bs bs_groups in
   let lib_incls = emit_bsc_lib_includes bs_dependencies source_dirs.lib external_includes namespace in
   let rules : Bsb_ninja_rule.builtin = 
@@ -193,8 +190,9 @@ let output_ninja_and_namespace_map
       ~bs_dep
       ~ppx_flags
       ~bsc_flags
-      ~dpkg_incls
-      ~lib_incls
+      ~dpkg_incls (* dev dependencies *)
+      ~lib_incls (* its own libs *)
+      ~dev_incls (* its own devs *)
       generators in   
 
   output_static_resources static_resources rules.copy_resources oc ;

--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -126,6 +126,9 @@ let output_ninja_and_namespace_map
   let bsc_flags = (get_bsc_flags bsc_flags) in 
   let bsc_path = (Ext_filename.maybe_quote Bsb_global_paths.vendor_bsc) in      
   let bs_dep = (Ext_filename.maybe_quote Bsb_global_paths.vendor_bsdep) in 
+  let dpkg_incls  =  (Bsb_build_util.include_dirs_by
+                        bs_dev_dependencies
+                        (fun x -> x.package_install_path)) in 
   let () = 
     Ext_option.iter pp_file (fun flag ->
         Bsb_ninja_targets.output_kv Bsb_ninja_global_vars.pp_flags
@@ -136,23 +139,9 @@ let output_ninja_and_namespace_map
         Bsb_ninja_targets.output_kv Bsb_ninja_global_vars.gentypeconfig
           ("-bs-gentype " ^ x.path) oc
       );    
-    Bsb_ninja_targets.output_kvs
-      [|
-
-        Bsb_ninja_global_vars.src_root_dir, per_proj_dir (* TODO: need check its integrity -- allow relocate or not? *);
-        (* The path to [bsc.exe] independent of config  *)
-
-
-
-        Bsb_ninja_global_vars.bsc_flags,  bsc_flags;
-        
-
-        Bsb_ninja_global_vars.g_dpkg_incls, 
-        (Bsb_build_util.include_dirs_by
-           bs_dev_dependencies
-           (fun x -> x.package_install_path));  
-
-      |] oc 
+    Bsb_ninja_targets.output_kv      
+      Bsb_ninja_global_vars.src_root_dir per_proj_dir                 
+      oc 
   in          
   let bs_groups : Bsb_db.t = {lib = Map_string.empty; dev = Map_string.empty} in
   let source_dirs : string list Bsb_db.cat = {lib = []; dev = []} in
@@ -204,6 +193,8 @@ let output_ninja_and_namespace_map
       ~warnings
       ~bs_dep
       ~ppx_flags
+      ~bsc_flags
+      ~dpkg_incls
       generators in   
   emit_bsc_lib_includes bs_dependencies source_dirs.lib external_includes namespace oc;
   output_static_resources static_resources rules.copy_resources oc ;

--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -124,6 +124,7 @@ let output_ninja_and_namespace_map
   let oc = open_out_bin (cwd_lib_bs // Literals.build_ninja) in          
   let warnings = Bsb_warning.to_bsb_string ~toplevel warning in
   let bsc_flags = (get_bsc_flags bsc_flags) in 
+  let bsc_path = (Ext_filename.maybe_quote Bsb_global_paths.vendor_bsc) in      
   let () = 
     Ext_option.iter pp_file (fun flag ->
         Bsb_ninja_targets.output_kv Bsb_ninja_global_vars.pp_flags
@@ -139,7 +140,7 @@ let output_ninja_and_namespace_map
 
         Bsb_ninja_global_vars.src_root_dir, per_proj_dir (* TODO: need check its integrity -- allow relocate or not? *);
         (* The path to [bsc.exe] independent of config  *)
-        Bsb_ninja_global_vars.bsc, (Ext_filename.maybe_quote Bsb_global_paths.vendor_bsc);
+
         (* The path to [bsb_heler.exe] *)
         Bsb_ninja_global_vars.bsdep, (Ext_filename.maybe_quote Bsb_global_paths.vendor_bsdep) ;
         Bsb_ninja_global_vars.warnings, warnings;
@@ -200,6 +201,7 @@ let output_ninja_and_namespace_map
       ~namespace
       ~digest
       ~package_name
+      ~bsc:bsc_path
       generators in   
   emit_bsc_lib_includes bs_dependencies source_dirs.lib external_includes namespace oc;
   output_static_resources static_resources rules.copy_resources oc ;

--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -129,11 +129,6 @@ let output_ninja_and_namespace_map
                         (fun x -> x.package_install_path)) in 
   
   let () = 
-    Ext_option.iter pp_file (fun flag ->
-        Bsb_ninja_targets.output_kv Bsb_ninja_global_vars.pp_flags
-          (Bsb_build_util.pp_flag flag) oc 
-      );
-
     Bsb_ninja_targets.output_kv      
       Bsb_ninja_global_vars.src_root_dir per_proj_dir                 
       oc 
@@ -175,7 +170,7 @@ let output_ninja_and_namespace_map
       ~refmt
       ~gentype_config
       ~has_postbuild:js_post_build_cmd 
-      ~has_pp:(pp_file <> None)
+      ~pp_file
       ~has_builtin:(built_in_dependency <> None)
       ~reason_react_jsx
       ~package_specs

--- a/jscomp/bsb/bsb_ninja_global_vars.ml
+++ b/jscomp/bsb/bsb_ninja_global_vars.ml
@@ -31,14 +31,10 @@
 let src_root_dir = "src_root_dir"
 
 
-let bsc_flags = "bsc_flags"
-
 
 
 let pp_flags = "pp_flags"
 
-
-let g_dpkg_incls = "g_dpkg_incls"
 
 let refmt = "refmt"
 

--- a/jscomp/bsb/bsb_ninja_global_vars.ml
+++ b/jscomp/bsb/bsb_ninja_global_vars.ml
@@ -26,10 +26,13 @@
  
 
 
+(* Invariant: the two string literal has 
+  to be "a" and "$a"
+*)
 
+let src_root_dir = "g_root"
 
-let src_root_dir = "src_root_dir"
-
+let lazy_src_root_dir = "$g_root" 
 
 
 

--- a/jscomp/bsb/bsb_ninja_global_vars.ml
+++ b/jscomp/bsb/bsb_ninja_global_vars.ml
@@ -33,7 +33,7 @@ let src_root_dir = "src_root_dir"
 
 
 
-let pp_flags = "pp_flags"
+
 
 
 let refmt = "refmt"

--- a/jscomp/bsb/bsb_ninja_global_vars.ml
+++ b/jscomp/bsb/bsb_ninja_global_vars.ml
@@ -26,7 +26,7 @@
  
 
 
-let bsc = "bsc" 
+
 
 let src_root_dir = "src_root_dir"
 let bsdep = "bsdep"

--- a/jscomp/bsb/bsb_ninja_global_vars.ml
+++ b/jscomp/bsb/bsb_ninja_global_vars.ml
@@ -39,7 +39,5 @@ let pp_flags = "pp_flags"
 let refmt = "refmt"
 
 
-let gentypeconfig = "gentypeconfig"
-
 
 

--- a/jscomp/bsb/bsb_ninja_global_vars.ml
+++ b/jscomp/bsb/bsb_ninja_global_vars.ml
@@ -24,7 +24,7 @@
 
 
  
-let g_pkg_flg = "g_pkg_flg"
+
 
 let bsc = "bsc" 
 

--- a/jscomp/bsb/bsb_ninja_global_vars.ml
+++ b/jscomp/bsb/bsb_ninja_global_vars.ml
@@ -35,9 +35,3 @@ let src_root_dir = "src_root_dir"
 
 
 
-
-let refmt = "refmt"
-
-
-
-

--- a/jscomp/bsb/bsb_ninja_global_vars.ml
+++ b/jscomp/bsb/bsb_ninja_global_vars.ml
@@ -38,9 +38,6 @@ let pp_flags = "pp_flags"
 
 let refmt = "refmt"
 
-let refmt_flags = "refmt_flags"
-
-
 
 let gentypeconfig = "gentypeconfig"
 

--- a/jscomp/bsb/bsb_ninja_global_vars.ml
+++ b/jscomp/bsb/bsb_ninja_global_vars.ml
@@ -48,7 +48,7 @@ let postbuild = "postbuild"
 
 
 
-let warnings = "warnings"
+
 
 let gentypeconfig = "gentypeconfig"
 

--- a/jscomp/bsb/bsb_ninja_global_vars.ml
+++ b/jscomp/bsb/bsb_ninja_global_vars.ml
@@ -40,10 +40,6 @@ let refmt = "refmt"
 
 let refmt_flags = "refmt_flags"
 
-let postbuild = "postbuild"
-
-
-
 
 
 let gentypeconfig = "gentypeconfig"

--- a/jscomp/bsb/bsb_ninja_global_vars.ml
+++ b/jscomp/bsb/bsb_ninja_global_vars.ml
@@ -33,7 +33,7 @@ let src_root_dir = "src_root_dir"
 
 let bsc_flags = "bsc_flags"
 
-let ppx_flags = "ppx_flags"
+
 
 let pp_flags = "pp_flags"
 

--- a/jscomp/bsb/bsb_ninja_global_vars.ml
+++ b/jscomp/bsb/bsb_ninja_global_vars.ml
@@ -41,5 +41,5 @@ let refmt = "refmt"
 
 let gentypeconfig = "gentypeconfig"
 
-let g_dev_incls = "g_dev_incls"
+
 

--- a/jscomp/bsb/bsb_ninja_global_vars.ml
+++ b/jscomp/bsb/bsb_ninja_global_vars.ml
@@ -29,7 +29,7 @@
 
 
 let src_root_dir = "src_root_dir"
-let bsdep = "bsdep"
+
 
 let bsc_flags = "bsc_flags"
 

--- a/jscomp/bsb/bsb_ninja_rule.ml
+++ b/jscomp/bsb/bsb_ninja_rule.ml
@@ -114,7 +114,7 @@ type builtin = {
 ;;
 
 let make_custom_rules 
-  ~(has_gentype : bool)        
+  ~(gentype_config : Bsb_config_types.gentype_config option)        
   ~(has_postbuild : string option)
   ~(has_pp : bool)
   ~(has_builtin : bool)
@@ -158,13 +158,17 @@ let make_custom_rules
       Ext_buffer.add_string buf " -nostdlib";
     Ext_buffer.add_char_string buf ' ' warnings;  
     Ext_buffer.add_char_string buf ' ' bsc_flags;
+    begin match gentype_config with 
+      | None -> ()
+      | Some x ->
+        Ext_buffer.add_string buf " -bs-gentype " ;
+        Ext_buffer.add_string buf x.path
+    end;
     if read_cmi <> `is_cmi then begin 
       Ext_buffer.add_string buf " -bs-package-name ";
       Ext_buffer.add_string buf package_name;
       Ext_buffer.add_string buf (Bsb_package_specs.package_flag_of_package_specs package_specs "$in_d")
     end;
-    if has_gentype then
-      Ext_buffer.add_ninja_prefix_var buf Bsb_ninja_global_vars.gentypeconfig;
     Ext_buffer.add_string buf " -o $out $in";
     begin match postbuild with 
     | None -> ()

--- a/jscomp/bsb/bsb_ninja_rule.ml
+++ b/jscomp/bsb/bsb_ninja_rule.ml
@@ -128,6 +128,8 @@ let make_custom_rules
   ~warnings
   ~bs_dep
   ~ppx_flags
+  ~bsc_flags
+  ~dpkg_incls
   (custom_rules : command Map_string.t) : 
   builtin = 
   (** FIXME: We don't need set [-o ${out}] when building ast 
@@ -154,12 +156,12 @@ let make_custom_rules
     if is_dev then 
       Ext_buffer.add_ninja_prefix_var buf Bsb_ninja_global_vars.g_dev_incls;      
     Ext_buffer.add_ninja_prefix_var buf Bsb_build_schemas.g_lib_incls;
-    if is_dev then
-      Ext_buffer.add_ninja_prefix_var buf Bsb_ninja_global_vars.g_dpkg_incls;
+    
+    Ext_buffer.add_char_string buf ' ' dpkg_incls;
     if not has_builtin then   
       Ext_buffer.add_string buf " -nostdlib";
     Ext_buffer.add_char_string buf ' ' warnings;  
-    Ext_buffer.add_string buf " $bsc_flags";
+    Ext_buffer.add_char_string buf ' ' bsc_flags;
     if has_gentype then
       Ext_buffer.add_ninja_prefix_var buf Bsb_ninja_global_vars.gentypeconfig;
     Ext_buffer.add_string buf " -o $out $in";
@@ -193,8 +195,9 @@ let make_custom_rules
        -> Ext_buffer.add_string buf " -bs-jsx 3"
     );
     
-    Ext_buffer.add_string buf ppx_flags; 
-    Ext_buffer.add_string buf " $bsc_flags -o $out -bs-ast $in";   
+    Ext_buffer.add_char_string buf ' ' ppx_flags; 
+    Ext_buffer.add_char_string buf ' ' bsc_flags;
+    Ext_buffer.add_string buf " -o $out -bs-ast $in";   
     Ext_buffer.contents buf
   in  
   let build_ast =

--- a/jscomp/bsb/bsb_ninja_rule.ml
+++ b/jscomp/bsb/bsb_ninja_rule.ml
@@ -125,6 +125,7 @@ let make_custom_rules
   ~(package_specs: Bsb_package_specs.t)
   ~namespace
   ~package_name
+  ~bsc
   (custom_rules : command Map_string.t) : 
   builtin = 
   (** FIXME: We don't need set [-o ${out}] when building ast 
@@ -138,7 +139,7 @@ let make_custom_rules
       ~is_dev 
       ~postbuild : string =     
     Ext_buffer.clear buf;
-    Ext_buffer.add_string buf "$bsc";
+    Ext_buffer.add_string buf bsc;
     
     Ext_buffer.add_string buf ns_flag;
     if read_cmi <> `is_cmi then begin 
@@ -170,7 +171,8 @@ let make_custom_rules
   in   
   let mk_ast ~(has_pp : bool) ~has_ppx ~has_reason_react_jsx : string =
     Ext_buffer.clear buf ; 
-    Ext_buffer.add_string buf "$bsc  $warnings -bs-v ";
+    Ext_buffer.add_string buf bsc;
+    Ext_buffer.add_string buf " $warnings -bs-v ";
     Ext_buffer.add_string buf Bs_version.version;
     (match refmt with 
     | None -> ()
@@ -250,7 +252,7 @@ let make_custom_rules
       ~name:"mi" in 
   let build_package = 
     define
-      ~command:"$bsc -w -49 -color always -no-alias-deps  $in"
+      ~command:(bsc ^ " -w -49 -color always -no-alias-deps  $in")
       ~restat:()
       "build_package"
   in 

--- a/jscomp/bsb/bsb_ninja_rule.ml
+++ b/jscomp/bsb/bsb_ninja_rule.ml
@@ -124,6 +124,7 @@ let make_custom_rules
   ~(refmt : string option) (* set refmt path when needed *)
   ~(package_specs: Bsb_package_specs.t)
   ~namespace
+  ~package_name
   (custom_rules : command Map_string.t) : 
   builtin = 
   (** FIXME: We don't need set [-o ${out}] when building ast 
@@ -141,7 +142,8 @@ let make_custom_rules
     
     Ext_buffer.add_string buf ns_flag;
     if read_cmi <> `is_cmi then begin 
-      Ext_buffer.add_ninja_prefix_var buf Bsb_ninja_global_vars.g_pkg_flg;
+      Ext_buffer.add_string buf " -bs-package-name ";
+      Ext_buffer.add_string buf package_name;
       Ext_buffer.add_string buf (Bsb_package_specs.package_flag_of_package_specs package_specs "$in_d")
     end;
     if read_cmi = `yes then 

--- a/jscomp/bsb/bsb_ninja_rule.ml
+++ b/jscomp/bsb/bsb_ninja_rule.ml
@@ -116,7 +116,6 @@ type builtin = {
 let make_custom_rules 
   ~(has_gentype : bool)        
   ~(has_postbuild : string option)
-  ~(has_ppx : bool)
   ~(has_pp : bool)
   ~(has_builtin : bool)
   ~(reason_react_jsx : Bsb_config_types.reason_react_jsx option)
@@ -128,6 +127,7 @@ let make_custom_rules
   ~bsc
   ~warnings
   ~bs_dep
+  ~ppx_flags
   (custom_rules : command Map_string.t) : 
   builtin = 
   (** FIXME: We don't need set [-o ${out}] when building ast 
@@ -172,7 +172,7 @@ let make_custom_rules
     end ;
     Ext_buffer.contents buf
   in   
-  let mk_ast ~(has_pp : bool) ~has_ppx ~has_reason_react_jsx : string =
+  let mk_ast ~(has_pp : bool) ~has_reason_react_jsx : string =
     Ext_buffer.clear buf ; 
     Ext_buffer.add_string buf bsc;
     Ext_buffer.add_char_string buf ' ' warnings;  
@@ -192,18 +192,18 @@ let make_custom_rules
      | _, Some Jsx_v3 
        -> Ext_buffer.add_string buf " -bs-jsx 3"
     );
-    if has_ppx then 
-      Ext_buffer.add_ninja_prefix_var buf Bsb_ninja_global_vars.ppx_flags; 
+    
+    Ext_buffer.add_string buf ppx_flags; 
     Ext_buffer.add_string buf " $bsc_flags -o $out -bs-ast $in";   
     Ext_buffer.contents buf
   in  
   let build_ast =
     define
-      ~command:(mk_ast ~has_pp ~has_ppx ~has_reason_react_jsx:false )
+      ~command:(mk_ast ~has_pp ~has_reason_react_jsx:false )
       "ast" in
   let build_ast_from_re =
     define
-      ~command:(mk_ast ~has_pp ~has_ppx ~has_reason_react_jsx:true)
+      ~command:(mk_ast ~has_pp ~has_reason_react_jsx:true)
       "astj" in 
  
   let copy_resources =    

--- a/jscomp/bsb/bsb_ninja_rule.ml
+++ b/jscomp/bsb/bsb_ninja_rule.ml
@@ -131,6 +131,7 @@ let make_custom_rules
   ~bsc_flags
   ~dpkg_incls
   ~lib_incls
+  ~dev_incls
   (custom_rules : command Map_string.t) : 
   builtin = 
   (** FIXME: We don't need set [-o ${out}] when building ast 
@@ -148,8 +149,9 @@ let make_custom_rules
     Ext_buffer.add_string buf ns_flag;
     if read_cmi = `yes then 
       Ext_buffer.add_string buf " -bs-read-cmi";
+    (* The include order matters below *)
     if is_dev then 
-      Ext_buffer.add_ninja_prefix_var buf Bsb_ninja_global_vars.g_dev_incls;      
+      Ext_buffer.add_char_string buf ' ' dev_incls;      
     Ext_buffer.add_char_string buf ' ' lib_incls;    
     Ext_buffer.add_char_string buf ' ' dpkg_incls;
     if not has_builtin then   

--- a/jscomp/bsb/bsb_ninja_rule.ml
+++ b/jscomp/bsb/bsb_ninja_rule.ml
@@ -130,6 +130,7 @@ let make_custom_rules
   ~ppx_flags
   ~bsc_flags
   ~dpkg_incls
+  ~lib_incls
   (custom_rules : command Map_string.t) : 
   builtin = 
   (** FIXME: We don't need set [-o ${out}] when building ast 
@@ -143,25 +144,23 @@ let make_custom_rules
       ~is_dev 
       ~postbuild : string =     
     Ext_buffer.clear buf;
-    Ext_buffer.add_string buf bsc;
-    
+    Ext_buffer.add_string buf bsc;    
     Ext_buffer.add_string buf ns_flag;
-    if read_cmi <> `is_cmi then begin 
-      Ext_buffer.add_string buf " -bs-package-name ";
-      Ext_buffer.add_string buf package_name;
-      Ext_buffer.add_string buf (Bsb_package_specs.package_flag_of_package_specs package_specs "$in_d")
-    end;
     if read_cmi = `yes then 
       Ext_buffer.add_string buf " -bs-read-cmi";
     if is_dev then 
       Ext_buffer.add_ninja_prefix_var buf Bsb_ninja_global_vars.g_dev_incls;      
-    Ext_buffer.add_ninja_prefix_var buf Bsb_build_schemas.g_lib_incls;
-    
+    Ext_buffer.add_char_string buf ' ' lib_incls;    
     Ext_buffer.add_char_string buf ' ' dpkg_incls;
     if not has_builtin then   
       Ext_buffer.add_string buf " -nostdlib";
     Ext_buffer.add_char_string buf ' ' warnings;  
     Ext_buffer.add_char_string buf ' ' bsc_flags;
+    if read_cmi <> `is_cmi then begin 
+      Ext_buffer.add_string buf " -bs-package-name ";
+      Ext_buffer.add_string buf package_name;
+      Ext_buffer.add_string buf (Bsb_package_specs.package_flag_of_package_specs package_specs "$in_d")
+    end;
     if has_gentype then
       Ext_buffer.add_ninja_prefix_var buf Bsb_ninja_global_vars.gentypeconfig;
     Ext_buffer.add_string buf " -o $out $in";
@@ -246,7 +245,7 @@ let make_custom_rules
       ~restat:() (* Always restat when having mli *)
       (name ^ "_dev")
   in 
-  (* [g_lib_incls] are fixed for libs *)
+
   let mj, mj_dev =
     aux ~name:"mj" ~read_cmi:`yes ~postbuild:has_postbuild in   
   let mij, mij_dev =

--- a/jscomp/bsb/bsb_ninja_rule.ml
+++ b/jscomp/bsb/bsb_ninja_rule.ml
@@ -116,7 +116,7 @@ type builtin = {
 let make_custom_rules 
   ~(gentype_config : Bsb_config_types.gentype_config option)        
   ~(has_postbuild : string option)
-  ~(has_pp : bool)
+  ~(pp_file : string option)
   ~(has_builtin : bool)
   ~(reason_react_jsx : Bsb_config_types.reason_react_jsx option)
   ~(digest : string)
@@ -180,7 +180,7 @@ let make_custom_rules
     end ;
     Ext_buffer.contents buf
   in   
-  let mk_ast ~(has_pp : bool) ~has_reason_react_jsx : string =
+  let mk_ast  ~has_reason_react_jsx : string =
     Ext_buffer.clear buf ; 
     Ext_buffer.add_string buf bsc;
     Ext_buffer.add_char_string buf ' ' warnings;  
@@ -192,8 +192,12 @@ let make_custom_rules
       Ext_buffer.add_string buf " -bs-refmt ";
       Ext_buffer.add_string buf (Ext_filename.maybe_quote x);
     );
-    if has_pp then
-      Ext_buffer.add_ninja_prefix_var buf Bsb_ninja_global_vars.pp_flags;
+    (match pp_file with 
+     | None -> ()
+     | Some flag ->
+       Ext_buffer.add_char_string buf ' '
+         (Bsb_build_util.pp_flag flag)
+    );
     (match has_reason_react_jsx, reason_react_jsx with
      | false, _ 
      | _, None -> ()
@@ -208,11 +212,11 @@ let make_custom_rules
   in  
   let build_ast =
     define
-      ~command:(mk_ast ~has_pp ~has_reason_react_jsx:false )
+      ~command:(mk_ast ~has_reason_react_jsx:false )
       "ast" in
   let build_ast_from_re =
     define
-      ~command:(mk_ast ~has_pp ~has_reason_react_jsx:true)
+      ~command:(mk_ast  ~has_reason_react_jsx:true)
       "astj" in 
  
   let copy_resources =    

--- a/jscomp/bsb/bsb_ninja_rule.ml
+++ b/jscomp/bsb/bsb_ninja_rule.ml
@@ -127,6 +127,7 @@ let make_custom_rules
   ~package_name
   ~bsc
   ~warnings
+  ~bs_dep
   (custom_rules : command Map_string.t) : 
   builtin = 
   (** FIXME: We don't need set [-o ${out}] when building ast 
@@ -218,13 +219,13 @@ let make_custom_rules
     define
       ~restat:()
       ~command:
-      ("$bsdep -hash " ^ digest ^ ns_flag ^ " $in")
+      (bs_dep ^ " -hash " ^ digest ^ ns_flag ^ " $in")
       "deps" in 
   let build_bin_deps_dev =
     define
       ~restat:()
       ~command:
-      ("$bsdep -g -hash " ^ digest ^ ns_flag ^ " $in")
+      (bs_dep ^ " -g -hash " ^ digest ^ ns_flag ^ " $in")
       "deps_dev" in     
   let aux ~name ~read_cmi  ~postbuild =
     define

--- a/jscomp/bsb/bsb_ninja_rule.ml
+++ b/jscomp/bsb/bsb_ninja_rule.ml
@@ -207,7 +207,7 @@ let make_custom_rules
     
     Ext_buffer.add_char_string buf ' ' ppx_flags; 
     Ext_buffer.add_char_string buf ' ' bsc_flags;
-    Ext_buffer.add_string buf "-bs-ast -o $out $in";   
+    Ext_buffer.add_string buf " -bs-ast -o $out $in";   
     Ext_buffer.contents buf
   in  
   let build_ast =

--- a/jscomp/bsb/bsb_ninja_rule.ml
+++ b/jscomp/bsb/bsb_ninja_rule.ml
@@ -207,7 +207,7 @@ let make_custom_rules
     
     Ext_buffer.add_char_string buf ' ' ppx_flags; 
     Ext_buffer.add_char_string buf ' ' bsc_flags;
-    Ext_buffer.add_string buf " -o $out -bs-ast $in";   
+    Ext_buffer.add_string buf "-bs-ast -o $out $in";   
     Ext_buffer.contents buf
   in  
   let build_ast =

--- a/jscomp/bsb/bsb_ninja_rule.ml
+++ b/jscomp/bsb/bsb_ninja_rule.ml
@@ -152,8 +152,9 @@ let make_custom_rules
     (* The include order matters below *)
     if is_dev then 
       Ext_buffer.add_char_string buf ' ' dev_incls;      
-    Ext_buffer.add_char_string buf ' ' lib_incls;    
-    Ext_buffer.add_char_string buf ' ' dpkg_incls;
+    Ext_buffer.add_char_string buf ' ' lib_incls; 
+    if is_dev then    
+      Ext_buffer.add_char_string buf ' ' dpkg_incls;
     if not has_builtin then   
       Ext_buffer.add_string buf " -nostdlib";
     Ext_buffer.add_char_string buf ' ' warnings;  

--- a/jscomp/bsb/bsb_ninja_rule.ml
+++ b/jscomp/bsb/bsb_ninja_rule.ml
@@ -126,6 +126,7 @@ let make_custom_rules
   ~namespace
   ~package_name
   ~bsc
+  ~warnings
   (custom_rules : command Map_string.t) : 
   builtin = 
   (** FIXME: We don't need set [-o ${out}] when building ast 
@@ -156,7 +157,8 @@ let make_custom_rules
       Ext_buffer.add_ninja_prefix_var buf Bsb_ninja_global_vars.g_dpkg_incls;
     if not has_builtin then   
       Ext_buffer.add_string buf " -nostdlib";
-    Ext_buffer.add_string buf " $warnings $bsc_flags";
+    Ext_buffer.add_char_string buf ' ' warnings;  
+    Ext_buffer.add_string buf " $bsc_flags";
     if has_gentype then
       Ext_buffer.add_ninja_prefix_var buf Bsb_ninja_global_vars.gentypeconfig;
     Ext_buffer.add_string buf " -o $out $in";
@@ -172,7 +174,8 @@ let make_custom_rules
   let mk_ast ~(has_pp : bool) ~has_ppx ~has_reason_react_jsx : string =
     Ext_buffer.clear buf ; 
     Ext_buffer.add_string buf bsc;
-    Ext_buffer.add_string buf " $warnings -bs-v ";
+    Ext_buffer.add_char_string buf ' ' warnings;  
+    Ext_buffer.add_string buf " -bs-v ";
     Ext_buffer.add_string buf Bs_version.version;
     (match refmt with 
     | None -> ()

--- a/jscomp/bsb/bsb_ninja_rule.mli
+++ b/jscomp/bsb/bsb_ninja_rule.mli
@@ -69,7 +69,7 @@ type command = string
     we must make sure it is re-entrant
 *)
 val make_custom_rules : 
-  has_gentype:bool ->
+  gentype_config:Bsb_config_types.gentype_config option ->
   has_postbuild:string option ->
   has_pp:bool ->
   has_builtin:bool -> 

--- a/jscomp/bsb/bsb_ninja_rule.mli
+++ b/jscomp/bsb/bsb_ninja_rule.mli
@@ -82,6 +82,7 @@ val make_custom_rules :
   package_name:string ->
   bsc:string ->
   warnings:string ->
+  bs_dep:string ->
   command Map_string.t ->
   builtin
 

--- a/jscomp/bsb/bsb_ninja_rule.mli
+++ b/jscomp/bsb/bsb_ninja_rule.mli
@@ -83,6 +83,8 @@ val make_custom_rules :
   warnings:string ->
   bs_dep:string ->
   ppx_flags:string ->
+  bsc_flags:string ->
+  dpkg_incls:string ->
   command Map_string.t ->
   builtin
 

--- a/jscomp/bsb/bsb_ninja_rule.mli
+++ b/jscomp/bsb/bsb_ninja_rule.mli
@@ -80,6 +80,7 @@ val make_custom_rules :
   package_specs:Bsb_package_specs.t ->
   namespace:string option ->
   package_name:string ->
+  bsc:string ->
   command Map_string.t ->
   builtin
 

--- a/jscomp/bsb/bsb_ninja_rule.mli
+++ b/jscomp/bsb/bsb_ninja_rule.mli
@@ -83,8 +83,9 @@ val make_custom_rules :
   warnings:string ->
   bs_dep:string ->
   ppx_flags:string ->
-  bsc_flags:string ->
+  bsc_flags:string ->  
   dpkg_incls:string ->
+  lib_incls:string ->
   command Map_string.t ->
   builtin
 

--- a/jscomp/bsb/bsb_ninja_rule.mli
+++ b/jscomp/bsb/bsb_ninja_rule.mli
@@ -71,7 +71,7 @@ type command = string
 val make_custom_rules : 
   gentype_config:Bsb_config_types.gentype_config option ->
   has_postbuild:string option ->
-  has_pp:bool ->
+  pp_file:string option ->
   has_builtin:bool -> 
   reason_react_jsx : Bsb_config_types.reason_react_jsx option ->
   digest:string ->

--- a/jscomp/bsb/bsb_ninja_rule.mli
+++ b/jscomp/bsb/bsb_ninja_rule.mli
@@ -86,6 +86,7 @@ val make_custom_rules :
   bsc_flags:string ->  
   dpkg_incls:string ->
   lib_incls:string ->
+  dev_incls:string ->
   command Map_string.t ->
   builtin
 

--- a/jscomp/bsb/bsb_ninja_rule.mli
+++ b/jscomp/bsb/bsb_ninja_rule.mli
@@ -71,7 +71,6 @@ type command = string
 val make_custom_rules : 
   has_gentype:bool ->
   has_postbuild:string option ->
-  has_ppx:bool ->
   has_pp:bool ->
   has_builtin:bool -> 
   reason_react_jsx : Bsb_config_types.reason_react_jsx option ->
@@ -83,6 +82,7 @@ val make_custom_rules :
   bsc:string ->
   warnings:string ->
   bs_dep:string ->
+  ppx_flags:string ->
   command Map_string.t ->
   builtin
 

--- a/jscomp/bsb/bsb_ninja_rule.mli
+++ b/jscomp/bsb/bsb_ninja_rule.mli
@@ -81,6 +81,7 @@ val make_custom_rules :
   namespace:string option ->
   package_name:string ->
   bsc:string ->
+  warnings:string ->
   command Map_string.t ->
   builtin
 

--- a/jscomp/bsb/bsb_ninja_rule.mli
+++ b/jscomp/bsb/bsb_ninja_rule.mli
@@ -79,6 +79,7 @@ val make_custom_rules :
   refmt:string option ->
   package_specs:Bsb_package_specs.t ->
   namespace:string option ->
+  package_name:string ->
   command Map_string.t ->
   builtin
 

--- a/lib/4.06.1/bsb.ml
+++ b/lib/4.06.1/bsb.ml
@@ -13256,7 +13256,7 @@ let make_custom_rules
     
     Ext_buffer.add_char_string buf ' ' ppx_flags; 
     Ext_buffer.add_char_string buf ' ' bsc_flags;
-    Ext_buffer.add_string buf "-bs-ast -o $out $in";   
+    Ext_buffer.add_string buf " -bs-ast -o $out $in";   
     Ext_buffer.contents buf
   in  
   let build_ast =

--- a/lib/4.06.1/bsb.ml
+++ b/lib/4.06.1/bsb.ml
@@ -4943,6 +4943,51 @@ let is_empty (x : file_group) =
   x.resources = [] &&
   x.generators = []    
 end
+module Bsb_ninja_global_vars
+= struct
+#1 "bsb_ninja_global_vars.ml"
+(* Copyright (C) 2017 Authors of BuckleScript
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition to the permissions granted to you by the LGPL, you may combine
+ * or link a "work that uses the Library" with a publicly distributed version
+ * of this file to produce a combined library or application, then distribute
+ * that combined work under the terms of your choosing, with no requirement
+ * to comply with the obligations normally placed on you by section 4 of the
+ * LGPL version 3 (or the corresponding section of a later version of the LGPL
+ * should you choose to use a later version).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
+
+
+ 
+
+
+(* Invariant: the two string literal has 
+  to be "a" and "$a"
+*)
+
+let src_root_dir = "g_root"
+
+let lazy_src_root_dir = "$g_root" 
+
+
+
+
+
+
+end
 module Ext_module_system
 = struct
 #1 "ext_module_system.ml"
@@ -5919,8 +5964,7 @@ let rev_lib_bs_prefix p = rev_lib_bs // p
 
 let ocaml_bin_install_prefix p = lib_ocaml // p
 
-let lazy_src_root_dir = "$src_root_dir" 
-let proj_rel path = lazy_src_root_dir // path
+let proj_rel path = Bsb_ninja_global_vars.lazy_src_root_dir // path
 
 (** it may not be a bad idea to hard code the binary path 
     of bsb in configuration time
@@ -13822,48 +13866,6 @@ let handle_files_per_dir
     oc ~order_only_deps:[] ~inputs:[] ~output:group.dir *)
 
     (* pseuduo targets per directory *)
-
-end
-module Bsb_ninja_global_vars
-= struct
-#1 "bsb_ninja_global_vars.ml"
-(* Copyright (C) 2017 Authors of BuckleScript
- * 
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * In addition to the permissions granted to you by the LGPL, you may combine
- * or link a "work that uses the Library" with a publicly distributed version
- * of this file to produce a combined library or application, then distribute
- * that combined work under the terms of your choosing, with no requirement
- * to comply with the obligations normally placed on you by section 4 of the
- * LGPL version 3 (or the corresponding section of a later version of the LGPL
- * should you choose to use a later version).
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
-
-
- 
-
-
-
-
-let src_root_dir = "src_root_dir"
-
-
-
-
-
-
 
 end
 module Bsb_ninja_gen : sig 

--- a/lib/4.06.1/bsb.ml
+++ b/lib/4.06.1/bsb.ml
@@ -13205,8 +13205,9 @@ let make_custom_rules
     (* The include order matters below *)
     if is_dev then 
       Ext_buffer.add_char_string buf ' ' dev_incls;      
-    Ext_buffer.add_char_string buf ' ' lib_incls;    
-    Ext_buffer.add_char_string buf ' ' dpkg_incls;
+    Ext_buffer.add_char_string buf ' ' lib_incls; 
+    if is_dev then    
+      Ext_buffer.add_char_string buf ' ' dpkg_incls;
     if not has_builtin then   
       Ext_buffer.add_string buf " -nostdlib";
     Ext_buffer.add_char_string buf ' ' warnings;  

--- a/lib/4.06.1/bsb.ml
+++ b/lib/4.06.1/bsb.ml
@@ -13865,12 +13865,6 @@ let src_root_dir = "src_root_dir"
 
 
 
-let refmt = "refmt"
-
-
-
-
-
 end
 module Bsb_ninja_gen : sig 
 #1 "bsb_ninja_gen.mli"

--- a/lib/4.06.1/bsb.ml
+++ b/lib/4.06.1/bsb.ml
@@ -1925,7 +1925,7 @@ let export_all = "all"
 let export_none = "none"
 
 
-let g_lib_incls = "g_lib_incls"
+
 let use_stdlib = "use-stdlib"
 let reason = "reason"
 let react_jsx = "react-jsx"
@@ -13050,8 +13050,9 @@ val make_custom_rules :
   warnings:string ->
   bs_dep:string ->
   ppx_flags:string ->
-  bsc_flags:string ->
+  bsc_flags:string ->  
   dpkg_incls:string ->
+  lib_incls:string ->
   command Map_string.t ->
   builtin
 
@@ -13190,6 +13191,7 @@ let make_custom_rules
   ~ppx_flags
   ~bsc_flags
   ~dpkg_incls
+  ~lib_incls
   (custom_rules : command Map_string.t) : 
   builtin = 
   (** FIXME: We don't need set [-o ${out}] when building ast 
@@ -13203,25 +13205,23 @@ let make_custom_rules
       ~is_dev 
       ~postbuild : string =     
     Ext_buffer.clear buf;
-    Ext_buffer.add_string buf bsc;
-    
+    Ext_buffer.add_string buf bsc;    
     Ext_buffer.add_string buf ns_flag;
-    if read_cmi <> `is_cmi then begin 
-      Ext_buffer.add_string buf " -bs-package-name ";
-      Ext_buffer.add_string buf package_name;
-      Ext_buffer.add_string buf (Bsb_package_specs.package_flag_of_package_specs package_specs "$in_d")
-    end;
     if read_cmi = `yes then 
       Ext_buffer.add_string buf " -bs-read-cmi";
     if is_dev then 
       Ext_buffer.add_ninja_prefix_var buf Bsb_ninja_global_vars.g_dev_incls;      
-    Ext_buffer.add_ninja_prefix_var buf Bsb_build_schemas.g_lib_incls;
-    
+    Ext_buffer.add_char_string buf ' ' lib_incls;    
     Ext_buffer.add_char_string buf ' ' dpkg_incls;
     if not has_builtin then   
       Ext_buffer.add_string buf " -nostdlib";
     Ext_buffer.add_char_string buf ' ' warnings;  
     Ext_buffer.add_char_string buf ' ' bsc_flags;
+    if read_cmi <> `is_cmi then begin 
+      Ext_buffer.add_string buf " -bs-package-name ";
+      Ext_buffer.add_string buf package_name;
+      Ext_buffer.add_string buf (Bsb_package_specs.package_flag_of_package_specs package_specs "$in_d")
+    end;
     if has_gentype then
       Ext_buffer.add_ninja_prefix_var buf Bsb_ninja_global_vars.gentypeconfig;
     Ext_buffer.add_string buf " -o $out $in";
@@ -13306,7 +13306,7 @@ let make_custom_rules
       ~restat:() (* Always restat when having mli *)
       (name ^ "_dev")
   in 
-  (* [g_lib_incls] are fixed for libs *)
+
   let mj, mj_dev =
     aux ~name:"mj" ~read_cmi:`yes ~postbuild:has_postbuild in   
   let mij, mij_dev =
@@ -13953,8 +13953,7 @@ let emit_bsc_lib_includes
     (bs_dependencies : Bsb_config_types.dependencies)
   (source_dirs : string list) 
   (external_includes) 
-  (namespace : _ option)
-  (oc : out_channel): unit = 
+  (namespace : _ option): string = 
   (* TODO: bsc_flags contain stdlib path which is in the latter position currently *)
   let all_includes source_dirs  = 
     source_dirs @
@@ -13970,14 +13969,13 @@ let emit_bsc_lib_includes
         (fun x -> if Filename.is_relative x then Bsb_config.rev_lib_bs_prefix  x else x) 
     )
   in 
-  Bsb_ninja_targets.output_kv
-    Bsb_build_schemas.g_lib_incls 
-    (Bsb_build_util.include_dirs 
-       (all_includes 
-          (if namespace = None then source_dirs 
-           else Filename.current_dir_name :: source_dirs
-           (*working dir is [lib/bs] we include this path to have namespace mapping*)
-          )))  oc 
+
+  (Bsb_build_util.include_dirs 
+     (all_includes 
+        (if namespace = None then source_dirs 
+         else Filename.current_dir_name :: source_dirs
+         (*working dir is [lib/bs] we include this path to have namespace mapping*)
+        )))
 
 
 let output_static_resources 
@@ -14084,6 +14082,7 @@ let output_ninja_and_namespace_map
       (Bsb_build_util.include_dirs source_dirs.dev) oc
   ;
   let digest = Bsb_db_encode.write_build_cache ~dir:cwd_lib_bs bs_groups in
+  let lib_incls = emit_bsc_lib_includes bs_dependencies source_dirs.lib external_includes namespace in
   let rules : Bsb_ninja_rule.builtin = 
       Bsb_ninja_rule.make_custom_rules 
       ~refmt
@@ -14102,8 +14101,9 @@ let output_ninja_and_namespace_map
       ~ppx_flags
       ~bsc_flags
       ~dpkg_incls
+      ~lib_incls
       generators in   
-  emit_bsc_lib_includes bs_dependencies source_dirs.lib external_includes namespace oc;
+
   output_static_resources static_resources rules.copy_resources oc ;
   (** Generate build statement for each file *)        
   Ext_list.iter bs_file_groups 

--- a/lib/4.06.1/bsb.ml
+++ b/lib/4.06.1/bsb.ml
@@ -12949,9 +12949,6 @@ let pp_flags = "pp_flags"
 
 let refmt = "refmt"
 
-let refmt_flags = "refmt_flags"
-
-
 
 let gentypeconfig = "gentypeconfig"
 

--- a/lib/4.06.1/bsb.ml
+++ b/lib/4.06.1/bsb.ml
@@ -12937,7 +12937,7 @@ module Bsb_ninja_global_vars
  
 
 
-let bsc = "bsc" 
+
 
 let src_root_dir = "src_root_dir"
 let bsdep = "bsdep"
@@ -13051,6 +13051,7 @@ val make_custom_rules :
   package_specs:Bsb_package_specs.t ->
   namespace:string option ->
   package_name:string ->
+  bsc:string ->
   command Map_string.t ->
   builtin
 
@@ -13184,6 +13185,7 @@ let make_custom_rules
   ~(package_specs: Bsb_package_specs.t)
   ~namespace
   ~package_name
+  ~bsc
   (custom_rules : command Map_string.t) : 
   builtin = 
   (** FIXME: We don't need set [-o ${out}] when building ast 
@@ -13197,7 +13199,7 @@ let make_custom_rules
       ~is_dev 
       ~postbuild : string =     
     Ext_buffer.clear buf;
-    Ext_buffer.add_string buf "$bsc";
+    Ext_buffer.add_string buf bsc;
     
     Ext_buffer.add_string buf ns_flag;
     if read_cmi <> `is_cmi then begin 
@@ -13229,7 +13231,8 @@ let make_custom_rules
   in   
   let mk_ast ~(has_pp : bool) ~has_ppx ~has_reason_react_jsx : string =
     Ext_buffer.clear buf ; 
-    Ext_buffer.add_string buf "$bsc  $warnings -bs-v ";
+    Ext_buffer.add_string buf bsc;
+    Ext_buffer.add_string buf " $warnings -bs-v ";
     Ext_buffer.add_string buf Bs_version.version;
     (match refmt with 
     | None -> ()
@@ -13309,7 +13312,7 @@ let make_custom_rules
       ~name:"mi" in 
   let build_package = 
     define
-      ~command:"$bsc -w -49 -color always -no-alias-deps  $in"
+      ~command:(bsc ^ " -w -49 -color always -no-alias-deps  $in")
       ~restat:()
       "build_package"
   in 
@@ -14021,6 +14024,7 @@ let output_ninja_and_namespace_map
   let oc = open_out_bin (cwd_lib_bs // Literals.build_ninja) in          
   let warnings = Bsb_warning.to_bsb_string ~toplevel warning in
   let bsc_flags = (get_bsc_flags bsc_flags) in 
+  let bsc_path = (Ext_filename.maybe_quote Bsb_global_paths.vendor_bsc) in      
   let () = 
     Ext_option.iter pp_file (fun flag ->
         Bsb_ninja_targets.output_kv Bsb_ninja_global_vars.pp_flags
@@ -14036,7 +14040,7 @@ let output_ninja_and_namespace_map
 
         Bsb_ninja_global_vars.src_root_dir, per_proj_dir (* TODO: need check its integrity -- allow relocate or not? *);
         (* The path to [bsc.exe] independent of config  *)
-        Bsb_ninja_global_vars.bsc, (Ext_filename.maybe_quote Bsb_global_paths.vendor_bsc);
+
         (* The path to [bsb_heler.exe] *)
         Bsb_ninja_global_vars.bsdep, (Ext_filename.maybe_quote Bsb_global_paths.vendor_bsdep) ;
         Bsb_ninja_global_vars.warnings, warnings;
@@ -14097,6 +14101,7 @@ let output_ninja_and_namespace_map
       ~namespace
       ~digest
       ~package_name
+      ~bsc:bsc_path
       generators in   
   emit_bsc_lib_includes bs_dependencies source_dirs.lib external_includes namespace oc;
   output_static_resources static_resources rules.copy_resources oc ;

--- a/lib/4.06.1/bsb.ml
+++ b/lib/4.06.1/bsb.ml
@@ -12935,7 +12935,7 @@ module Bsb_ninja_global_vars
 
 
  
-let g_pkg_flg = "g_pkg_flg"
+
 
 let bsc = "bsc" 
 
@@ -13050,6 +13050,7 @@ val make_custom_rules :
   refmt:string option ->
   package_specs:Bsb_package_specs.t ->
   namespace:string option ->
+  package_name:string ->
   command Map_string.t ->
   builtin
 
@@ -13182,6 +13183,7 @@ let make_custom_rules
   ~(refmt : string option) (* set refmt path when needed *)
   ~(package_specs: Bsb_package_specs.t)
   ~namespace
+  ~package_name
   (custom_rules : command Map_string.t) : 
   builtin = 
   (** FIXME: We don't need set [-o ${out}] when building ast 
@@ -13199,7 +13201,8 @@ let make_custom_rules
     
     Ext_buffer.add_string buf ns_flag;
     if read_cmi <> `is_cmi then begin 
-      Ext_buffer.add_ninja_prefix_var buf Bsb_ninja_global_vars.g_pkg_flg;
+      Ext_buffer.add_string buf " -bs-package-name ";
+      Ext_buffer.add_string buf package_name;
       Ext_buffer.add_string buf (Bsb_package_specs.package_flag_of_package_specs package_specs "$in_d")
     end;
     if read_cmi = `yes then 
@@ -14016,9 +14019,6 @@ let output_ninja_and_namespace_map
   let cwd_lib_bs = per_proj_dir // lib_artifacts_dir in 
   let ppx_flags = Bsb_build_util.ppx_flags ppx_files in
   let oc = open_out_bin (cwd_lib_bs // Literals.build_ninja) in          
-  let g_pkg_flg  =     
-      Ext_string.inter2 "-bs-package-name" package_name
-  in  
   let warnings = Bsb_warning.to_bsb_string ~toplevel warning in
   let bsc_flags = (get_bsc_flags bsc_flags) in 
   let () = 
@@ -14033,7 +14033,7 @@ let output_ninja_and_namespace_map
       );    
     Bsb_ninja_targets.output_kvs
       [|
-        Bsb_ninja_global_vars.g_pkg_flg, g_pkg_flg ; 
+
         Bsb_ninja_global_vars.src_root_dir, per_proj_dir (* TODO: need check its integrity -- allow relocate or not? *);
         (* The path to [bsc.exe] independent of config  *)
         Bsb_ninja_global_vars.bsc, (Ext_filename.maybe_quote Bsb_global_paths.vendor_bsc);
@@ -14096,6 +14096,7 @@ let output_ninja_and_namespace_map
       ~package_specs
       ~namespace
       ~digest
+      ~package_name
       generators in   
   emit_bsc_lib_includes bs_dependencies source_dirs.lib external_includes namespace oc;
   output_static_resources static_resources rules.copy_resources oc ;

--- a/lib/4.06.1/bsb.ml
+++ b/lib/4.06.1/bsb.ml
@@ -12951,10 +12951,6 @@ let refmt = "refmt"
 
 let refmt_flags = "refmt_flags"
 
-let postbuild = "postbuild"
-
-
-
 
 
 let gentypeconfig = "gentypeconfig"

--- a/lib/4.06.1/bsb.ml
+++ b/lib/4.06.1/bsb.ml
@@ -13212,7 +13212,7 @@ let make_custom_rules
     
     Ext_buffer.add_char_string buf ' ' ppx_flags; 
     Ext_buffer.add_char_string buf ' ' bsc_flags;
-    Ext_buffer.add_string buf " -o $out -bs-ast $in";   
+    Ext_buffer.add_string buf "-bs-ast -o $out $in";   
     Ext_buffer.contents buf
   in  
   let build_ast =


### PR DESCRIPTION
variables in rule are expensive, they are looked up per each build target, when it's easy to have it calcuated without bloating the file size, we should the pre-computation.

Also for the variable interpolation, it should be put in the tail position based on the mutable string appending