### PR TITLE
Tweak CONTRIBUTING for the local workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,7 @@ If this doesn't work (rare), then:
 If you'd like to use your modified ReScript like an end-user, try:
 
 ```sh
+npm uninstall -g bs-platform
 BS_TRAVIS_CI=1 npm install -g .
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ If this doesn't work (rare), then:
 If you'd like to use your modified ReScript like an end-user, try:
 
 ```sh
-npm uninstall -g bs-platform
+npm uninstall -g bs-platform # a cache-busting uninstall is needed, but only for npm >=7
 BS_TRAVIS_CI=1 npm install -g .
 ```
 

--- a/jscomp/build_tests/super_errors/README.md
+++ b/jscomp/build_tests/super_errors/README.md
@@ -1,8 +1,9 @@
 Special tests for super errors (the pretty error display)
 
-Follow CONTRIBUTING.md and run the integration test:
+Follow CONTRIBUTING.md and run the integration build that produces the binary needed in these tests:
 
 ```sh
+npm uninstall -g bs-platform # a cache-busting uninstall is needed, but only for npm >=7
 BS_TRAVIS_CI=1 npm install -g .
 ```
 


### PR DESCRIPTION
It seems that a repeated `BS_TRAVIS_CI=1 npm install -g .` doesn't
actually trigger a newer bsb/bsc build & install anymore. Wipe the
previous one as a fix. Not sure this is the right workflow.
