### PR TITLE
Use HTTPS to fetch ninja git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	branch = master
 [submodule "ninja"]
 	path = ninja
-	url = git@github.com:rescript-lang/ninja.git
+	url = https://github.com/rescript-lang/ninja
 	ignore = untracked


### PR DESCRIPTION
Unlike SSH, HTTPS allows for anonymous fetching, such as on a build server.