### PR TITLE
consistent check for name field in bsconfig.json

### DIFF
--- a/jscomp/bsb/bsb_build_util.ml
+++ b/jscomp/bsb/bsb_build_util.ml
@@ -153,9 +153,13 @@ let get_list_string s = get_list_string_acc s []
 let (|?)  m (key, cb) =
   m  |> Ext_json.test key cb
 
+type top = 
+  | Expect_none 
+  | Expect_name of string   
+
 type package_context = {
   proj_dir : string ; 
-  top : bool ; 
+  top : top ; 
 }
 
 (**
@@ -172,18 +176,26 @@ type package_context = {
 let pp_packages_rev ppf lst = 
   Ext_list.rev_iter lst (fun  s ->  Format.fprintf ppf "%s " s) 
 
+
 let rec walk_all_deps_aux 
   (visited : string Hash_string.t) 
   (paths : string list) 
-  (top : bool) 
-  (dir : string) 
+  ~(top : top) 
+  (dir : string)  
   (cb : package_context -> unit) =
   let bsconfig_json =  dir // Literals.bsconfig_json in
   match Ext_json_parse.parse_json_from_file bsconfig_json with
   | Obj {map; loc} ->
     let cur_package_name = 
       match Map_string.find_opt map Bsb_build_schemas.name with 
-      | Some (Str {str }) -> str
+      | Some (Str {str ; loc }) -> 
+        (match top with 
+         | Expect_none -> ()  
+         | Expect_name s ->  
+          if s <> str then 
+            Bsb_exception.errorf ~loc "package name is expected to be %s but got %s" s str
+        );
+        str
       | Some _ 
       | None -> Bsb_exception.errorf ~loc "package name missing in %s/bsconfig.json" dir 
     in 
@@ -210,7 +222,7 @@ let rec walk_all_deps_aux
                    let package_dir = 
                      Bsb_pkg.resolve_bs_package ~cwd:dir 
                        (Bsb_pkg_types.string_as_package   new_package) in 
-                   walk_all_deps_aux visited package_stacks  false package_dir cb  ;
+                   walk_all_deps_aux visited package_stacks  ~top:(Expect_name new_package) package_dir cb  ;
                  | _ -> 
                    Bsb_exception.errorf ~loc 
                      "%s expect an array"
@@ -219,7 +231,7 @@ let rec walk_all_deps_aux
         |> ignore in
       begin 
         explore_deps Bsb_build_schemas.bs_dependencies;          
-        if top then explore_deps Bsb_build_schemas.bs_dev_dependencies;
+        if top = Expect_none then explore_deps Bsb_build_schemas.bs_dev_dependencies;
         cb {top ; proj_dir = dir};
         Hash_string.add visited cur_package_name dir;
       end
@@ -230,4 +242,4 @@ let rec walk_all_deps_aux
 
 let walk_all_deps dir cb = 
   let visited = Hash_string.create 0 in 
-  walk_all_deps_aux visited [] true dir cb 
+  walk_all_deps_aux visited [] ~top:Expect_none dir cb 

--- a/jscomp/bsb/bsb_build_util.ml
+++ b/jscomp/bsb/bsb_build_util.ml
@@ -193,7 +193,8 @@ let rec walk_all_deps_aux
          | Expect_none -> ()  
          | Expect_name s ->  
           if s <> str then 
-            Bsb_exception.errorf ~loc "package name is expected to be %s but got %s" s str
+            Bsb_exception.errorf 
+            ~loc "package name is expected to be %s but got %s" s str 
         );
         str
       | Some _ 

--- a/jscomp/bsb/bsb_build_util.mli
+++ b/jscomp/bsb/bsb_build_util.mli
@@ -86,6 +86,10 @@ val get_list_string :
     Ext_json_types.t array -> 
     string list
 
+type top = 
+  | Expect_none 
+  | Expect_name of string   
+
 type result = { path : string; checked : bool }    
 
 (* [resolve_bsb_magic_file]
@@ -100,7 +104,10 @@ val resolve_bsb_magic_file :
 
 type package_context = {
   proj_dir : string ; 
-  top : bool ; 
+  top : top ; 
 }
 
-val walk_all_deps : string -> (package_context -> unit) -> unit
+val walk_all_deps : 
+  string -> 
+  (package_context -> unit) -> 
+  unit

--- a/jscomp/bsb/bsb_exception.ml
+++ b/jscomp/bsb/bsb_exception.ml
@@ -73,9 +73,10 @@ let print (fmt : Format.formatter) (x : error) =
          in_json
 
   | Json_config (pos,s) ->
-    Format.fprintf fmt "File \"bsconfig.json\", line %d:\n\
+    Format.fprintf fmt "File %S, line %d:\n\
                         @{<error>Error:@} %s \n\
                         For more details, please checkout the schema http://bucklescript.github.io/bucklescript/docson/#build-schema.json"
+                        pos.pos_fname
                         pos.pos_lnum s
   | Invalid_spec s ->
     Format.fprintf fmt

--- a/jscomp/bsb/bsb_ninja_targets.mli
+++ b/jscomp/bsb/bsb_ninja_targets.mli
@@ -31,7 +31,6 @@
    however, for the command we don't need pass `-o`
 *)
 val output_build :
-  (* ?order_only_deps:string list -> *)
   outputs:string list ->
   inputs:string list ->
   rule:Bsb_ninja_rule.t -> 

--- a/jscomp/bsb/bsb_world.ml
+++ b/jscomp/bsb/bsb_world.ml
@@ -37,7 +37,9 @@ let build_bs_deps cwd (deps : Bsb_package_specs.t) (ninja_args : string array) =
   in 
   let lib_artifacts_dir = Bsb_config.lib_bs in
   Bsb_build_util.walk_all_deps  cwd (fun ({top; proj_dir} : Bsb_build_util.package_context) ->
-      if not top then
+      match top with 
+      | Expect_none -> ()
+      | Expect_name _ ->
         begin 
           let  lib_bs_dir = proj_dir // lib_artifacts_dir in 
           Bsb_build_util.mkp lib_bs_dir;

--- a/jscomp/build_tests/jsxv/input.js
+++ b/jscomp/build_tests/jsxv/input.js
@@ -6,4 +6,4 @@ var p = require('child_process')
 
 var output = p.spawnSync(`bsb`, {cwd:__dirname, encoding:'utf8',shell:true})
 
-assert.ok(output.stderr.match(/File "bsconfig.json", line 10/))
+assert.ok(output.stderr.match(/File ".*bsconfig.json", line 10/))

--- a/lib/4.06.1/bsb.ml
+++ b/lib/4.06.1/bsb.ml
@@ -6560,9 +6560,10 @@ let print (fmt : Format.formatter) (x : error) =
          in_json
 
   | Json_config (pos,s) ->
-    Format.fprintf fmt "File \"bsconfig.json\", line %d:\n\
+    Format.fprintf fmt "File %S, line %d:\n\
                         @{<error>Error:@} %s \n\
                         For more details, please checkout the schema http://bucklescript.github.io/bucklescript/docson/#build-schema.json"
+                        pos.pos_fname
                         pos.pos_lnum s
   | Invalid_spec s ->
     Format.fprintf fmt
@@ -10032,7 +10033,8 @@ let rec walk_all_deps_aux
          | Expect_none -> ()  
          | Expect_name s ->  
           if s <> str then 
-            Bsb_exception.errorf ~loc "package name is expected to be %s but got %s" s str
+            Bsb_exception.errorf 
+            ~loc "package name is expected to be %s but got %s" s str 
         );
         str
       | Some _ 

--- a/lib/4.06.1/bsb.ml
+++ b/lib/4.06.1/bsb.ml
@@ -9809,6 +9809,10 @@ val get_list_string :
     Ext_json_types.t array -> 
     string list
 
+type top = 
+  | Expect_none 
+  | Expect_name of string   
+
 type result = { path : string; checked : bool }    
 
 (* [resolve_bsb_magic_file]
@@ -9823,10 +9827,13 @@ val resolve_bsb_magic_file :
 
 type package_context = {
   proj_dir : string ; 
-  top : bool ; 
+  top : top ; 
 }
 
-val walk_all_deps : string -> (package_context -> unit) -> unit
+val walk_all_deps : 
+  string -> 
+  (package_context -> unit) -> 
+  unit
 
 end = struct
 #1 "bsb_build_util.ml"
@@ -9985,9 +9992,13 @@ let get_list_string s = get_list_string_acc s []
 let (|?)  m (key, cb) =
   m  |> Ext_json.test key cb
 
+type top = 
+  | Expect_none 
+  | Expect_name of string   
+
 type package_context = {
   proj_dir : string ; 
-  top : bool ; 
+  top : top ; 
 }
 
 (**
@@ -10004,18 +10015,26 @@ type package_context = {
 let pp_packages_rev ppf lst = 
   Ext_list.rev_iter lst (fun  s ->  Format.fprintf ppf "%s " s) 
 
+
 let rec walk_all_deps_aux 
   (visited : string Hash_string.t) 
   (paths : string list) 
-  (top : bool) 
-  (dir : string) 
+  ~(top : top) 
+  (dir : string)  
   (cb : package_context -> unit) =
   let bsconfig_json =  dir // Literals.bsconfig_json in
   match Ext_json_parse.parse_json_from_file bsconfig_json with
   | Obj {map; loc} ->
     let cur_package_name = 
       match Map_string.find_opt map Bsb_build_schemas.name with 
-      | Some (Str {str }) -> str
+      | Some (Str {str ; loc }) -> 
+        (match top with 
+         | Expect_none -> ()  
+         | Expect_name s ->  
+          if s <> str then 
+            Bsb_exception.errorf ~loc "package name is expected to be %s but got %s" s str
+        );
+        str
       | Some _ 
       | None -> Bsb_exception.errorf ~loc "package name missing in %s/bsconfig.json" dir 
     in 
@@ -10042,7 +10061,7 @@ let rec walk_all_deps_aux
                    let package_dir = 
                      Bsb_pkg.resolve_bs_package ~cwd:dir 
                        (Bsb_pkg_types.string_as_package   new_package) in 
-                   walk_all_deps_aux visited package_stacks  false package_dir cb  ;
+                   walk_all_deps_aux visited package_stacks  ~top:(Expect_name new_package) package_dir cb  ;
                  | _ -> 
                    Bsb_exception.errorf ~loc 
                      "%s expect an array"
@@ -10051,7 +10070,7 @@ let rec walk_all_deps_aux
         |> ignore in
       begin 
         explore_deps Bsb_build_schemas.bs_dependencies;          
-        if top then explore_deps Bsb_build_schemas.bs_dev_dependencies;
+        if top = Expect_none then explore_deps Bsb_build_schemas.bs_dev_dependencies;
         cb {top ; proj_dir = dir};
         Hash_string.add visited cur_package_name dir;
       end
@@ -10062,7 +10081,7 @@ let rec walk_all_deps_aux
 
 let walk_all_deps dir cb = 
   let visited = Hash_string.create 0 in 
-  walk_all_deps_aux visited [] true dir cb 
+  walk_all_deps_aux visited [] ~top:Expect_none dir cb 
 
 end
 module Bsb_global_paths : sig 
@@ -13056,7 +13075,6 @@ module Bsb_ninja_targets : sig
    however, for the command we don't need pass `-o`
 *)
 val output_build :
-  (* ?order_only_deps:string list -> *)
   outputs:string list ->
   inputs:string list ->
   rule:Bsb_ninja_rule.t -> 
@@ -16261,7 +16279,9 @@ let build_bs_deps cwd (deps : Bsb_package_specs.t) (ninja_args : string array) =
   in 
   let lib_artifacts_dir = Bsb_config.lib_bs in
   Bsb_build_util.walk_all_deps  cwd (fun ({top; proj_dir} : Bsb_build_util.package_context) ->
-      if not top then
+      match top with 
+      | Expect_none -> ()
+      | Expect_name _ ->
         begin 
           let  lib_bs_dir = proj_dir // lib_artifacts_dir in 
           Bsb_build_util.mkp lib_bs_dir;


### PR DESCRIPTION
It's common some projects inited from template use the old name which is not consistent with package.josn