### PR TITLE
Fix broken ocaml build when compiled with gcc 10

### DIFF
--- a/scripts/buildocaml.js
+++ b/scripts/buildocaml.js
@@ -64,7 +64,7 @@ function build(config) {
     if (config) {
       var { make } = require("./config.js");
       cp.execSync(
-        "./configure -cc \"gcc -Wno-implicit-function-declaration\" -flambda -prefix " +
+        "./configure -cc \"gcc -Wno-implicit-function-declaration -fcommon\" -flambda -prefix " +
           prefix +
           ` -no-ocamlbuild  -no-curses -no-graph -no-pthread -no-debugger && ${make} clean`,
         { cwd: ocamlSrcDir, stdio: [0, 1, 2] }


### PR DESCRIPTION
As discussed here: https://github.com/ocaml/ocaml/issues/9144, and here: https://github.com/ocaml/opam-repository/pull/16583.
I hope this won't break the build process. 