### PR TITLE
make the dev version of bsc.exe behave the same as release version of bsc

### DIFF
--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -92,9 +92,11 @@ let output_static_resources
   FIXME: check if the trick still works
   phony build.ninja : | resources 
 *)      
-
+let mark_rescript oc = 
+  output_string oc "rescript = 1\n"  
 let output_installation_file cwd_lib_bs namespace files_to_install = 
   let install_oc = open_out_bin (cwd_lib_bs // "install.ninja") in 
+  mark_rescript install_oc;
   let o s = output_string install_oc s in
   let[@inline] oo suffix ~dest ~src =   
     o  "o " ; 
@@ -232,7 +234,8 @@ let output_ninja_and_namespace_map
       ~dev_incls (* its own devs *)
       generators in  
 
-  let oc = open_out_bin (cwd_lib_bs // Literals.build_ninja) in              
+  let oc = open_out_bin (cwd_lib_bs // Literals.build_ninja) in 
+  mark_rescript oc;
   Bsb_ninja_targets.output_kv      
     Bsb_ninja_global_vars.src_root_dir per_proj_dir                 
     oc ;

--- a/jscomp/core/bs_conditional_initial.ml
+++ b/jscomp/core/bs_conditional_initial.ml
@@ -63,6 +63,15 @@ let setup_env () =
     Matching_polyfill.names_from_construct_pattern;
 #if undefined BS_RELEASE_BUILD then
     Printexc.record_backtrace true;
+    (let root_dir = 
+        Filename.dirname 
+          (Filename.dirname Sys.executable_name) in 
+    let (//) = Filename.concat in       
+    Clflags.include_dirs :=
+      (root_dir//"jscomp"//"others") ::
+      (root_dir//"jscomp"//"stdlib-406") ::
+      (root_dir//"jscomp"//"runtime") ::
+      !Clflags.include_dirs);
 #end
   Lexer.replace_directive_bool "BS" true;
   Lexer.replace_directive_bool "JS" true;

--- a/lib/4.06.1/bsb.ml
+++ b/lib/4.06.1/bsb.ml
@@ -13663,9 +13663,11 @@ let output_static_resources
   FIXME: check if the trick still works
   phony build.ninja : | resources 
 *)      
-
+let mark_rescript oc = 
+  output_string oc "rescript = 1\n"  
 let output_installation_file cwd_lib_bs namespace files_to_install = 
   let install_oc = open_out_bin (cwd_lib_bs // "install.ninja") in 
+  mark_rescript install_oc;
   let o s = output_string install_oc s in
   let[@inline] oo suffix ~dest ~src =   
     o  "o " ; 
@@ -13803,7 +13805,8 @@ let output_ninja_and_namespace_map
       ~dev_incls (* its own devs *)
       generators in  
 
-  let oc = open_out_bin (cwd_lib_bs // Literals.build_ninja) in              
+  let oc = open_out_bin (cwd_lib_bs // Literals.build_ninja) in 
+  mark_rescript oc;
   Bsb_ninja_targets.output_kv      
     Bsb_ninja_global_vars.src_root_dir per_proj_dir                 
     oc ;

--- a/scripts/ninja.js
+++ b/scripts/ninja.js
@@ -859,7 +859,7 @@ function generateNinja(depsMap, allTargets, cwd, extraDeps = []) {
   return build_stmts;
 }
 
-var COMPILIER = `../${process.platform}/bsc`;
+var COMPILIER = `../${process.platform}/bsc.exe`;
 var BSC_COMPILER = `bsc = ${COMPILIER}`;
 var compilerTarget = pseudoTarget(COMPILIER);
 
@@ -1613,7 +1613,7 @@ o common/bs_version.ml : mk_bsversion build_version.js ../package.json
 
 o ../${
     process.platform
-  }/bsc: link napkin/napkin.cmxa js_parser/js_parser.cmxa stubs/stubs.cmxa ext/ext.cmxa common/common.cmxa syntax/syntax.cmxa depends/depends.cmxa super_errors/super_errors.cmxa outcome_printer/outcome_printer.cmxa core/core.cmxa main/js_main.cmx
+  }/bsc.exe: link napkin/napkin.cmxa js_parser/js_parser.cmxa stubs/stubs.cmxa ext/ext.cmxa common/common.cmxa syntax/syntax.cmxa depends/depends.cmxa super_errors/super_errors.cmxa outcome_printer/outcome_printer.cmxa core/core.cmxa main/js_main.cmx
     libs = ocamlcommon.cmxa
 o ../${
     process.platform


### PR DESCRIPTION
- Previously, in the dev mode, it does not load cmi/cmj by default since there's a bootstrap issue, 
you need build those binary artifacts first before embedding it, this cause the slightly different behavior
 between the compiler built in dev mode and release mode, this commit make them behave almost 
the same by adding the include path in dev mode, so that those binary artifacts are loaded during the runtime
The consequence is that to test the compiler, we don't need go into a release mode, you can test the new behavior very fast

- add `rescript = 1` in ninja file so that the build engine could do some specialization