### PR TITLE
experimental changes so that only cmi/j changes will trigger a rebuild

### DIFF
--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -117,17 +117,18 @@ let output_installation_file cwd_lib_bs namespace files_to_install =
   files_to_install 
   |> Queue.iter (fun ({name_sans_extension;syntax_kind; info} : Bsb_db.module_info) -> 
       let base = Filename.basename name_sans_extension in 
-      let ns_base = Ext_namespace_encode.make ?ns:namespace base in
+      let dest = Ext_namespace_encode.make ?ns:namespace base in
       let ns_origin = Ext_namespace_encode.make ?ns:namespace name_sans_extension in
-      oo Literals.suffix_cmi ~dest:ns_base ~src:(bs//ns_origin);
-      oo Literals.suffix_cmj ~dest:ns_base ~src:(bs//ns_origin);      
-      oo Literals.suffix_cmt ~dest:ns_base ~src:(bs//ns_origin);
-      Ext_buffer.add_string essentials ns_base ;
-      Ext_buffer.add_string essentials Literals.suffix_cmi;
-      Ext_buffer.add_string essentials " ";
-      Ext_buffer.add_string essentials ns_base ;
-      Ext_buffer.add_string essentials Literals.suffix_cmj;
-      Ext_buffer.add_string essentials " ";
+      let src = bs//ns_origin in 
+      oo Literals.suffix_cmi ~dest ~src;
+      oo Literals.suffix_cmj ~dest ~src;      
+      oo Literals.suffix_cmt ~dest ~src;
+      
+      Ext_buffer.add_string essentials  dest ;
+      Ext_buffer.add_string_char essentials Literals.suffix_cmi ' ';    
+      Ext_buffer.add_string essentials dest ;
+      Ext_buffer.add_string_char essentials Literals.suffix_cmj ' ';
+
       let suffix = 
         match syntax_kind with 
         | Ml -> Literals.suffix_ml 
@@ -144,22 +145,21 @@ let output_installation_file cwd_lib_bs namespace files_to_install =
           | Reason ->  Literals.suffix_rei
           | Res ->  Literals.suffix_resi in   
         oo suffix_b  ~dest:base ~src:(sb//name_sans_extension);                      
-        oo Literals.suffix_cmti ~dest:ns_base ~src:(bs//ns_origin)
+        oo Literals.suffix_cmti ~dest ~src
     );
   begin match namespace with 
   | None -> ()      
-  | Some x -> 
-    let src = bs // x in   
-    oo Literals.suffix_cmi ~dest:x ~src; 
-    oo Literals.suffix_cmj ~dest:x ~src;
-    oo Literals.suffix_cmt ~dest:x ~src;
-    Ext_buffer.add_string essentials x ; 
-    Ext_buffer.add_string essentials Literals.suffix_cmi;
-    Ext_buffer.add_string essentials " ";
-    Ext_buffer.add_string essentials x ;
-    Ext_buffer.add_string essentials Literals.suffix_cmj;
+  | Some dest -> 
+    let src = bs // dest in   
+    oo Literals.suffix_cmi ~dest ~src; 
+    oo Literals.suffix_cmj ~dest ~src;
+    oo Literals.suffix_cmt ~dest ~src;
+    Ext_buffer.add_string essentials dest ; 
+    Ext_buffer.add_string_char essentials Literals.suffix_cmi ' ';
+    Ext_buffer.add_string essentials dest ;
+    Ext_buffer.add_string essentials Literals.suffix_cmj 
   end;
-  Ext_buffer.add_string essentials "\n";
+  Ext_buffer.add_char essentials '\n';
   o "build install.stamp : touch ";
   Ext_buffer.output_buffer install_oc essentials;
   close_out install_oc

--- a/jscomp/bsb/bsb_ninja_gen.ml
+++ b/jscomp/bsb/bsb_ninja_gen.ml
@@ -108,7 +108,8 @@ let output_installation_file cwd_lib_bs namespace files_to_install =
   let bs = ".."//"bs" in  
   let sb = ".."//".." in 
   o (if Ext_sys.is_windows_or_cygwin then 
-      "rule cp\n  command = cmd.exe /C copy /Y $i $out >NUL\n"
+      "rule cp\n  command = cmd.exe /C copy /Y $i $out >NUL\n\
+       rule touch\n command = cmd.exe /C type nul >>$out & copy $out+,, >NUL\n"
     else
       "rule cp\n  command = cp $i $out\n\
        rule touch\n command = touch $out\n"

--- a/lib/4.06.1/bsb.ml
+++ b/lib/4.06.1/bsb.ml
@@ -13627,7 +13627,8 @@ let output_installation_file cwd_lib_bs namespace files_to_install =
   let bs = ".."//"bs" in  
   let sb = ".."//".." in 
   o (if Ext_sys.is_windows_or_cygwin then 
-      "rule cp\n  command = cmd.exe /C copy /Y $i $out >NUL\n"
+      "rule cp\n  command = cmd.exe /C copy /Y $i $out >NUL\n\
+       rule touch\n command = cmd.exe /C type nul >>$out & copy $out+,, >NUL\n"
     else
       "rule cp\n  command = cp $i $out\n\
        rule touch\n command = touch $out\n"
@@ -13636,17 +13637,18 @@ let output_installation_file cwd_lib_bs namespace files_to_install =
   files_to_install 
   |> Queue.iter (fun ({name_sans_extension;syntax_kind; info} : Bsb_db.module_info) -> 
       let base = Filename.basename name_sans_extension in 
-      let ns_base = Ext_namespace_encode.make ?ns:namespace base in
+      let dest = Ext_namespace_encode.make ?ns:namespace base in
       let ns_origin = Ext_namespace_encode.make ?ns:namespace name_sans_extension in
-      oo Literals.suffix_cmi ~dest:ns_base ~src:(bs//ns_origin);
-      oo Literals.suffix_cmj ~dest:ns_base ~src:(bs//ns_origin);      
-      oo Literals.suffix_cmt ~dest:ns_base ~src:(bs//ns_origin);
-      Ext_buffer.add_string essentials ns_base ;
-      Ext_buffer.add_string essentials Literals.suffix_cmi;
-      Ext_buffer.add_string essentials " ";
-      Ext_buffer.add_string essentials ns_base ;
-      Ext_buffer.add_string essentials Literals.suffix_cmj;
-      Ext_buffer.add_string essentials " ";
+      let src = bs//ns_origin in 
+      oo Literals.suffix_cmi ~dest ~src;
+      oo Literals.suffix_cmj ~dest ~src;      
+      oo Literals.suffix_cmt ~dest ~src;
+      
+      Ext_buffer.add_string essentials  dest ;
+      Ext_buffer.add_string_char essentials Literals.suffix_cmi ' ';    
+      Ext_buffer.add_string essentials dest ;
+      Ext_buffer.add_string_char essentials Literals.suffix_cmj ' ';
+
       let suffix = 
         match syntax_kind with 
         | Ml -> Literals.suffix_ml 
@@ -13663,22 +13665,21 @@ let output_installation_file cwd_lib_bs namespace files_to_install =
           | Reason ->  Literals.suffix_rei
           | Res ->  Literals.suffix_resi in   
         oo suffix_b  ~dest:base ~src:(sb//name_sans_extension);                      
-        oo Literals.suffix_cmti ~dest:ns_base ~src:(bs//ns_origin)
+        oo Literals.suffix_cmti ~dest ~src
     );
   begin match namespace with 
   | None -> ()      
-  | Some x -> 
-    let src = bs // x in   
-    oo Literals.suffix_cmi ~dest:x ~src; 
-    oo Literals.suffix_cmj ~dest:x ~src;
-    oo Literals.suffix_cmt ~dest:x ~src;
-    Ext_buffer.add_string essentials x ; 
-    Ext_buffer.add_string essentials Literals.suffix_cmi;
-    Ext_buffer.add_string essentials " ";
-    Ext_buffer.add_string essentials x ;
-    Ext_buffer.add_string essentials Literals.suffix_cmj;
+  | Some dest -> 
+    let src = bs // dest in   
+    oo Literals.suffix_cmi ~dest ~src; 
+    oo Literals.suffix_cmj ~dest ~src;
+    oo Literals.suffix_cmt ~dest ~src;
+    Ext_buffer.add_string essentials dest ; 
+    Ext_buffer.add_string_char essentials Literals.suffix_cmi ' ';
+    Ext_buffer.add_string essentials dest ;
+    Ext_buffer.add_string essentials Literals.suffix_cmj 
   end;
-  Ext_buffer.add_string essentials "\n";
+  Ext_buffer.add_char essentials '\n';
   o "build install.stamp : touch ";
   Ext_buffer.output_buffer install_oc essentials;
   close_out install_oc

--- a/lib/4.06.1/bsb.ml
+++ b/lib/4.06.1/bsb.ml
@@ -13629,8 +13629,10 @@ let output_installation_file cwd_lib_bs namespace files_to_install =
   o (if Ext_sys.is_windows_or_cygwin then 
       "rule cp\n  command = cmd.exe /C copy /Y $i $out >NUL\n"
     else
-      "rule cp\n  command = cp $i $out\n"
+      "rule cp\n  command = cp $i $out\n\
+       rule touch\n command = touch $out\n"
     );
+  let essentials = Ext_buffer.create 1_000 in   
   files_to_install 
   |> Queue.iter (fun ({name_sans_extension;syntax_kind; info} : Bsb_db.module_info) -> 
       let base = Filename.basename name_sans_extension in 
@@ -13639,6 +13641,12 @@ let output_installation_file cwd_lib_bs namespace files_to_install =
       oo Literals.suffix_cmi ~dest:ns_base ~src:(bs//ns_origin);
       oo Literals.suffix_cmj ~dest:ns_base ~src:(bs//ns_origin);      
       oo Literals.suffix_cmt ~dest:ns_base ~src:(bs//ns_origin);
+      Ext_buffer.add_string essentials ns_base ;
+      Ext_buffer.add_string essentials Literals.suffix_cmi;
+      Ext_buffer.add_string essentials " ";
+      Ext_buffer.add_string essentials ns_base ;
+      Ext_buffer.add_string essentials Literals.suffix_cmj;
+      Ext_buffer.add_string essentials " ";
       let suffix = 
         match syntax_kind with 
         | Ml -> Literals.suffix_ml 
@@ -13663,8 +13671,16 @@ let output_installation_file cwd_lib_bs namespace files_to_install =
     let src = bs // x in   
     oo Literals.suffix_cmi ~dest:x ~src; 
     oo Literals.suffix_cmj ~dest:x ~src;
-    oo Literals.suffix_cmt ~dest:x ~src
+    oo Literals.suffix_cmt ~dest:x ~src;
+    Ext_buffer.add_string essentials x ; 
+    Ext_buffer.add_string essentials Literals.suffix_cmi;
+    Ext_buffer.add_string essentials " ";
+    Ext_buffer.add_string essentials x ;
+    Ext_buffer.add_string essentials Literals.suffix_cmj;
   end;
+  Ext_buffer.add_string essentials "\n";
+  o "build install.stamp : touch ";
+  Ext_buffer.output_buffer install_oc essentials;
   close_out install_oc
 
 let output_ninja_and_namespace_map
@@ -13758,7 +13774,7 @@ let output_ninja_and_namespace_map
   let oc = open_out_bin (cwd_lib_bs // Literals.build_ninja) in 
   mark_rescript oc;
   let finger_file  = 
-    fun (x : Bsb_config_types.dependency) -> x.package_install_path //".ninja_log"
+    fun (x : Bsb_config_types.dependency) -> x.package_install_path //"install.stamp"
   in  
   Ext_list.iter bs_dependencies (fun x -> 
       Bsb_ninja_targets.output_finger Bsb_ninja_global_vars.g_finger


### PR DESCRIPTION
- [x]  windows support

This commit could cut some unneeded rebuild for `-make-world`. So for a package chain A -> B -> C

If we change A, however, its public essential files, cmi and cmj does not change, it will not trigger rebuild for B and C.

This works well when you write interface file for package A so its public interface is small.

