### PR TITLE
Porting to OpenBSD/adJ

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -10,10 +10,11 @@ var sys_extension;
 switch (os.type()) {
     case 'Darwin':
     case 'FreeBSD':
-    case 'Linux':        
+    case 'Linux':
+    case 'OpenBSD':
     case 'Windows_NT':
         sys_extension = "." + os.platform(); break;
-    default: throw ("Not supported" + os.type())
+    default: throw ("Not supported " + os.type())
 }
 
 exports.sys_extension  = sys_extension

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -18,7 +18,7 @@ var root_dir = path.join(__dirname, "..");
 var lib_dir = path.join(root_dir, "lib");
 var jscomp_dir = path.join(root_dir, "jscomp");
 
-var supported_os = ["darwin", "freebsd", "linux", "win32"];
+var supported_os = ["darwin", "freebsd", "linux", "openbsd", "win32"];
 if (supported_os.indexOf(process.platform) < 0) {
   throw new Error("Not supported platform" + process.platform);
 }


### PR DESCRIPTION
With this PR I'm able to compile by running first `ulimit -d 4000000`.  

```
ulimit -d 4000000
git submodule update --init
node scripts/buildocaml.js
npm install   # Also works CXX=c++ yarn install
./scripts/ninja.js config./scripts/ninja.js build
```

I ported on the following platform:

OS: OpenBSD/adJ 6.7
node: 12.16.1

(although not used by rescript-lang, this platform includes ocaml 4.09.0)

I didn't include the generated `openbsd/ninja.exe` with this PR, however I included it in the branch `openbsd-bin6.7` of my fork  <https://github.com/vtamara/rescript-compiler/tree/openbsd-bin6.7>

¿Should I do the pull request including `openbsd/ninja.exe`?