### PR TITLE
Add Js_exn.anyToExnInternal function

### DIFF
--- a/jscomp/others/js_exn.ml
+++ b/jscomp/others/js_exn.ml
@@ -45,6 +45,12 @@ external makeError : string -> error = "Error" [@@bs.new]
 external isCamlExceptionOrOpenVariant : 
   'a -> bool = "caml_is_extension"
 
+let unsafeAnyToExn obj =
+  if isCamlExceptionOrOpenVariant obj then
+    (Obj.magic obj : exn)
+  else
+    Error ((Obj.magic obj) : t)
+
 let raiseError str = 
   raise (Obj.magic (makeError str : error) : exn)
 

--- a/jscomp/others/js_exn.ml
+++ b/jscomp/others/js_exn.ml
@@ -45,7 +45,7 @@ external makeError : string -> error = "Error" [@@bs.new]
 external isCamlExceptionOrOpenVariant : 
   'a -> bool = "caml_is_extension"
 
-let unsafeAnyToExn obj =
+let anyToExnInternal obj =
   if isCamlExceptionOrOpenVariant obj then
     (Obj.magic obj : exn)
   else

--- a/jscomp/others/js_exn.mli
+++ b/jscomp/others/js_exn.mli
@@ -43,7 +43,7 @@ external isCamlExceptionOrOpenVariant:
   'a -> bool = "caml_is_extension"
 (** internal use only *)
 
-val unsafeAnyToExn : 'a -> exn
+val anyToExnInternal: 'a -> exn
 (** [unsafeAnyToExn obj] will take any value [obj] and wrap it
  * in a Js.Exn.Error if given value is not an exn already. If
  * [obj] is an exn, it will return [obj] without any changes. 

--- a/jscomp/others/js_exn.mli
+++ b/jscomp/others/js_exn.mli
@@ -44,13 +44,16 @@ external isCamlExceptionOrOpenVariant:
 (** internal use only *)
 
 val anyToExnInternal: 'a -> exn
-(** [unsafeAnyToExn obj] will take any value [obj] and wrap it
+(**
+ * [anyToExnInternal obj] will take any value [obj] and wrap it
  * in a Js.Exn.Error if given value is not an exn already. If
  * [obj] is an exn, it will return [obj] without any changes. 
  *
  * This function is mostly useful for cases where you want to unify a type of a value
  * that potentially is either exn, a JS error, or any other JS value really (e.g. for 
  * a value passed to a Promise.catch callback) 
+ *
+ * IMPORTANT: This is an internal API and may be changed / removed any time in the future.
  *
  * @example {[
  *   switch (Js.Exn.unsafeAnyToExn("test")) {

--- a/jscomp/others/js_exn.mli
+++ b/jscomp/others/js_exn.mli
@@ -43,6 +43,25 @@ external isCamlExceptionOrOpenVariant:
   'a -> bool = "caml_is_extension"
 (** internal use only *)
 
+val unsafeAnyToExn : 'a -> exn
+(** [unsafeAnyToExn obj] will take any value [obj] and wrap it
+ * in a Js.Exn.Error if given value is not an exn already. If
+ * [obj] is an exn, it will return [obj] without any changes. 
+ *
+ * This function is mostly useful for cases where you want to unify a type of a value
+ * that potentially is either exn, a JS error, or any other JS value really (e.g. for 
+ * a value passed to a Promise.catch callback) 
+ *
+ * @example {[
+ *   switch (Js.Exn.unsafeAnyToExn("test")) {
+ *     | Js.Exn.Error(v) =>
+ *       switch(Js.Exn.message(v)) {
+ *         | Some(str) => Js.log("We won't end up here")
+           | None => Js.log2("We will land here: ", v)
+ *       }
+ *   }
+ * ]}
+ * **)
 
 (** Raise Js exception Error object with stacktrace *)
 val raiseError : string -> 'a


### PR DESCRIPTION
I am trying to express an idiomatic `Promise.catch` approach, which usually receives an error like this:

```
type t<+'a> = Js.Promise.t<'a>
type error = Js.Promise.error

@bs.send
external catch: (t<'a>, @bs.uncurry (error => 'b)) => t<'b> = "catch"
```

Now, `error`'s value is determined by following scenarios (in a scope of a `Promise.then`):
- 1) `raise(MyOwnError)`
- 2) `Promise.reject(MyOwnError)`
- 3) `Js.Exn.raiseError`
- 4) `someJsFunctionThatThrowsError()`
- 5) `someJsFnThatThrowsNonError()`

Case 1) and 2) are fine, because they are already making sure that our `error` is pattern matchable.

Generally I would have liked to just type the catch value to be of `type exn` and just use the explicit exception patterns and a default case for the other values, like this:

```rescript
@val external asyncParseFail: unit => Promise.t<string> = "asyncParseFail"
    asyncParseFail()->catch((e:exn) => {
      switch e {
      | err =>
        switch Js.Exn.asJsExn(e) {
          | Some(v) => Js.log(v)
          | None => Js.log("not a JS Exn")
        }
        Js.Exn.asJsExn(err)->Belt.Option.flatMap(v => Js.Exn.message(v)) ==
          Some("Unexpected token . in JSON at position 1")
      }
    })
  }
```

In this particular example we have a problem though: Since `asyncParseFail` throws an `Error` object, it will not respond to the `asJsExn` convertion, because it is not wrapped in a `Js.Exn.Error` value, therefore I have no chance of seeing if it is a JS Error or not.

Which means we need to rely on `Js.Exn.isCamlExceptionOrVariant` and if so, try to coerce it somehow to the appropriate value:

```
// Promise.res
exception Unknown(Js.Exn.t)
let handleError = (e: error) => {
   if unsafeToExn(e)->Js.Exn.isCamlExceptionOrOpenVariant { 
   unsafeToExn(e) 
   } else { 
   Unknown(unsafeToJsExn(e)) 
   } 
}
```

With this function in place, we will have an easier time "lifting" the passed values to a fine granular type that allows more logical access to the data:

```
    asyncParseFail()->catch(e => {
      let success = switch handleError(e) {
      | UnknownError(obj) =>
        switch Js.Exn.message(obj) {
        | Some(msg) => Js.log("It's a js exn: " ++ msg)
        | None => Js.log("it's not")
        }
        true
      | err => false
      }
```

Now that `UnknownError` exception is extremely annoying, because we have a standardized value that is `Js.Exn.Error(Js.Exn.t)` already.


So the idea of this PR is to add an (internal) function `Js.Exn.unsafeAnyToExn` function, that takes any value, and lifts it to a `Js.Exn.Error` value, in case it is not already a exn / open variant:

```res
let unsafeAnyToExn: ('a) => exn
``` 

With this in place we can simplify our `handleError` to the following:

```
// let handleError: error => exn
let handleError = e => {
  Js.Exn.unsafeAnyToExn(e)
}
```

Now in our program, instead of using `Unknown`, we are using our `Js.Exn.Error` value (like in normal try / catch scenarios):

```diff
    asyncParseFail()->catch(e => {
      let success = switch handleError(e) {
+      | Js.Exn.Error(obj) =>
        switch Js.Exn.message(obj) {
        | Some(msg) => Js.log("It's a js exn: " ++ msg)
        | None => Js.log("it's not")
        }
        true
      | err => false
      }
```

This would help us implement a cleaner Promise error handling implementation without adding too much overhead, while being familiar with exception handling!

