### PR TITLE
Add stale bot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,38 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 720 
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - "PRIORITY:HIGH"
+  - bug
+  - non-critical-bug 
+  - security
+  - enhancement
+  - optimization
+  - v8-breaking-changes
+  - documentation
+  - "need feedback"
+  - "GOOD FIRST TASK"
+  - "BREAKING CHANGES"
+  - APPROVED
+  - discussion
+  - BUILD
+  - "help wanted"
+  - "GOOD FOR PR"
+  - "TO REPRODUCE"
+  - FFI
+  - internal
+  - ideas
+  - playground
+  - Syntax
+  - test
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
Resolves #4730 

This will configure [stale bot](https://github.com/marketplace/stale) to close all stale issues that haven't been active for the past 2 years.

It will keep all issues open that are tagged with a label listed in exemptLabels.

I'd recommend to reduce the labels at some point. There are over 50 different labels, and I think many of them are redundant.