### PR TITLE
Attribution in `.mli` files

### DIFF
--- a/jscomp/bsb/bsb_arg.mli
+++ b/jscomp/bsb/bsb_arg.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2020- Authors of ReScript
+(* Copyright (C) 2020- Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/bsb/bsb_clean.mli
+++ b/jscomp/bsb/bsb_clean.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017 Authors of ReScript
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/bsb/bsb_db_encode.mli
+++ b/jscomp/bsb/bsb_db_encode.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2019 - Present Authors of ReScript
- * 
+(* Copyright (C) 2019 - Present Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/bsb/bsb_file_groups.mli
+++ b/jscomp/bsb/bsb_file_groups.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2018- Authors of ReScript
- * 
+(* Copyright (C) 2018- Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/bsb/bsb_global_paths.mli
+++ b/jscomp/bsb/bsb_global_paths.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2019 - Authors of ReScript
+(* Copyright (C) 2019 - Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/bsb/bsb_log.mli
+++ b/jscomp/bsb/bsb_log.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/bsb/bsb_namespace_map_gen.mli
+++ b/jscomp/bsb/bsb_namespace_map_gen.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017 Authors of ReScript
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/bsb/bsb_ninja_file_groups.mli
+++ b/jscomp/bsb/bsb_ninja_file_groups.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017 Authors of ReScript
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/bsb/bsb_ninja_regen.mli
+++ b/jscomp/bsb/bsb_ninja_regen.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017 Authors of ReScript
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/bsb/bsb_package_specs.mli
+++ b/jscomp/bsb/bsb_package_specs.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/bsb/bsb_pkg_types.mli
+++ b/jscomp/bsb/bsb_pkg_types.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2019- Authors of ReScript
+(* Copyright (C) 2019- Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/bsb/bsb_regex.mli
+++ b/jscomp/bsb/bsb_regex.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017 Authors of ReScript
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/bsb/bsb_warning.mli
+++ b/jscomp/bsb/bsb_warning.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017 Authors of ReScript
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/bsb/bsb_watcher_gen.mli
+++ b/jscomp/bsb/bsb_watcher_gen.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017- Authors of ReScript
+(* Copyright (C) 2017- Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/bsb/bsb_world.mli
+++ b/jscomp/bsb/bsb_world.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017- Authors of ReScript
+(* Copyright (C) 2017- Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/bsb_helper/bsb_db_decode.mli
+++ b/jscomp/bsb_helper/bsb_db_decode.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2019 - Present Authors of ReScript
- * 
+(* Copyright (C) 2019 - Present Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/core/js_block_runtime.mli
+++ b/jscomp/core/js_block_runtime.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2019- Authors of ReScript
- * 
+(* Copyright (C) 2019- Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/core/js_cmj_load.mli
+++ b/jscomp/core/js_cmj_load.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) Authors of ReScript
- * 
+(* Copyright (C) Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/core/js_dump_import_export.mli
+++ b/jscomp/core/js_dump_import_export.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017 Authors of ReScript
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/core/js_dump_program.mli
+++ b/jscomp/core/js_dump_program.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/core/js_dump_property.mli
+++ b/jscomp/core/js_dump_property.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017 Authors of ReScript
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/core/js_dump_string.mli
+++ b/jscomp/core/js_dump_string.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017 Authors of ReScript
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/core/js_name_of_module_id.mli
+++ b/jscomp/core/js_name_of_module_id.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/core/js_packages_info.mli
+++ b/jscomp/core/js_packages_info.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017 Authors of ReScript
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/core/js_packages_state.mli
+++ b/jscomp/core/js_packages_state.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017 Authors of ReScript
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/core/js_pass_get_used.mli
+++ b/jscomp/core/js_pass_get_used.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2020- Authors of ReScript
- * 
+(* Copyright (C) 2020- Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/core/lam_arity.ml
+++ b/jscomp/core/lam_arity.ml
@@ -1,5 +1,5 @@
 (* Copyright (C) Hongbo Zhang, Authors of ReScript
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/core/lam_arity.mli
+++ b/jscomp/core/lam_arity.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) Authors of ReScript
- * 
+(* Copyright (C) Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/core/lam_check.mli
+++ b/jscomp/core/lam_check.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2018 Authors of ReScript
+(* Copyright (C) 2018 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/core/lam_compat.mli
+++ b/jscomp/core/lam_compat.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2018 Authors of ReScript
+(* Copyright (C) 2018 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/core/lam_constant.mli
+++ b/jscomp/core/lam_constant.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2018- Authors of ReScript
+(* Copyright (C) 2018- Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/core/lam_constant_convert.mli
+++ b/jscomp/core/lam_constant_convert.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2018- Authors of ReScript
+(* Copyright (C) 2018- Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/core/lam_convert.mli
+++ b/jscomp/core/lam_convert.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2018 - Authors of ReScript
- * 
+(* Copyright (C) 2018 - Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/core/lam_exit_count.mli
+++ b/jscomp/core/lam_exit_count.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2018 Authors of ReScript
+(* Copyright (C) 2018 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/core/lam_free_variables.mli
+++ b/jscomp/core/lam_free_variables.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2018 Authors of ReScript
+(* Copyright (C) 2018 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/core/lam_hit.mli
+++ b/jscomp/core/lam_hit.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2015 - Authors of ReScript
+(* Copyright (C) 2015 - Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/core/lam_id_kind.mli
+++ b/jscomp/core/lam_id_kind.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) Authors of ReScript
- * 
+(* Copyright (C) Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/core/lam_iter.mli
+++ b/jscomp/core/lam_iter.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2018 - Authors of ReScript
+(* Copyright (C) 2018 - Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/core/lam_primitive.mli
+++ b/jscomp/core/lam_primitive.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2018 Authors of ReScript
+(* Copyright (C) 2018 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/core/lam_scc.mli
+++ b/jscomp/core/lam_scc.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2018 Authors of ReScript
- * 
+(* Copyright (C) 2018 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/core/lam_subst.mli
+++ b/jscomp/core/lam_subst.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/core/lam_var_stats.mli
+++ b/jscomp/core/lam_var_stats.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2018 Authors of ReScript
- * 
+(* Copyright (C) 2018 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/core/matching_polyfill.mli
+++ b/jscomp/core/matching_polyfill.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2020- Authors of ReScript
+(* Copyright (C) 2020- Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/core/res_compmisc.mli
+++ b/jscomp/core/res_compmisc.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2015-2020 Authors of ReScript
+(* Copyright (C) 2015-2020 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/depends/bspack_ast_extract.mli
+++ b/jscomp/depends/bspack_ast_extract.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2020 - Authors of ReScript
- * 
+(* Copyright (C) 2020 - Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/ext/bsc_args.mli
+++ b/jscomp/ext/bsc_args.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2020- Authors of ReScript
+(* Copyright (C) 2020- Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/ext/ext_digest.mli
+++ b/jscomp/ext/ext_digest.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2019- Authors of ReScript
- * 
+(* Copyright (C) 2019- Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/ext/ext_json_noloc.mli
+++ b/jscomp/ext/ext_json_noloc.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017- Authors of ReScript
+(* Copyright (C) 2017- Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/ext/ext_modulename.mli
+++ b/jscomp/ext/ext_modulename.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/ext/ext_namespace_encode.mli
+++ b/jscomp/ext/ext_namespace_encode.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2020- Authors of ReScript
- * 
+(* Copyright (C) 2020- Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/ext/ext_obj.mli
+++ b/jscomp/ext/ext_obj.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2019-Present Authors of ReScript 
- * 
+(* Copyright (C) 2019-Present Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/ext/ext_path.mli
+++ b/jscomp/ext/ext_path.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/ext/ext_stack.mli
+++ b/jscomp/ext/ext_stack.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/ext/ext_string_array.mli
+++ b/jscomp/ext/ext_string_array.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2020 - Present Authors of ReScript
- * 
+(* Copyright (C) 2020 - Present Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/ext/js_reserved_map.mli
+++ b/jscomp/ext/js_reserved_map.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2019-Present Authors of ReScript
+(* Copyright (C) 2019-Present Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/frontend/ast_compatible.mli
+++ b/jscomp/frontend/ast_compatible.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2018 Authors of ReScript
- * 
+(* Copyright (C) 2018 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/frontend/ast_config.mli
+++ b/jscomp/frontend/ast_config.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2020 Authors of ReScript
+(* Copyright (C) 2020 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/frontend/ast_core_type_class_type.mli
+++ b/jscomp/frontend/ast_core_type_class_type.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2018 Authors of ReScript
- * 
+(* Copyright (C) 2018 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/frontend/ast_derive_abstract.mli
+++ b/jscomp/frontend/ast_derive_abstract.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/frontend/ast_derive_js_mapper.mli
+++ b/jscomp/frontend/ast_derive_js_mapper.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/frontend/ast_exp_apply.mli
+++ b/jscomp/frontend/ast_exp_apply.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2018 Authors of ReScript
- * 
+(* Copyright (C) 2018 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/frontend/ast_exp_extension.mli
+++ b/jscomp/frontend/ast_exp_extension.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2018 Authors of ReScript
- * 
+(* Copyright (C) 2018 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/frontend/ast_exp_handle_external.mli
+++ b/jscomp/frontend/ast_exp_handle_external.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2020 Authors of ReScript
- * 
+(* Copyright (C) 2020 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/frontend/ast_external.mli
+++ b/jscomp/frontend/ast_external.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2018 Authors of ReScript
+(* Copyright (C) 2018 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/frontend/ast_polyvar.mli
+++ b/jscomp/frontend/ast_polyvar.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/frontend/ast_reason_pp.mli
+++ b/jscomp/frontend/ast_reason_pp.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2019- Authors of ReScript
- * 
+(* Copyright (C) 2019- Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/frontend/ast_tdcls.mli
+++ b/jscomp/frontend/ast_tdcls.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2018 Authors of ReScript
+(* Copyright (C) 2018 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/frontend/ast_tuple_pattern_flatten.mli
+++ b/jscomp/frontend/ast_tuple_pattern_flatten.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2018 Authors of ReScript
+(* Copyright (C) 2018 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/frontend/ast_typ_uncurry.mli
+++ b/jscomp/frontend/ast_typ_uncurry.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2020 Authors of ReScript
- * 
+(* Copyright (C) 2020 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/frontend/ast_uncurry_apply.mli
+++ b/jscomp/frontend/ast_uncurry_apply.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2020- Authors of ReScript
- * 
+(* Copyright (C) 2020- Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/frontend/ast_uncurry_gen.mli
+++ b/jscomp/frontend/ast_uncurry_gen.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2020- Authors of ReScript
- * 
+(* Copyright (C) 2020- Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/frontend/bs_flow_ast_utils.mli
+++ b/jscomp/frontend/bs_flow_ast_utils.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2020 - Authors of ReScript 
+(* Copyright (C) 2020 - Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/frontend/classify_function.mli
+++ b/jscomp/frontend/classify_function.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2020- Authors of ReScript
- * 
+(* Copyright (C) 2020- Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/frontend/ppx_driver.mli
+++ b/jscomp/frontend/ppx_driver.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2019- Authors of ReScript
- * 
+(* Copyright (C) 2019- Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/others/belt_Float.mli
+++ b/jscomp/others/belt_Float.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/others/belt_HashMap.mli
+++ b/jscomp/others/belt_HashMap.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2018 Authors of ReScript
+(* Copyright (C) 2018 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/others/belt_Int.mli
+++ b/jscomp/others/belt_Int.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/others/belt_List.mli
+++ b/jscomp/others/belt_List.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017 Authors of ReScript
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/others/belt_MapDict.mli
+++ b/jscomp/others/belt_MapDict.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/others/belt_MutableMap.mli
+++ b/jscomp/others/belt_MutableMap.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017 Authors of ReScript
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/others/belt_MutableSet.mli
+++ b/jscomp/others/belt_MutableSet.mli
@@ -1,5 +1,5 @@
 
-(* Copyright (C) 2017 Authors of ReScript
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/others/belt_MutableSetInt.mli
+++ b/jscomp/others/belt_MutableSetInt.mli
@@ -1,6 +1,6 @@
 # 1 "others/setm.cppo.mli"
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/others/belt_MutableSetString.mli
+++ b/jscomp/others/belt_MutableSetString.mli
@@ -1,6 +1,6 @@
 # 1 "others/setm.cppo.mli"
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/others/belt_MutableStack.mli
+++ b/jscomp/others/belt_MutableStack.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/others/belt_Option.mli
+++ b/jscomp/others/belt_Option.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017 Authors of ReScript
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/others/belt_Range.mli
+++ b/jscomp/others/belt_Range.mli
@@ -1,6 +1,6 @@
 
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/others/belt_Result.mli
+++ b/jscomp/others/belt_Result.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017 Authors of ReScript
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/others/belt_Set.mli
+++ b/jscomp/others/belt_Set.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017 Authors of ReScript
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/others/belt_SetDict.mli
+++ b/jscomp/others/belt_SetDict.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/others/belt_SortArray.mli
+++ b/jscomp/others/belt_SortArray.mli
@@ -1,5 +1,5 @@
 
-(* Copyright (C) 2017 Authors of ReScript
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/others/belt_internalAVLset.mli
+++ b/jscomp/others/belt_internalAVLset.mli
@@ -1,6 +1,6 @@
 
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/others/belt_internalBuckets.mli
+++ b/jscomp/others/belt_internalBuckets.mli
@@ -1,4 +1,4 @@
-(* Copyright (C) 2017 Authors of ReScript
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/jscomp/others/belt_internalBucketsType.mli
+++ b/jscomp/others/belt_internalBucketsType.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2018 Authors of ReScript
- * 
+(* Copyright (C) 2018 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/others/js_mapperRt.mli
+++ b/jscomp/others/js_mapperRt.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/others/setm.cppo.mli
+++ b/jscomp/others/setm.cppo.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/outcome_printer/outcome_printer_ns.mli
+++ b/jscomp/outcome_printer/outcome_printer_ns.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2017 Authors of ReScript
- * 
+(* Copyright (C) 2017 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/runtime/caml_hash_primitive.mli
+++ b/jscomp/runtime/caml_hash_primitive.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2018 Authors of ReScript
- * 
+(* Copyright (C) 2018 Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/jscomp/runtime/caml_splice_call.mli
+++ b/jscomp/runtime/caml_splice_call.mli
@@ -1,5 +1,5 @@
-(* Copyright (C) 2019- Authors of ReScript
- * 
+(* Copyright (C) 2019- Hongbo Zhang, Authors of ReScript
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or


### PR DESCRIPTION
This change builds on #4998 by adding the same attribution text to the `.mli` files.

The PR didn't include a specific title or description related to attribution, so I'm only guessing here, but it looks like there was an oversight and these files were missed.