### PR TITLE
[Super errors] Remove useless spaces from old Format's indentation logic

### DIFF
--- a/jscomp/build_tests/super_errors/expected/arity_mismatch.re.expected
+++ b/jscomp/build_tests/super_errors/expected/arity_mismatch.re.expected
@@ -1,9 +1,9 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/arity_mismatch.re[0m:[2m3:21-27[0m
-  
+
   1 [2m│[0m 
   2 [2m│[0m let makeVar = (. ~f, ()) => 34;
   [1;31m3[0m [2m│[0m let makeVariables = [1;31mmakeVar[0m(. ~f=f => f);
-  
+
   This function expected [1;33m2[0m arguments, but got [1;31m1[0m

--- a/jscomp/build_tests/super_errors/expected/arity_mismatch2.re.expected
+++ b/jscomp/build_tests/super_errors/expected/arity_mismatch2.re.expected
@@ -1,9 +1,9 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/arity_mismatch2.re[0m:[2m3:21-27[0m
-  
+
   1 [2m│[0m 
   2 [2m│[0m let makeVar = (. f, ()) => 34;
   [1;31m3[0m [2m│[0m let makeVariables = [1;31mmakeVar[0m(. 1,2,3);
-  
+
   This function expected [1;33m2[0m arguments, but got [1;31m3[0m

--- a/jscomp/build_tests/super_errors/expected/arity_mismatch3.re.expected
+++ b/jscomp/build_tests/super_errors/expected/arity_mismatch3.re.expected
@@ -1,7 +1,7 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/arity_mismatch3.re[0m:[2m1:23-35[0m
-  
+
   [1;31m1[0m [2m│[0m Belt.Array.mapU([||], [1;31m(. a, b) => 1[0m);
-  
+
   This function expected [1;33m1[0m argument, but got [1;31m2[0m

--- a/jscomp/build_tests/super_errors/expected/bucklescript.re.expected
+++ b/jscomp/build_tests/super_errors/expected/bucklescript.re.expected
@@ -1,12 +1,12 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/bucklescript.re[0m:[2m4:1-3[0m
-  
+
   2 [2m│[0m let app = [@bs] (f, x, y) => f(x);
   3 [2m│[0m 
   [1;31m4[0m [2m│[0m [1;31mapp[0m(((x) => x + 1), 2);
   5 [2m│[0m 
-  
+
   This is an uncurried ReScript function. [1;33mIt must be applied with a dot[0m.
   
   Like this: [1;33mfoo(. a, b)[0m

--- a/jscomp/build_tests/super_errors/expected/collections.re.expected
+++ b/jscomp/build_tests/super_errors/expected/collections.re.expected
@@ -1,11 +1,11 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/collections.re[0m:[2m2:8-14[0m
-  
+
   1 [2m│[0m /* wrong type in a list */
   [1;31m2[0m [2m│[0m [1, 2, [1;31m"Hello"[0m] -> ignore;
   3 [2m│[0m 
-  
+
   This has type: [1;31mstring[0m
   Somewhere wanted: [1;33mint[0m
   

--- a/jscomp/build_tests/super_errors/expected/curry_in_uncurry.re.expected
+++ b/jscomp/build_tests/super_errors/expected/curry_in_uncurry.re.expected
@@ -1,9 +1,9 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/curry_in_uncurry.re[0m:[2m3:1[0m
-  
+
   1 [2m│[0m let f = (a,b) => a + b;
   2 [2m│[0m 
   [1;31m3[0m [2m│[0m [1;31mf[0m(.2,2)->Js.log;
-  
+
   This function is a curried function where an uncurried function is expected

--- a/jscomp/build_tests/super_errors/expected/highlighting1.re.expected
+++ b/jscomp/build_tests/super_errors/expected/highlighting1.re.expected
@@ -1,11 +1,11 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/highlighting1.re[0m:[2m1:14-3:3[0m
-  
+
   [1;31m1[0m [2m│[0m let a: int = [1;31m"hel[0m
   [1;31m2[0m [2m│[0m 
   [1;31m3[0m [2m│[0m [1;31mlo"[0m;
-  
+
   This has type: [1;31mstring[0m
   Somewhere wanted: [1;33mint[0m
   

--- a/jscomp/build_tests/super_errors/expected/highlighting2.re.expected
+++ b/jscomp/build_tests/super_errors/expected/highlighting2.re.expected
@@ -1,13 +1,13 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/highlighting2.re[0m:[2m2:36-4:25[0m
-  
+
   1 [2m┆[0m 
   [1;31m2[0m [2m┆[0m let a: int = [1;31m"hel[0m
   [1;31m3[0m [2m┆[0m 
   [1;31m4[0m [2m┆[0m [1;31mlo"[0m;
   5 [2m┆[0m 
-  
+
   This has type: [1;31mstring[0m
   Somewhere wanted: [1;33mint[0m
   

--- a/jscomp/build_tests/super_errors/expected/highlighting3.re.expected
+++ b/jscomp/build_tests/super_errors/expected/highlighting3.re.expected
@@ -1,13 +1,13 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/highlighting3.re[0m:[2m2:14-4:16[0m
-  
+
   1 [2m│[0m 
   [1;31m2[0m [2m│[0m let a: int = [1;31m"helllllll[0m
   [1;31m3[0m [2m│[0m 
   [1;31m4[0m [2m│[0m [1;31mloooooooooooooo"[0m;
   5 [2m│[0m 
-  
+
   This has type: [1;31mstring[0m
   Somewhere wanted: [1;33mint[0m
   

--- a/jscomp/build_tests/super_errors/expected/highlighting4.re.expected
+++ b/jscomp/build_tests/super_errors/expected/highlighting4.re.expected
@@ -1,10 +1,10 @@
 
   [1;31mWarning number 3[0m (configured as error) 
   [36m/.../fixtures/highlighting4.re[0m:[2m5:10[0m
-  
+
   3 [2m│[0m [@deprecated]
   4 [2m│[0m type a = int;
   [1;31m5[0m [2m│[0m type b = [1;31ma[0m
   6 [2m│[0m 
-  
+
   deprecated: a

--- a/jscomp/build_tests/super_errors/expected/highlighting5.re.expected
+++ b/jscomp/build_tests/super_errors/expected/highlighting5.re.expected
@@ -1,12 +1,12 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/highlighting5.re[0m:[2m2:14-100[0m
-  
+
   1 [2m│[0m /* overflows in the terminal */
   [1;31m2[0m [2m│[0m let a: int = [1;31m"hellllllllllllllllllllllllllllllllllllllllllllllllllllllll[0m
       [1;31mlllllllllllllllllllllllllll";[0m
   3 [2m│[0m 
-  
+
   This has type: [1;31mstring[0m
   Somewhere wanted: [1;33mint[0m
   

--- a/jscomp/build_tests/super_errors/expected/highlighting6.re.expected
+++ b/jscomp/build_tests/super_errors/expected/highlighting6.re.expected
@@ -1,11 +1,11 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/highlighting6.re[0m:[2m2:9-13[0m
-  
+
   1 [2m│[0m let aaaaa = 10;
   [1;31m2[0m [2m│[0m let b = [1;31maaaab[0m;
   3 [2m│[0m 
-  
+
   The value aaaab can't be found
   
   [1;33mHint: Did you mean aaaaa?[0m

--- a/jscomp/build_tests/super_errors/expected/method_arity_mismatch.re.expected
+++ b/jscomp/build_tests/super_errors/expected/method_arity_mismatch.re.expected
@@ -1,10 +1,10 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/method_arity_mismatch.re[0m:[2m3:5-11[0m
-  
+
   1 [2m│[0m let f = ( obj ) => {
   2 [2m│[0m     obj##hi (1,2);
   [1;31m3[0m [2m│[0m     [1;31mobj##hi[0m (1)
   4 [2m│[0m }
-  
+
   This method has arity2 but was expected arity1

--- a/jscomp/build_tests/super_errors/expected/modules1.re.expected
+++ b/jscomp/build_tests/super_errors/expected/modules1.re.expected
@@ -1,10 +1,10 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/modules1.re[0m:[2m1:9-13[0m
-  
+
   [1;31m1[0m [2m│[0m let b = [1;31mFoo.b[0m;
   2 [2m│[0m 
-  
+
   [1;33mThe module or file Foo can't be found.[0m
   - If it's a third-party dependency:
     - Did you list it in bsconfig.json?

--- a/jscomp/build_tests/super_errors/expected/modules2.re.expected
+++ b/jscomp/build_tests/super_errors/expected/modules2.re.expected
@@ -1,7 +1,7 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/modules2.re[0m:[2m1:9-14[0m
-  
+
   [1;31m1[0m [2m│[0m let b = [1;31mList.b[0m;
-  
+
   The value b can't be found in List

--- a/jscomp/build_tests/super_errors/expected/modules3.re.expected
+++ b/jscomp/build_tests/super_errors/expected/modules3.re.expected
@@ -1,13 +1,13 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/modules3.re[0m:[2m11:11-21[0m
-  
+
    9 [2m│[0m };
   10 [2m│[0m 
   [1;31m11[0m [2m│[0m let asd = [1;31mA.B.C.D.aaa[0m;
   12 [2m│[0m 
   13 [2m│[0m 
-  
+
   The value aaa can't be found in A.B.C.D
   
   [1;33mHint: Did you mean aaaa?[0m

--- a/jscomp/build_tests/super_errors/expected/moreArguments1.re.expected
+++ b/jscomp/build_tests/super_errors/expected/moreArguments1.re.expected
@@ -1,9 +1,9 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/moreArguments1.re[0m:[2m2:9-15[0m
-  
+
   1 [2m│[0m let x = (~a, ~b) => a + b;
   [1;31m2[0m [2m│[0m let y = [1;31mx(~a=2)[0m + 2;
   3 [2m│[0m 
-  
+
   [1;33mThis call is missing an argument[0m of type (~b: int)

--- a/jscomp/build_tests/super_errors/expected/moreArguments2.re.expected
+++ b/jscomp/build_tests/super_errors/expected/moreArguments2.re.expected
@@ -1,9 +1,9 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/moreArguments2.re[0m:[2m2:9-12[0m
-  
+
   1 [2m│[0m let x = (a, b) => a + b;
   [1;31m2[0m [2m│[0m let y = [1;31mx(2)[0m + 2;
   3 [2m│[0m 
-  
+
   [1;33mThis call is missing an argument[0m of type int

--- a/jscomp/build_tests/super_errors/expected/moreArguments3.re.expected
+++ b/jscomp/build_tests/super_errors/expected/moreArguments3.re.expected
@@ -1,9 +1,9 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/moreArguments3.re[0m:[2m2:9-12[0m
-  
+
   1 [2m│[0m let x = (a, b, c, d) => a + b;
   [1;31m2[0m [2m│[0m let y = [1;31mx(2)[0m + 2;
   3 [2m│[0m 
-  
+
   [1;33mThis call is missing arguments[0m of type: int, 'a, 'b

--- a/jscomp/build_tests/super_errors/expected/moreArguments4.re.expected
+++ b/jscomp/build_tests/super_errors/expected/moreArguments4.re.expected
@@ -1,9 +1,9 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/moreArguments4.re[0m:[2m2:9-12[0m
-  
+
   1 [2m│[0m let x = (a, ~b, ~c, ~d) => a + b;
   [1;31m2[0m [2m│[0m let y = [1;31mx(2)[0m + 2;
   3 [2m│[0m 
-  
+
   [1;33mThis call is missing arguments[0m of type: (~b: int), (~c: 'a), (~d: 'b)

--- a/jscomp/build_tests/super_errors/expected/moreArguments5.re.expected
+++ b/jscomp/build_tests/super_errors/expected/moreArguments5.re.expected
@@ -1,10 +1,10 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/moreArguments5.re[0m:[2m5:9-12[0m
-  
+
   3 [2m│[0m };
   4 [2m│[0m let x = (a, b, c, d) => {Sub.a: 2};
   [1;31m5[0m [2m│[0m let y = [1;31mx(2)[0m.Sub.a;
   6 [2m│[0m 
-  
+
   [1;33mThis call is missing arguments[0m of type: 'a, 'b, 'c

--- a/jscomp/build_tests/super_errors/expected/partial_app.re.expected
+++ b/jscomp/build_tests/super_errors/expected/partial_app.re.expected
@@ -1,10 +1,10 @@
 
   [1;31mWarning number 109[0m (configured as error) 
   [36m/.../fixtures/partial_app.re[0m:[2m5:1-7[0m
-  
+
   3 [2m│[0m };
   4 [2m│[0m 
   [1;31m5[0m [2m│[0m [1;31mf (1,2)[0m;
   6 [2m│[0m 
-  
+
   Toplevel expression is expected to have unit type.

--- a/jscomp/build_tests/super_errors/expected/primitives1.re.expected
+++ b/jscomp/build_tests/super_errors/expected/primitives1.re.expected
@@ -1,11 +1,11 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/primitives1.re[0m:[2m2:1-2[0m
-  
+
   1 [2m│[0m /* got float, wanted int */
   [1;31m2[0m [2m│[0m [1;31m2.[0m + 2;
   3 [2m│[0m 
-  
+
   This has type: [1;31mfloat[0m
   Somewhere wanted: [1;33mint[0m
   

--- a/jscomp/build_tests/super_errors/expected/primitives10.re.expected
+++ b/jscomp/build_tests/super_errors/expected/primitives10.re.expected
@@ -1,11 +1,11 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/primitives10.re[0m:[2m2:9-13[0m
-  
+
   1 [2m│[0m let aaaaa = 10;
   [1;31m2[0m [2m│[0m let b = [1;31maaaab[0m;
   3 [2m│[0m 
-  
+
   The value aaaab can't be found
   
   [1;33mHint: Did you mean aaaaa?[0m

--- a/jscomp/build_tests/super_errors/expected/primitives11.re.expected
+++ b/jscomp/build_tests/super_errors/expected/primitives11.re.expected
@@ -1,12 +1,12 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/primitives11.re[0m:[2m5:11-27[0m
-  
+
   3 [2m│[0m type a = option(aa)
   4 [2m│[0m type b = option(bb)
   [1;31m5[0m [2m│[0m let a:a = [1;31m(Some(Some(5)):b)[0m
   6 [2m│[0m 
-  
+
   This has type: [1;31mb[0m [2m(defined as[0m [1;31moption(bb)[0m[2m)[0m
   Somewhere wanted: [1;33ma[0m [2m(defined as[0m [1;33moption(aa)[0m[2m)[0m
   

--- a/jscomp/build_tests/super_errors/expected/primitives2.re.expected
+++ b/jscomp/build_tests/super_errors/expected/primitives2.re.expected
@@ -1,11 +1,11 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/primitives2.re[0m:[2m2:1[0m
-  
+
   1 [2m│[0m /* got int, wanted string */
   [1;31m2[0m [2m│[0m [1;31m2[0m ++ " things";
   3 [2m│[0m 
-  
+
   This has type: [1;31mint[0m
   Somewhere wanted: [1;33mstring[0m
   

--- a/jscomp/build_tests/super_errors/expected/primitives3.re.expected
+++ b/jscomp/build_tests/super_errors/expected/primitives3.re.expected
@@ -1,11 +1,11 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/primitives3.re[0m:[2m3:1[0m
-  
+
   1 [2m│[0m /* Too many arguments */
   2 [2m│[0m let x = (a) => a + 2;
   [1;31m3[0m [2m│[0m [1;31mx[0m(2, 4);
   4 [2m│[0m 
-  
+
   This function has type [1;33mint => int[0m
   It only accepts 1 argument; here, it's called with more.

--- a/jscomp/build_tests/super_errors/expected/primitives4.re.expected
+++ b/jscomp/build_tests/super_errors/expected/primitives4.re.expected
@@ -1,11 +1,11 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/primitives4.re[0m:[2m3:1[0m
-  
+
   1 [2m│[0m /* Not a function */
   2 [2m│[0m let x = 10;
   [1;31m3[0m [2m│[0m [1;31mx[0m(10);
   4 [2m│[0m 
-  
+
   This expression has type int
   It is not a function.

--- a/jscomp/build_tests/super_errors/expected/primitives5.re.expected
+++ b/jscomp/build_tests/super_errors/expected/primitives5.re.expected
@@ -1,10 +1,10 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/primitives5.re[0m:[2m3:1-5[0m
-  
+
   1 [2m│[0m /* Not enough arguments */
   2 [2m│[0m type x = X(int, float);
   [1;31m3[0m [2m│[0m [1;31mX(10)[0m -> ignore;
   4 [2m│[0m 
-  
+
   This variant constructor, X, expects 2 arguments; here, we've only found 1.

--- a/jscomp/build_tests/super_errors/expected/primitives6.re.expected
+++ b/jscomp/build_tests/super_errors/expected/primitives6.re.expected
@@ -1,12 +1,12 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/primitives6.re[0m:[2m3:7-8[0m
-  
+
   1 [2m│[0m /* Wrong constructor argument */
   2 [2m│[0m type x = X(int, float);
   [1;31m3[0m [2m│[0m X(10, [1;31m10[0m) -> ignore;
   4 [2m│[0m 
-  
+
   This has type: [1;31mint[0m
   Somewhere wanted: [1;33mfloat[0m
   

--- a/jscomp/build_tests/super_errors/expected/primitives7.re.expected
+++ b/jscomp/build_tests/super_errors/expected/primitives7.re.expected
@@ -1,12 +1,12 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/primitives7.re[0m:[2m3:28[0m
-  
+
   1 [2m│[0m /* Wanted list(float), found list(int) */
   2 [2m│[0m let a = [1,2,3];
   [1;31m3[0m [2m│[0m List.map(((n) => n +. 2.), [1;31ma[0m);
   4 [2m│[0m 
-  
+
   This has type: [1;31mlist(int)[0m
   Somewhere wanted: [1;33mlist(float)[0m
   

--- a/jscomp/build_tests/super_errors/expected/primitives8.re.expected
+++ b/jscomp/build_tests/super_errors/expected/primitives8.re.expected
@@ -1,8 +1,8 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/primitives8.re[0m:[2m1:11-13[0m
-  
+
   [1;31m1[0m [2m│[0m let asd = [1;31maaa[0m;
   2 [2m│[0m 
-  
+
   The value aaa can't be found

--- a/jscomp/build_tests/super_errors/expected/primitives9.re.expected
+++ b/jscomp/build_tests/super_errors/expected/primitives9.re.expected
@@ -1,10 +1,10 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/primitives9.re[0m:[2m1:14-20[0m
-  
+
   [1;31m1[0m [2m│[0m let a: int = [1;31m"hello"[0m
   2 [2m│[0m 
-  
+
   This has type: [1;31mstring[0m
   Somewhere wanted: [1;33mint[0m
   

--- a/jscomp/build_tests/super_errors/expected/syntaxErrors1.re.expected
+++ b/jscomp/build_tests/super_errors/expected/syntaxErrors1.re.expected
@@ -3,7 +3,7 @@ Error: syntax error, consider adding a `;' before
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/syntaxErrors1.re[0m
-  
+
   [1;33mThere's been an error running Reason's parser on a file.[0m
   If the message doesn't help, check for errors slightly above.
   Please file an issue on github.com/facebook/reason. Thanks!

--- a/jscomp/build_tests/super_errors/expected/syntaxErrors2.re.expected
+++ b/jscomp/build_tests/super_errors/expected/syntaxErrors2.re.expected
@@ -3,7 +3,7 @@ Error: Syntax error
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/syntaxErrors2.re[0m
-  
+
   [1;33mThere's been an error running Reason's parser on a file.[0m
   If the message doesn't help, check for errors slightly above.
   Please file an issue on github.com/facebook/reason. Thanks!

--- a/jscomp/build_tests/super_errors/expected/syntaxErrors3.re.expected
+++ b/jscomp/build_tests/super_errors/expected/syntaxErrors3.re.expected
@@ -3,7 +3,7 @@ Error: Unclosed "(" (opened line 1, column 18)
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/syntaxErrors3.re[0m
-  
+
   [1;33mThere's been an error running Reason's parser on a file.[0m
   If the message doesn't help, check for errors slightly above.
   Please file an issue on github.com/facebook/reason. Thanks!

--- a/jscomp/build_tests/super_errors/expected/syntaxErrors4.re.expected
+++ b/jscomp/build_tests/super_errors/expected/syntaxErrors4.re.expected
@@ -1,7 +1,7 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/syntaxErrors4.re[0m:[2m5:13-21:3[0m
-  
+
    3 [2m│[0m /* */
    4 [2m│[0m /* */
    [1;31m5[0m [2m│[0m let a:int = [1;31m"asdaaaaaaaaaaaaaaaaaaaaa[0m
@@ -11,7 +11,7 @@
   [1;31m21[0m [2m│[0m [1;31maa"[0m
   22 [2m│[0m /* */
   23 [2m│[0m /* */
-  
+
   This has type: [1;31mstring[0m
   Somewhere wanted: [1;33mint[0m
   

--- a/jscomp/build_tests/super_errors/expected/syntaxErrors5.re.expected
+++ b/jscomp/build_tests/super_errors/expected/syntaxErrors5.re.expected
@@ -3,7 +3,7 @@ Error: Unclosed "(" (opened line 1, column 8)
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/syntaxErrors5.re[0m
-  
+
   [1;33mThere's been an error running Reason's parser on a file.[0m
   If the message doesn't help, check for errors slightly above.
   Please file an issue on github.com/facebook/reason. Thanks!

--- a/jscomp/build_tests/super_errors/expected/type1.re.expected
+++ b/jscomp/build_tests/super_errors/expected/type1.re.expected
@@ -1,10 +1,10 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/type1.re[0m:[2m1:9-10[0m
-  
+
   [1;31m1[0m [2m│[0m let x = [1;31m2.[0m + 2;
   2 [2m│[0m 
-  
+
   This has type: [1;31mfloat[0m
   Somewhere wanted: [1;33mint[0m
   

--- a/jscomp/build_tests/super_errors/expected/uncurry_in_curry.re.expected
+++ b/jscomp/build_tests/super_errors/expected/uncurry_in_curry.re.expected
@@ -1,11 +1,11 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/uncurry_in_curry.re[0m:[2m3:1[0m
-  
+
   1 [2m│[0m let f = (.a,b) => a + b;
   2 [2m│[0m 
   [1;31m3[0m [2m│[0m [1;31mf[0m(2,2);
-  
+
   This is an uncurried ReScript function. [1;33mIt must be applied with a dot[0m.
   
   Like this: [1;33mfoo(. a, b)[0m

--- a/jscomp/build_tests/super_errors/expected/unused_warnings.re.expected
+++ b/jscomp/build_tests/super_errors/expected/unused_warnings.re.expected
@@ -1,19 +1,19 @@
 
   [1;33mWarning number 32[0m
   [36m/.../fixtures/unused_warnings.re[0m:[2m1:5[0m
-  
+
   [1;33m1[0m [2m│[0m let [1;33ma[0m = 3;
   2 [2m│[0m let a = 33 + 3; 
   3 [2m│[0m let a = 33 + 3 + 3;
-  
+
   unused value a.
-  
+
 
   [1;33mWarning number 32[0m
   [36m/.../fixtures/unused_warnings.re[0m:[2m2:5[0m
-  
+
   1 [2m│[0m let a = 3;
   [1;33m2[0m [2m│[0m let [1;33ma[0m = 33 + 3; 
   3 [2m│[0m let a = 33 + 3 + 3;
-  
+
   unused value a.

--- a/jscomp/build_tests/super_errors/expected/warnings1.re.expected
+++ b/jscomp/build_tests/super_errors/expected/warnings1.re.expected
@@ -1,12 +1,12 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/warnings1.re[0m:[2m3:3-7[0m
-  
+
   1 [2m│[0m let x = (a, b) => a + b;
   2 [2m│[0m let z = () => {
   [1;31m3[0m [2m│[0m   [1;31mx(10)[0m;
   4 [2m│[0m   10
   5 [2m│[0m };
-  
+
   This has type: [1;31mint => int[0m
   Somewhere wanted: [1;33munit[0m

--- a/jscomp/build_tests/super_errors/expected/warnings2.re.expected
+++ b/jscomp/build_tests/super_errors/expected/warnings2.re.expected
@@ -1,11 +1,11 @@
 
   [1;31mWe've found a bug for you![0m
   [36m/.../fixtures/warnings2.re[0m:[2m2:3-4[0m
-  
+
   1 [2m│[0m let z = () => {
   [1;31m2[0m [2m│[0m   [1;31m10[0m;
   3 [2m│[0m   10
   4 [2m│[0m };
-  
+
   This has type: [1;31mint[0m
   Somewhere wanted: [1;33munit[0m

--- a/jscomp/build_tests/super_errors/expected/warnings3.re.expected
+++ b/jscomp/build_tests/super_errors/expected/warnings3.re.expected
@@ -1,34 +1,34 @@
 
   [1;33mWarning number 3[0m
   [36m/.../fixtures/warnings3.re[0m:[2m1:9-23[0m
-  
+
   [1;33m1[0m [2m│[0m let _ = [1;33mstring_of_float[0m(34.)
   2 [2m│[0m let _ = string_of_float(34.)
   3 [2m│[0m let _ = string_of_float(34.)
-  
+
   deprecated: Pervasives.string_of_float
 Please use Js.Float.toString instead, string_of_float generates unparseable floats
-  
+
 
   [1;33mWarning number 3[0m
   [36m/.../fixtures/warnings3.re[0m:[2m2:9-23[0m
-  
+
   1 [2m│[0m let _ = string_of_float(34.)
   [1;33m2[0m [2m│[0m let _ = [1;33mstring_of_float[0m(34.)
   3 [2m│[0m let _ = string_of_float(34.)
   4 [2m│[0m 
-  
+
   deprecated: Pervasives.string_of_float
 Please use Js.Float.toString instead, string_of_float generates unparseable floats
-  
+
 
   [1;33mWarning number 3[0m
   [36m/.../fixtures/warnings3.re[0m:[2m3:9-23[0m
-  
+
   1 [2m│[0m let _ = string_of_float(34.)
   2 [2m│[0m let _ = string_of_float(34.)
   [1;33m3[0m [2m│[0m let _ = [1;33mstring_of_float[0m(34.)
   4 [2m│[0m 
-  
+
   deprecated: Pervasives.string_of_float
 Please use Js.Float.toString instead, string_of_float generates unparseable floats

--- a/jscomp/super_errors/super_code_frame.ml
+++ b/jscomp/super_errors/super_code_frame.ml
@@ -264,7 +264,4 @@ let print ~is_warning ~src ~startPos ~endPos =
       );
     end
   );
-  (* TODO: remove the extra space that catered to making existing tests pass *)
-  Buffer.add_string buf (col NoColor "  ");
   Buffer.contents buf
-

--- a/jscomp/super_errors/super_location.ml
+++ b/jscomp/super_errors/super_location.ml
@@ -51,9 +51,7 @@ let print ~message_kind intro ppf (loc : Location.t) =
       (* again: end_char is exclusive, so +1-1=0 *)
       Some ((start_line, start_char + 1), (end_line, end_char))
   in
-  (* TODO: remove the extra space that catered to making existing tests pass *)
-  fprintf ppf "  @[%a@]@,  " (print_loc ~normalizedRange) loc;
-  (* TODO: clean up *)
+  fprintf ppf "  @[%a@]@," (print_loc ~normalizedRange) loc;
   match normalizedRange with
   | None -> ()
   | Some _ -> begin
@@ -81,8 +79,7 @@ let print ~message_kind intro ppf (loc : Location.t) =
 let rec super_error_reporter ppf ({loc; msg; sub} : Location.error) =
   setup_colors ();
   (* open a vertical box. Everything in our message is indented 2 spaces *)
-  (* TODO: clean up after next PR *)
-  Format.fprintf ppf "@[<v 0>@,  %a@,  %s@,@]" (print ~message_kind:`error "We've found a bug for you!") loc msg;
+  Format.fprintf ppf "@[<v>@,  %a@,  %s@,@]" (print ~message_kind:`error "We've found a bug for you!") loc msg;
   List.iter (Format.fprintf ppf "@,@[%a@]" super_error_reporter) sub
 (* no need to flush here; location's report_exception (which uses this ultimately) flushes *)
 
@@ -95,8 +92,7 @@ let super_warning_printer loc ppf w =
   | `Active { Warnings. number = _; message = _; is_error; sub_locs = _} ->
     setup_colors ();
     let message_kind = if is_error then `warning_as_error else `warning in
-    (* TODO: clean up after next PR *)
-    Format.fprintf ppf "@[<v 0>@,  %a@,  %s@,  @]@."
+    Format.fprintf ppf "@[<v>@,  %a@,  %s@,@]@."
       (print ~message_kind ("Warning number " ^ (Warnings.number w |> string_of_int)))
       loc
       (Warnings.message w);


### PR DESCRIPTION
Follow-up of #5013
