### PR TITLE
Turn off debug mode type error stack trace again

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,9 @@ If this doesn't work (rare), then:
 
 > Note: production, only `path/to/bsc myTestFile.ml` is needed. During development, you need to pass the `-I jscomp/runtime/` flag for various reasons (e.g. to avoid cyclic dependencies).
 
+Tips:
+- To get a nice stack trace when you debug type errors from running `bsc`/`bsb`, uncomment the conditional compilation check in [`js_main.ml`](https://github.com/rescript-lang/rescript-compiler/blob/496c70d1d4e709c26dba23629e430dc944bd59f9/jscomp/main/js_main.ml#L501).
+
 ### Integration Test
 
 If you'd like to use your modified ReScript like an end-user, try:

--- a/jscomp/main/js_main.ml
+++ b/jscomp/main/js_main.ml
@@ -510,7 +510,7 @@ let _ : unit =
     exit 2
   | x -> 
     begin
-#if undefined BS_RELEASE_BUILD
+#if false (* undefined BS_RELEASE_BUILD *)
         Ext_obj.bt ();
 #end
       Location.report_exception ppf x;


### PR DESCRIPTION
Fixes #5034

This intentionally went in in #5024, but the extra debugging stack trace made some bsc/bsb diagnostics harder to read when working on the repo. So it's turned off again now. I've added a line in CONTRIBUTING.md on reactivating it, because it's a nice utility.
