### PR TITLE
Fix Js.String.match_ return type

### DIFF
--- a/jscomp/others/js_string.ml
+++ b/jscomp/others/js_string.ml
@@ -274,7 +274,7 @@ external localeCompare : t -> float = "localeCompare" [@@bs.send.pipe: t]
 ]}
 
 *)
-external match_ : Js_re.t -> t array option = "match" [@@bs.send.pipe: t] [@@bs.return {null_to_opt}]
+external match_ : Js_re.t -> t option array option = "match" [@@bs.send.pipe: t] [@@bs.return {null_to_opt}]
 
 (** [normalize str] returns the normalized Unicode string using Normalization Form Canonical (NFC) Composition.
 

--- a/jscomp/others/js_string2.ml
+++ b/jscomp/others/js_string2.ml
@@ -273,7 +273,7 @@ external localeCompare : t -> t -> float = "localeCompare" [@@bs.send]
 ]}
 
 *)
-external match_ : t -> Js_re.t -> t array option = "match" [@@bs.send] [@@bs.return {null_to_opt}]
+external match_ : t -> Js_re.t -> t option array option = "match" [@@bs.send] [@@bs.return {null_to_opt}]
 
 (** [normalize str] returns the normalized Unicode string using Normalization Form Canonical (NFC) Composition.
 

--- a/jscomp/test/js_string_test.ml
+++ b/jscomp/test/js_string_test.ml
@@ -84,10 +84,13 @@ let suites = Mt.[
     );
 
     "match", (fun _ ->
-      Eq(Some [| "na"; "na" |], "banana" |. Js.String2.match_ [%re "/na+/g"])
+      Eq(Some [| Some "na"; Some "na" |], "banana" |. Js.String2.match_ [%re "/na+/g"])
     );
     "match - no match", (fun _ ->
       Eq(None, "banana" |. Js.String2.match_ [%re "/nanana+/g"])
+    );
+    "match - not found capture groups", (fun _ ->
+      Eq(Some [| Some "hello "; None |], "hello word" |. Js.String2.match_ [%re "/hello (world)?/"] |. Belt.Option.map Js.Array.copy )
     );
 
     (* es2015 *)


### PR DESCRIPTION
Javscript String.prototype.match function can return `undefined` for optional capture groups that are not found, which breaks the type annotations since this is not added as a `Js.nullable`, it's not possible to deal with those undefined values since it can't be passed to `Js.Nullable.isNullable`.

Fixes #5066.

I used the following code to test this.

```ocaml
let m = Js.String.match_ [%re "/hello (world)?/"] "hello word";;

let n =
  match m with
  | Some(n) -> Js.Array.filter (fun a -> not (Js.Nullable.isNullable a)) n
  | None -> [||];;

Js.log n;;
```