### PR TITLE
scripts/ciTest.js: catch exceptions from main

### DIFF
--- a/scripts/ciTest.js
+++ b/scripts/ciTest.js
@@ -1,7 +1,7 @@
 //@ts-check
 var cp = require("child_process");
-
 var path = require("path");
+var fs = require("fs");
 
 var installGlobal = false;
 var ounitTest = false;
@@ -41,8 +41,6 @@ if (all) {
   bsbTest = true;
 }
 
-var fs = require("fs");
-
 function init() {
   var vendorOCamlPath = path.join(
     __dirname,
@@ -61,9 +59,7 @@ function init() {
   }
 }
 
-function main() {
-  init();
-
+function runTests() {
   // when binary was prebuilt, there can be no ocaml installation
   // var output =
   //     cp.execSync('which ocaml', { encoding: 'ascii' })
@@ -156,4 +152,13 @@ function main() {
   }
 }
 
+function main() {
+  try {
+    init();
+    runTests();
+  } catch (err) {
+    console.error(err);
+    process.exit(2);
+  }
+}
 main();


### PR DESCRIPTION
In recent Node.js versions, an uncaught exception becomes an UnhandledPromiseRejection and that makes the actual error hard/impossible to find:

https://app.circleci.com/pipelines/github/rescript-lang/rescript-compiler/3637/workflows/928d0272-43fe-4ac6-b981-114bdf3c5355/jobs/3759