### PR TITLE
rescript format bugfixes

### DIFF
--- a/scripts/rescript_format.js
+++ b/scripts/rescript_format.js
@@ -125,7 +125,7 @@ function main(argv, rescript_exe, bsc_exe) {
             ["-format", filename],
             (error, stdout, stderr) => {
               if (error === null) {
-                console.log(stdout.trimEnd());
+                process.stdout.write(stdout);
               } else {
                 console.log(stderr);
                 process.exit(2);
@@ -159,7 +159,7 @@ function main(argv, rescript_exe, bsc_exe) {
         child_process.execFile(bsc_exe, flags, (error, stdout, stderr) => {
           if (error === null) {
             if (!write) {
-              console.log(stdout);
+              process.stdout.write(stdout);
             }
           } else {
             console.log(stderr);

--- a/scripts/rescript_format.js
+++ b/scripts/rescript_format.js
@@ -119,6 +119,7 @@ function main(argv, rescript_exe, bsc_exe) {
         (async function () {
           var content = await readStdin();
           fs.writeFileSync(filename, content, "utf8");
+          process.addListener('exit', () => fs.unlinkSync(filename));
           child_process.execFile(
             bsc_exe,
             ["-format", filename],

--- a/scripts/rescript_format.js
+++ b/scripts/rescript_format.js
@@ -102,7 +102,7 @@ function main(argv, rescript_exe, bsc_exe) {
                 // todo
               } else {
                 // todo error handling
-                console.log(stderr);
+                console.error(stderr);
               }
             }
           );
@@ -127,7 +127,7 @@ function main(argv, rescript_exe, bsc_exe) {
               if (error === null) {
                 process.stdout.write(stdout);
               } else {
-                console.log(stderr);
+                console.error(stderr);
                 process.exit(2);
               }
             }
@@ -162,7 +162,7 @@ function main(argv, rescript_exe, bsc_exe) {
               process.stdout.write(stdout);
             }
           } else {
-            console.log(stderr);
+            console.error(stderr);
           }
         });
       });

--- a/scripts/rescript_format.js
+++ b/scripts/rescript_format.js
@@ -91,22 +91,24 @@ function main(argv, rescript_exe, bsc_exe) {
         process.exit(2);
       }
       files = output.stdout.split("\n").map((x) => x.trim());
+      var hasError = false;
       for (let arg of files) {
         if (isSupportedFile(arg)) {
           // console.log(`processing ${arg}`);
           child_process.execFile(
             bsc_exe,
             ["-o", arg, "-format", arg],
-            (error, stdout, stderr) => {
-              if (error === null) {
-                // todo
-              } else {
-                // todo error handling
+            (error, _stdout, stderr) => {
+              if (error !== null) {
                 console.error(stderr);
+                hasError = true;
               }
             }
           );
         }
+      }
+      if (hasError) {
+        process.exit(2);
       }
     } else if (use_stdin) {
       if (isSupportedStd(use_stdin)) {
@@ -153,6 +155,7 @@ function main(argv, rescript_exe, bsc_exe) {
           process.exit(2);
         }
       }
+      var hasError = false;
       files.forEach((file) => {
         var write = isSupportedFile(file);
         var flags = write ? ["-o", file, "-format", file] : ["-format", file];
@@ -163,9 +166,13 @@ function main(argv, rescript_exe, bsc_exe) {
             }
           } else {
             console.error(stderr);
+            hasError = true;
           }
         });
       });
+      if (hasError) {
+        process.exit(2);
+      }
     }
   } catch (e) {
     if (e instanceof arg.ArgError) {


### PR DESCRIPTION
- `rescript format -stdin`: clean up created temp file when we're done
- `rescript format file.{ml,mli,re,rei}`: don't add an extra newline at the end
- `rescript format`: only write valid code to `stdout`; errors go to `stderr`
- `rescript format`: non-zero exit code when subprocess fails

Fixes #5131 