### PR TITLE
rescript format -stdin: check if tmpfile exists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rescript",
-  "version": "10.0.0",
+  "version": "10.0.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rescript",
-      "version": "10.0.0",
+      "version": "10.0.0-beta.1",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "bin": {

--- a/scripts/rescript_format.js
+++ b/scripts/rescript_format.js
@@ -126,7 +126,9 @@ function main(argv, rescript_exe, bsc_exe) {
         );
         (async function () {
           var content = await readStdin();
-          fs.writeFileSync(filename, content, "utf8");
+          var fd = fs.openSync(filename, "wx", 0o600);
+          fs.writeFileSync(fd, content, "utf8");
+          fs.closeSync(fd);
           process.addListener("exit", () => fs.unlinkSync(filename));
           child_process.execFile(
             bsc_exe,

--- a/scripts/rescript_format.js
+++ b/scripts/rescript_format.js
@@ -126,7 +126,7 @@ function main(argv, rescript_exe, bsc_exe) {
         );
         (async function () {
           var content = await readStdin();
-          var fd = fs.openSync(filename, "wx", 0o600);
+          var fd = fs.openSync(filename, "wx", 0o600); // Avoid overwriting existing file
           fs.writeFileSync(fd, content, "utf8");
           fs.closeSync(fd);
           process.addListener("exit", () => fs.unlinkSync(filename));


### PR DESCRIPTION
And use more restrictive permissions.
We should not accidentally overwrite a random file.

See discussion in https://github.com/rescript-lang/rescript-compiler/pull/5194/commits/86a5568ad2fb408f9bda324300fdc878e2319e39#r654858470