### PR TITLE
fix build script: rebuild tests when compiler changed

### DIFF
--- a/jscomp/test/build.ninja
+++ b/jscomp/test/build.ninja
@@ -18,706 +18,707 @@ rule mll
 o test/arith_lexer.ml : mll test/arith_lexer.mll
 o test/number_lexer.ml : mll test/number_lexer.mll
 o test/simple_lexer_test.ml : mll test/simple_lexer_test.mll
-o test/406_primitive_test.cmi test/406_primitive_test.cmj : cc test/406_primitive_test.ml | test/mt.cmj $stdlib
-o test/a.cmi test/a.cmj : cc test/a.ml | test/test_order.cmj $stdlib
-o test/a_filename_test.cmi test/a_filename_test.cmj : cc test/a_filename_test.ml | test/ext_filename_test.cmj test/mt.cmj $stdlib
-o test/a_list_test.cmi test/a_list_test.cmj : cc test/a_list_test.ml | test/ext_list_test.cmj test/mt.cmj $stdlib
-o test/a_recursive_type.cmj : cc_cmi test/a_recursive_type.ml | test/a_recursive_type.cmi $stdlib
-o test/a_recursive_type.cmi : cc test/a_recursive_type.mli | $stdlib
-o test/a_scope_bug.cmi test/a_scope_bug.cmj : cc test/a_scope_bug.ml | $stdlib
-o test/a_string_test.cmi test/a_string_test.cmj : cc test/a_string_test.ml | test/ext_string_test.cmj test/mt.cmj $stdlib
-o test/abstract_type.cmj : cc_cmi test/abstract_type.ml | test/abstract_type.cmi $stdlib
-o test/abstract_type.cmi : cc test/abstract_type.mli | test/mt.cmi $stdlib
-o test/adt_optimize_test.cmi test/adt_optimize_test.cmj : cc test/adt_optimize_test.ml | $stdlib
-o test/alias_test.cmj : cc_cmi test/alias_test.ml | test/alias_test.cmi $stdlib
-o test/alias_test.cmi : cc test/alias_test.mli | $stdlib
-o test/and_or_tailcall_test.cmi test/and_or_tailcall_test.cmj : cc test/and_or_tailcall_test.ml | test/mt.cmj $stdlib
-o test/app_root_finder.cmi test/app_root_finder.cmj : cc test/app_root_finder.ml | $stdlib
-o test/argv_test.cmi test/argv_test.cmj : cc test/argv_test.ml | $stdlib
-o test/ari_regress_test.cmj : cc_cmi test/ari_regress_test.ml | test/ari_regress_test.cmi test/mt.cmj $stdlib
-o test/ari_regress_test.cmi : cc test/ari_regress_test.mli | $stdlib
-o test/arith_lexer.cmi test/arith_lexer.cmj : cc test/arith_lexer.ml | test/arith_parser.cmj test/arith_syntax.cmj $stdlib
-o test/arith_parser.cmi test/arith_parser.cmj : cc test/arith_parser.ml | test/arith_syntax.cmj $stdlib
-o test/arith_syntax.cmi test/arith_syntax.cmj : cc test/arith_syntax.ml | $stdlib
-o test/arity.cmi test/arity.cmj : cc test/arity.re | $stdlib
-o test/arity_deopt.cmi test/arity_deopt.cmj : cc test/arity_deopt.ml | test/mt.cmj $stdlib
-o test/arity_infer.cmi test/arity_infer.cmj : cc test/arity_infer.ml | $stdlib
-o test/arity_ml.cmi test/arity_ml.cmj : cc test/arity_ml.ml | $stdlib
-o test/array_data_util.cmi test/array_data_util.cmj : cc test/array_data_util.ml | $stdlib
-o test/array_safe_get.cmi test/array_safe_get.cmj : cc test/array_safe_get.ml | $stdlib
-o test/array_subtle_test.cmi test/array_subtle_test.cmj : cc test/array_subtle_test.ml | test/mt.cmj $stdlib
-o test/array_test.cmj : cc_cmi test/array_test.ml | test/array_test.cmi test/mt.cmj $stdlib
-o test/array_test.cmi : cc test/array_test.mli | $stdlib
-o test/ast_abstract_test.cmi test/ast_abstract_test.cmj : cc test/ast_abstract_test.ml | test/mt.cmj $stdlib
-o test/ast_js_mapper_poly_test.cmi test/ast_js_mapper_poly_test.cmj : cc test/ast_js_mapper_poly_test.ml | test/mt.cmj $stdlib
-o test/ast_js_mapper_test.cmj : cc_cmi test/ast_js_mapper_test.ml | test/ast_js_mapper_test.cmi $stdlib
-o test/ast_js_mapper_test.cmi : cc test/ast_js_mapper_test.mli | $stdlib
-o test/ast_mapper_defensive_test.cmi test/ast_mapper_defensive_test.cmj : cc test/ast_mapper_defensive_test.ml | test/mt.cmj $stdlib
-o test/ast_mapper_unused_warning_test.cmi test/ast_mapper_unused_warning_test.cmj : cc test/ast_mapper_unused_warning_test.ml | $stdlib
-o test/async_ideas.cmi test/async_ideas.cmj : cc test/async_ideas.ml | $stdlib
-o test/attr_test.cmi test/attr_test.cmj : cc test/attr_test.ml | $stdlib
-o test/b.cmi test/b.cmj : cc test/b.ml | $stdlib
-o test/bal_set_mini.cmi test/bal_set_mini.cmj : cc test/bal_set_mini.ml | $stdlib
-o test/bang_primitive.cmi test/bang_primitive.cmj : cc test/bang_primitive.ml | $stdlib
-o test/basic_module_test.cmj : cc_cmi test/basic_module_test.ml | test/basic_module_test.cmi test/mt.cmj test/mt_global.cmj test/offset.cmj test/pr6726.cmj $stdlib
-o test/basic_module_test.cmi : cc test/basic_module_test.mli | $stdlib
-o test/bb.cmi test/bb.cmj : cc test/bb.ml | $stdlib
-o test/bdd.cmi test/bdd.cmj : cc test/bdd.ml | $stdlib
-o test/belt_internal_test.cmi test/belt_internal_test.cmj : cc test/belt_internal_test.ml | $stdlib
-o test/belt_result_alias_test.cmi test/belt_result_alias_test.cmj : cc test/belt_result_alias_test.ml | $stdlib
-o test/bench.cmi test/bench.cmj : cc test/bench.ml | $stdlib
-o test/big_enum.cmi test/big_enum.cmj : cc test/big_enum.ml | $stdlib
-o test/big_polyvar_test.cmi test/big_polyvar_test.cmj : cc test/big_polyvar_test.ml | $stdlib
-o test/block_alias_test.cmi test/block_alias_test.cmj : cc test/block_alias_test.ml | test/mt.cmj $stdlib
-o test/boolean_test.cmi test/boolean_test.cmj : cc test/boolean_test.ml | test/mt.cmj test/test_bool_equal.cmj $stdlib
-o test/bs_MapInt_test.cmi test/bs_MapInt_test.cmj : cc test/bs_MapInt_test.ml | $stdlib
-o test/bs_abstract_test.cmj : cc_cmi test/bs_abstract_test.ml | test/bs_abstract_test.cmi $stdlib
-o test/bs_abstract_test.cmi : cc test/bs_abstract_test.mli | $stdlib
-o test/bs_array_test.cmi test/bs_array_test.cmj : cc test/bs_array_test.ml | test/mt.cmj $stdlib
-o test/bs_auto_uncurry.cmi test/bs_auto_uncurry.cmj : cc test/bs_auto_uncurry.ml | $stdlib
-o test/bs_auto_uncurry_test.cmi test/bs_auto_uncurry_test.cmj : cc test/bs_auto_uncurry_test.ml | test/mt.cmj $stdlib
-o test/bs_float_test.cmi test/bs_float_test.cmj : cc test/bs_float_test.ml | test/mt.cmj $stdlib
-o test/bs_hashmap_test.cmi test/bs_hashmap_test.cmj : cc test/bs_hashmap_test.ml | test/array_data_util.cmj test/mt.cmj $stdlib
-o test/bs_hashset_int_test.cmi test/bs_hashset_int_test.cmj : cc test/bs_hashset_int_test.ml | test/array_data_util.cmj test/mt.cmj $stdlib
-o test/bs_hashtbl_string_test.cmi test/bs_hashtbl_string_test.cmj : cc test/bs_hashtbl_string_test.ml | $stdlib
-o test/bs_ignore_effect.cmi test/bs_ignore_effect.cmj : cc test/bs_ignore_effect.ml | test/mt.cmj $stdlib
-o test/bs_ignore_test.cmi test/bs_ignore_test.cmj : cc test/bs_ignore_test.ml | $stdlib
-o test/bs_int_test.cmi test/bs_int_test.cmj : cc test/bs_int_test.ml | test/mt.cmj $stdlib
-o test/bs_list_test.cmi test/bs_list_test.cmj : cc test/bs_list_test.ml | test/mt.cmj $stdlib
-o test/bs_map_set_dict_test.cmi test/bs_map_set_dict_test.cmj : cc test/bs_map_set_dict_test.ml | test/array_data_util.cmj test/mt.cmj $stdlib
-o test/bs_map_test.cmi test/bs_map_test.cmj : cc test/bs_map_test.ml | test/mt.cmj $stdlib
-o test/bs_min_max_test.cmi test/bs_min_max_test.cmj : cc test/bs_min_max_test.ml | test/mt.cmj $stdlib
-o test/bs_mutable_set_test.cmi test/bs_mutable_set_test.cmj : cc test/bs_mutable_set_test.ml | test/array_data_util.cmj test/mt.cmj $stdlib
-o test/bs_node_string_buffer_test.cmi test/bs_node_string_buffer_test.cmj : cc test/bs_node_string_buffer_test.ml | $stdlib
-o test/bs_poly_map_test.cmi test/bs_poly_map_test.cmj : cc test/bs_poly_map_test.ml | test/array_data_util.cmj test/mt.cmj $stdlib
-o test/bs_poly_mutable_map_test.cmi test/bs_poly_mutable_map_test.cmj : cc test/bs_poly_mutable_map_test.ml | test/array_data_util.cmj test/mt.cmj $stdlib
-o test/bs_poly_mutable_set_test.cmi test/bs_poly_mutable_set_test.cmj : cc test/bs_poly_mutable_set_test.ml | test/array_data_util.cmj test/mt.cmj $stdlib
-o test/bs_poly_set_test.cmi test/bs_poly_set_test.cmj : cc test/bs_poly_set_test.ml | test/array_data_util.cmj test/mt.cmj $stdlib
-o test/bs_qualified.cmi test/bs_qualified.cmj : cc test/bs_qualified.ml | $stdlib
-o test/bs_queue_test.cmi test/bs_queue_test.cmj : cc test/bs_queue_test.ml | test/mt.cmj $stdlib
-o test/bs_rbset_int_bench.cmi test/bs_rbset_int_bench.cmj : cc test/bs_rbset_int_bench.ml | test/rbset.cmj $stdlib
-o test/bs_rest_test.cmi test/bs_rest_test.cmj : cc test/bs_rest_test.ml | $stdlib
-o test/bs_set_bench.cmi test/bs_set_bench.cmj : cc test/bs_set_bench.ml | $stdlib
-o test/bs_set_int_test.cmi test/bs_set_int_test.cmj : cc test/bs_set_int_test.ml | test/array_data_util.cmj test/mt.cmj $stdlib
-o test/bs_sort_test.cmi test/bs_sort_test.cmj : cc test/bs_sort_test.ml | test/array_data_util.cmj test/mt.cmj $stdlib
-o test/bs_splice_partial.cmi test/bs_splice_partial.cmj : cc test/bs_splice_partial.ml | $stdlib
-o test/bs_stack_test.cmi test/bs_stack_test.cmj : cc test/bs_stack_test.ml | test/mt.cmj $stdlib
-o test/bs_string_test.cmi test/bs_string_test.cmj : cc test/bs_string_test.ml | test/mt.cmj $stdlib
-o test/bs_unwrap_test.cmi test/bs_unwrap_test.cmj : cc test/bs_unwrap_test.ml | $stdlib
-o test/buffer_test.cmi test/buffer_test.cmj : cc test/buffer_test.ml | test/mt.cmj $stdlib
-o test/bytes_split_gpr_743_test.cmi test/bytes_split_gpr_743_test.cmj : cc test/bytes_split_gpr_743_test.ml | test/mt.cmj $stdlib
-o test/caml_compare_test.cmi test/caml_compare_test.cmj : cc test/caml_compare_test.ml | test/mt.cmj $stdlib
-o test/caml_format_test.cmi test/caml_format_test.cmj : cc test/caml_format_test.ml | test/mt.cmj $stdlib
-o test/caml_sys_poly_fill_test.cmi test/caml_sys_poly_fill_test.cmj : cc test/caml_sys_poly_fill_test.ml | test/mt.cmj $stdlib
-o test/chain_code_test.cmi test/chain_code_test.cmj : cc test/chain_code_test.ml | test/mt.cmj $stdlib
-o test/chn_test.cmi test/chn_test.cmj : cc test/chn_test.ml | test/mt.cmj $stdlib
-o test/class_setter_getter.cmj : cc_cmi test/class_setter_getter.ml | test/class_setter_getter.cmi $stdlib
-o test/class_setter_getter.cmi : cc test/class_setter_getter.mli | $stdlib
-o test/class_type_ffi_test.cmi test/class_type_ffi_test.cmj : cc test/class_type_ffi_test.ml | $stdlib
-o test/compare_test.cmi test/compare_test.cmj : cc test/compare_test.ml | $stdlib
-o test/complete_parmatch_test.cmi test/complete_parmatch_test.cmj : cc test/complete_parmatch_test.ml | $stdlib
-o test/complex_if_test.cmi test/complex_if_test.cmj : cc test/complex_if_test.ml | test/mt.cmj $stdlib
-o test/complex_test.cmi test/complex_test.cmj : cc test/complex_test.ml | test/mt.cmj $stdlib
-o test/complex_while_loop.cmi test/complex_while_loop.cmj : cc test/complex_while_loop.ml | $stdlib
-o test/condition_compilation_test.cmi test/condition_compilation_test.cmj : cc test/condition_compilation_test.ml | test/mt.cmj $stdlib
-o test/config1_test.cmi test/config1_test.cmj : cc test/config1_test.ml | $stdlib
-o test/config2_test.cmj : cc_cmi test/config2_test.ml | test/config2_test.cmi $stdlib
-o test/config2_test.cmi : cc test/config2_test.mli | $stdlib
-o test/console_log_test.cmi test/console_log_test.cmj : cc test/console_log_test.ml | $stdlib
-o test/const_block_test.cmj : cc_cmi test/const_block_test.ml | test/const_block_test.cmi test/mt.cmj $stdlib
-o test/const_block_test.cmi : cc test/const_block_test.mli | $stdlib
-o test/const_defs.cmi test/const_defs.cmj : cc test/const_defs.ml | $stdlib
-o test/const_defs_test.cmi test/const_defs_test.cmj : cc test/const_defs_test.ml | test/const_defs.cmj $stdlib
-o test/const_test.cmi test/const_test.cmj : cc test/const_test.ml | $stdlib
-o test/cont_int_fold_test.cmi test/cont_int_fold_test.cmj : cc test/cont_int_fold_test.ml | $stdlib
-o test/cps_test.cmi test/cps_test.cmj : cc test/cps_test.ml | test/mt.cmj $stdlib
-o test/cross_module_inline_test.cmi test/cross_module_inline_test.cmj : cc test/cross_module_inline_test.ml | test/test_char.cmj $stdlib
-o test/custom_error_test.cmi test/custom_error_test.cmj : cc test/custom_error_test.ml | $stdlib
-o test/debug_keep_test.cmi test/debug_keep_test.cmj : cc test/debug_keep_test.ml | $stdlib
-o test/debug_mode_value.cmi test/debug_mode_value.cmj : cc test/debug_mode_value.ml | $stdlib
-o test/debug_tmp.cmi test/debug_tmp.cmj : cc test/debug_tmp.ml | $stdlib
-o test/debugger_test.cmi test/debugger_test.cmj : cc test/debugger_test.ml | $stdlib
-o test/default_export_test.cmi test/default_export_test.cmj : cc test/default_export_test.ml | $stdlib
-o test/defunctor_make_test.cmi test/defunctor_make_test.cmj : cc test/defunctor_make_test.ml | $stdlib
-o test/demo.cmi test/demo.cmj : cc test/demo.ml | test/demo_binding.cmj $stdlib
-o test/demo_binding.cmi test/demo_binding.cmj : cc test/demo_binding.ml | $stdlib
-o test/demo_int_map.cmj : cc_cmi test/demo_int_map.ml | test/demo_int_map.cmi $stdlib
-o test/demo_int_map.cmi : cc test/demo_int_map.mli | $stdlib
-o test/demo_page.cmi test/demo_page.cmj : cc test/demo_page.ml | $stdlib
-o test/demo_pipe.cmi test/demo_pipe.cmj : cc test/demo_pipe.ml | $stdlib
-o test/derive_dyntype.cmi test/derive_dyntype.cmj : cc test/derive_dyntype.ml | $stdlib
-o test/derive_projector_test.cmj : cc_cmi test/derive_projector_test.ml | test/derive_projector_test.cmi $stdlib
-o test/derive_projector_test.cmi : cc test/derive_projector_test.mli | $stdlib
-o test/derive_type_test.cmi test/derive_type_test.cmj : cc test/derive_type_test.ml | $stdlib
-o test/digest_test.cmi test/digest_test.cmj : cc test/digest_test.ml | test/ext_array_test.cmj test/mt.cmj $stdlib
-o test/div_by_zero_test.cmi test/div_by_zero_test.cmj : cc test/div_by_zero_test.ml | test/mt.cmj $stdlib
-o test/dollar_escape_test.cmi test/dollar_escape_test.cmj : cc test/dollar_escape_test.ml | test/mt.cmj $stdlib
-o test/earger_curry_test.cmi test/earger_curry_test.cmj : cc test/earger_curry_test.ml | test/mt.cmj $stdlib
-o test/effect.cmi test/effect.cmj : cc test/effect.ml | $stdlib
-o test/epsilon_test.cmi test/epsilon_test.cmj : cc test/epsilon_test.ml | test/mt.cmj $stdlib
-o test/equal_box_test.cmi test/equal_box_test.cmj : cc test/equal_box_test.ml | test/mt.cmj $stdlib
-o test/equal_exception_test.cmi test/equal_exception_test.cmj : cc test/equal_exception_test.ml | test/mt.cmj $stdlib
-o test/equal_test.cmi test/equal_test.cmj : cc test/equal_test.ml | $stdlib
-o test/es6_export.cmi test/es6_export.cmj : cc test/es6_export.ml | $stdlib
-o test/es6_import.cmi test/es6_import.cmj : cc test/es6_import.ml | test/es6_export.cmj $stdlib
-o test/es6_module_test.cmi test/es6_module_test.cmj : cc test/es6_module_test.ml | test/mt.cmj $stdlib
-o test/escape_esmodule.cmi test/escape_esmodule.cmj : cc test/escape_esmodule.ml | $stdlib
-o test/esmodule_ref.cmi test/esmodule_ref.cmj : cc test/esmodule_ref.ml | test/escape_esmodule.cmj $stdlib
-o test/event_ffi.cmi test/event_ffi.cmj : cc test/event_ffi.ml | $stdlib
-o test/exception_alias.cmi test/exception_alias.cmj : cc test/exception_alias.ml | $stdlib
-o test/exception_def.cmi test/exception_def.cmj : cc test/exception_def.ml | test/mt.cmj test/test_other_exn.cmj $stdlib
-o test/exception_raise_test.cmi test/exception_raise_test.cmj : cc test/exception_raise_test.ml | test/mt.cmj $stdlib
-o test/exception_rebind_test.cmi test/exception_rebind_test.cmj : cc test/exception_rebind_test.ml | test/exception_def.cmj $stdlib
-o test/exception_rebound_err_test.cmi test/exception_rebound_err_test.cmj : cc test/exception_rebound_err_test.ml | test/mt.cmj $stdlib
-o test/exception_repr_test.cmi test/exception_repr_test.cmj : cc test/exception_repr_test.ml | test/exception_def.cmj test/mt.cmj $stdlib
-o test/exception_value_test.cmi test/exception_value_test.cmj : cc test/exception_value_test.ml | $stdlib
-o test/exn_error_pattern.cmi test/exn_error_pattern.cmj : cc test/exn_error_pattern.ml | test/mt.cmj $stdlib
-o test/export_keyword.cmi test/export_keyword.cmj : cc test/export_keyword.ml | $stdlib
-o test/ext_array_test.cmi test/ext_array_test.cmj : cc test/ext_array_test.ml | $stdlib
-o test/ext_bytes_test.cmi test/ext_bytes_test.cmj : cc test/ext_bytes_test.ml | test/mt.cmj $stdlib
-o test/ext_filename_test.cmi test/ext_filename_test.cmj : cc test/ext_filename_test.ml | test/ext_string_test.cmj test/test_literals.cmj $stdlib
-o test/ext_list_test.cmi test/ext_list_test.cmj : cc test/ext_list_test.ml | test/ext_string_test.cmj $stdlib
-o test/ext_pervasives_test.cmj : cc_cmi test/ext_pervasives_test.ml | test/ext_pervasives_test.cmi $stdlib
-o test/ext_pervasives_test.cmi : cc test/ext_pervasives_test.mli | $stdlib
-o test/ext_string_test.cmi test/ext_string_test.cmj : cc test/ext_string_test.ml | test/ext_bytes_test.cmj $stdlib
-o test/ext_sys_test.cmj : cc_cmi test/ext_sys_test.ml | test/ext_sys_test.cmi $stdlib
-o test/ext_sys_test.cmi : cc test/ext_sys_test.mli | $stdlib
-o test/extensible_variant_test.cmi test/extensible_variant_test.cmj : cc test/extensible_variant_test.ml | test/mt.cmj $stdlib
-o test/external_polyfill_test.cmi test/external_polyfill_test.cmj : cc test/external_polyfill_test.ml | test/mt.cmj $stdlib
-o test/external_ppx.cmi test/external_ppx.cmj : cc test/external_ppx.ml | $stdlib
-o test/fail_comp.cmi test/fail_comp.cmj : cc test/fail_comp.ml | $stdlib
-o test/ffi_arity_test.cmi test/ffi_arity_test.cmj : cc test/ffi_arity_test.ml | test/mt.cmj $stdlib
-o test/ffi_array_test.cmi test/ffi_array_test.cmj : cc test/ffi_array_test.ml | test/mt.cmj $stdlib
-o test/ffi_js_test.cmi test/ffi_js_test.cmj : cc test/ffi_js_test.ml | test/mt.cmj $stdlib
-o test/ffi_splice_test.cmi test/ffi_splice_test.cmj : cc test/ffi_splice_test.ml | test/mt.cmj $stdlib
-o test/ffi_test.cmi test/ffi_test.cmj : cc test/ffi_test.ml | $stdlib
-o test/fib.cmi test/fib.cmj : cc test/fib.ml | $stdlib
-o test/flattern_order_test.cmi test/flattern_order_test.cmj : cc test/flattern_order_test.ml | $stdlib
-o test/flexible_array_test.cmi test/flexible_array_test.cmj : cc test/flexible_array_test.ml | $stdlib
-o test/float_array.cmi test/float_array.cmj : cc test/float_array.ml | $stdlib
-o test/float_of_bits_test.cmi test/float_of_bits_test.cmj : cc test/float_of_bits_test.ml | test/mt.cmj $stdlib
-o test/float_record.cmj : cc_cmi test/float_record.ml | test/float_record.cmi $stdlib
-o test/float_record.cmi : cc test/float_record.mli | $stdlib
-o test/float_test.cmi test/float_test.cmj : cc test/float_test.ml | test/mt.cmj test/mt_global.cmj $stdlib
-o test/floatarray_test.cmi test/floatarray_test.cmj : cc test/floatarray_test.ml | test/mt.cmj $stdlib
-o test/flow_parser_reg_test.cmj : cc_cmi test/flow_parser_reg_test.ml | test/flow_parser_reg_test.cmi test/mt.cmj $stdlib
-o test/flow_parser_reg_test.cmi : cc test/flow_parser_reg_test.mli | $stdlib
-o test/for_loop_test.cmi test/for_loop_test.cmj : cc test/for_loop_test.ml | test/mt.cmj $stdlib
-o test/for_side_effect_test.cmi test/for_side_effect_test.cmj : cc test/for_side_effect_test.ml | test/mt.cmj $stdlib
-o test/format_regression.cmi test/format_regression.cmj : cc test/format_regression.ml | $stdlib
-o test/format_test.cmi test/format_test.cmj : cc test/format_test.ml | test/mt.cmj $stdlib
-o test/fs_test.cmi test/fs_test.cmj : cc test/fs_test.ml | test/mt.cmj $stdlib
-o test/fun_pattern_match.cmi test/fun_pattern_match.cmj : cc test/fun_pattern_match.ml | $stdlib
-o test/functor_app_test.cmi test/functor_app_test.cmj : cc test/functor_app_test.ml | test/functor_def.cmj test/functor_inst.cmj test/mt.cmj $stdlib
-o test/functor_def.cmi test/functor_def.cmj : cc test/functor_def.ml | $stdlib
-o test/functor_ffi.cmi test/functor_ffi.cmj : cc test/functor_ffi.ml | $stdlib
-o test/functor_inst.cmi test/functor_inst.cmj : cc test/functor_inst.ml | $stdlib
-o test/functors.cmi test/functors.cmj : cc test/functors.ml | $stdlib
-o test/gbk.cmi test/gbk.cmj : cc test/gbk.ml | $stdlib
-o test/genlex_test.cmi test/genlex_test.cmj : cc test/genlex_test.ml | test/mt.cmj $stdlib
-o test/gentTypeReTest.cmi test/gentTypeReTest.cmj : cc test/gentTypeReTest.re | $stdlib
-o test/global_exception_regression_test.cmi test/global_exception_regression_test.cmj : cc test/global_exception_regression_test.ml | test/mt.cmj $stdlib
-o test/global_mangles.cmi test/global_mangles.cmj : cc test/global_mangles.ml | $stdlib
-o test/global_module_alias_test.cmi test/global_module_alias_test.cmj : cc test/global_module_alias_test.ml | test/mt.cmj $stdlib
-o test/google_closure_test.cmi test/google_closure_test.cmj : cc test/google_closure_test.ml | test/mt.cmj test/test_google_closure.cmj $stdlib
-o test/gpr496_test.cmi test/gpr496_test.cmj : cc test/gpr496_test.ml | test/mt.cmj $stdlib
-o test/gpr_1063_test.cmi test/gpr_1063_test.cmj : cc test/gpr_1063_test.ml | $stdlib
-o test/gpr_1072.cmi test/gpr_1072.cmj : cc test/gpr_1072.ml | $stdlib
-o test/gpr_1072_reg.cmi test/gpr_1072_reg.cmj : cc test/gpr_1072_reg.ml | $stdlib
-o test/gpr_1150.cmi test/gpr_1150.cmj : cc test/gpr_1150.ml | $stdlib
-o test/gpr_1154_test.cmi test/gpr_1154_test.cmj : cc test/gpr_1154_test.ml | test/mt.cmj $stdlib
-o test/gpr_1170.cmi test/gpr_1170.cmj : cc test/gpr_1170.ml | $stdlib
-o test/gpr_1240_missing_unbox.cmi test/gpr_1240_missing_unbox.cmj : cc test/gpr_1240_missing_unbox.ml | $stdlib
-o test/gpr_1245_test.cmi test/gpr_1245_test.cmj : cc test/gpr_1245_test.ml | $stdlib
-o test/gpr_1268.cmi test/gpr_1268.cmj : cc test/gpr_1268.ml | $stdlib
-o test/gpr_1409_test.cmi test/gpr_1409_test.cmj : cc test/gpr_1409_test.ml | test/mt.cmj test/string_set.cmj $stdlib
-o test/gpr_1423_app_test.cmi test/gpr_1423_app_test.cmj : cc test/gpr_1423_app_test.ml | test/gpr_1423_nav.cmj test/mt.cmj $stdlib
-o test/gpr_1423_nav.cmi test/gpr_1423_nav.cmj : cc test/gpr_1423_nav.ml | $stdlib
-o test/gpr_1438.cmi test/gpr_1438.cmj : cc test/gpr_1438.ml | $stdlib
-o test/gpr_1481.cmi test/gpr_1481.cmj : cc test/gpr_1481.ml | $stdlib
-o test/gpr_1484.cmi test/gpr_1484.cmj : cc test/gpr_1484.ml | $stdlib
-o test/gpr_1501_test.cmi test/gpr_1501_test.cmj : cc test/gpr_1501_test.ml | test/mt.cmj $stdlib
-o test/gpr_1503_test.cmi test/gpr_1503_test.cmj : cc test/gpr_1503_test.ml | test/mt.cmj $stdlib
-o test/gpr_1539_test.cmi test/gpr_1539_test.cmj : cc test/gpr_1539_test.ml | $stdlib
-o test/gpr_1600_test.cmi test/gpr_1600_test.cmj : cc test/gpr_1600_test.ml | $stdlib
-o test/gpr_1658_test.cmi test/gpr_1658_test.cmj : cc test/gpr_1658_test.ml | test/mt.cmj $stdlib
-o test/gpr_1667_test.cmi test/gpr_1667_test.cmj : cc test/gpr_1667_test.ml | test/mt.cmj $stdlib
-o test/gpr_1692_test.cmi test/gpr_1692_test.cmj : cc test/gpr_1692_test.ml | $stdlib
-o test/gpr_1698_test.cmi test/gpr_1698_test.cmj : cc test/gpr_1698_test.ml | $stdlib
-o test/gpr_1701_test.cmi test/gpr_1701_test.cmj : cc test/gpr_1701_test.ml | $stdlib
-o test/gpr_1716_test.cmi test/gpr_1716_test.cmj : cc test/gpr_1716_test.ml | test/mt.cmj $stdlib
-o test/gpr_1717_test.cmi test/gpr_1717_test.cmj : cc test/gpr_1717_test.ml | $stdlib
-o test/gpr_1728_test.cmi test/gpr_1728_test.cmj : cc test/gpr_1728_test.ml | test/mt.cmj $stdlib
-o test/gpr_1749_test.cmi test/gpr_1749_test.cmj : cc test/gpr_1749_test.ml | test/mt.cmj $stdlib
-o test/gpr_1759_test.cmi test/gpr_1759_test.cmj : cc test/gpr_1759_test.ml | $stdlib
-o test/gpr_1760_test.cmi test/gpr_1760_test.cmj : cc test/gpr_1760_test.ml | test/mt.cmj $stdlib
-o test/gpr_1762_test.cmi test/gpr_1762_test.cmj : cc test/gpr_1762_test.ml | test/mt.cmj $stdlib
-o test/gpr_1817_test.cmi test/gpr_1817_test.cmj : cc test/gpr_1817_test.ml | test/mt.cmj $stdlib
-o test/gpr_1822_test.cmi test/gpr_1822_test.cmj : cc test/gpr_1822_test.ml | test/mt.cmj $stdlib
-o test/gpr_1891_test.cmi test/gpr_1891_test.cmj : cc test/gpr_1891_test.ml | $stdlib
-o test/gpr_1943_test.cmi test/gpr_1943_test.cmj : cc test/gpr_1943_test.ml | test/mt.cmj $stdlib
-o test/gpr_1946_test.cmi test/gpr_1946_test.cmj : cc test/gpr_1946_test.ml | test/mt.cmj $stdlib
-o test/gpr_2316_test.cmi test/gpr_2316_test.cmj : cc test/gpr_2316_test.ml | test/mt.cmj $stdlib
-o test/gpr_2352_test.cmi test/gpr_2352_test.cmj : cc test/gpr_2352_test.ml | $stdlib
-o test/gpr_2413_test.cmi test/gpr_2413_test.cmj : cc test/gpr_2413_test.ml | $stdlib
-o test/gpr_2474.cmi test/gpr_2474.cmj : cc test/gpr_2474.ml | $stdlib
-o test/gpr_2487.cmi test/gpr_2487.cmj : cc test/gpr_2487.ml | $stdlib
-o test/gpr_2503_test.cmi test/gpr_2503_test.cmj : cc test/gpr_2503_test.ml | test/mt.cmj $stdlib
-o test/gpr_2608_test.cmi test/gpr_2608_test.cmj : cc test/gpr_2608_test.ml | test/mt.cmj $stdlib
-o test/gpr_2614_test.cmi test/gpr_2614_test.cmj : cc test/gpr_2614_test.ml | $stdlib
-o test/gpr_2633_test.cmi test/gpr_2633_test.cmj : cc test/gpr_2633_test.ml | $stdlib
-o test/gpr_2642_test.cmi test/gpr_2642_test.cmj : cc test/gpr_2642_test.ml | $stdlib
-o test/gpr_2652_test.cmi test/gpr_2652_test.cmj : cc test/gpr_2652_test.ml | $stdlib
-o test/gpr_2682_test.cmi test/gpr_2682_test.cmj : cc test/gpr_2682_test.ml | $stdlib
-o test/gpr_2700_test.cmi test/gpr_2700_test.cmj : cc test/gpr_2700_test.ml | $stdlib
-o test/gpr_2731_test.cmi test/gpr_2731_test.cmj : cc test/gpr_2731_test.ml | $stdlib
-o test/gpr_2789_test.cmi test/gpr_2789_test.cmj : cc test/gpr_2789_test.ml | test/mt.cmj $stdlib
-o test/gpr_2863_test.cmi test/gpr_2863_test.cmj : cc test/gpr_2863_test.ml | $stdlib
-o test/gpr_2931_test.cmi test/gpr_2931_test.cmj : cc test/gpr_2931_test.ml | test/mt.cmj $stdlib
-o test/gpr_3142_test.cmi test/gpr_3142_test.cmj : cc test/gpr_3142_test.ml | test/mt.cmj $stdlib
-o test/gpr_3154_test.cmi test/gpr_3154_test.cmj : cc test/gpr_3154_test.ml | test/mt.cmj $stdlib
-o test/gpr_3209_test.cmi test/gpr_3209_test.cmj : cc test/gpr_3209_test.ml | $stdlib
-o test/gpr_3492_test.cmi test/gpr_3492_test.cmj : cc test/gpr_3492_test.ml | test/mt.cmj $stdlib
-o test/gpr_3502_test.cmi test/gpr_3502_test.cmj : cc test/gpr_3502_test.ml | $stdlib
-o test/gpr_3519_jsx_test.cmi test/gpr_3519_jsx_test.cmj : cc test/gpr_3519_jsx_test.ml | $stdlib
-o test/gpr_3519_test.cmi test/gpr_3519_test.cmj : cc test/gpr_3519_test.ml | $stdlib
-o test/gpr_3536_test.cmi test/gpr_3536_test.cmj : cc test/gpr_3536_test.ml | test/mt.cmj $stdlib
-o test/gpr_3546_test.cmi test/gpr_3546_test.cmj : cc test/gpr_3546_test.ml | $stdlib
-o test/gpr_3548_test.cmi test/gpr_3548_test.cmj : cc test/gpr_3548_test.ml | $stdlib
-o test/gpr_3549_test.cmi test/gpr_3549_test.cmj : cc test/gpr_3549_test.ml | test/mt.cmj $stdlib
-o test/gpr_3566_drive_test.cmi test/gpr_3566_drive_test.cmj : cc test/gpr_3566_drive_test.ml | test/gpr_3566_test.cmj test/mt.cmj $stdlib
-o test/gpr_3566_test.cmi test/gpr_3566_test.cmj : cc test/gpr_3566_test.ml | $stdlib
-o test/gpr_3595_test.cmi test/gpr_3595_test.cmj : cc test/gpr_3595_test.ml | test/mt.cmj $stdlib
-o test/gpr_3609_test.cmi test/gpr_3609_test.cmj : cc test/gpr_3609_test.ml | $stdlib
-o test/gpr_3697_test.cmi test/gpr_3697_test.cmj : cc test/gpr_3697_test.ml | $stdlib
-o test/gpr_373_test.cmi test/gpr_373_test.cmj : cc test/gpr_373_test.ml | $stdlib
-o test/gpr_3770_test.cmi test/gpr_3770_test.cmj : cc test/gpr_3770_test.ml | $stdlib
-o test/gpr_3852_alias.cmi test/gpr_3852_alias.cmj : cc test/gpr_3852_alias.ml | test/gpr_3852_effect.cmj $stdlib
-o test/gpr_3852_alias_reify.cmj : cc_cmi test/gpr_3852_alias_reify.ml | test/gpr_3852_alias_reify.cmi test/gpr_3852_effect.cmj $stdlib
-o test/gpr_3852_alias_reify.cmi : cc test/gpr_3852_alias_reify.mli | $stdlib
-o test/gpr_3852_effect.cmi test/gpr_3852_effect.cmj : cc test/gpr_3852_effect.ml | $stdlib
-o test/gpr_3865.cmi test/gpr_3865.cmj : cc test/gpr_3865.re | test/gpr_3865_bar.cmj test/gpr_3865_foo.cmj $stdlib
-o test/gpr_3865_bar.cmi test/gpr_3865_bar.cmj : cc test/gpr_3865_bar.re | $stdlib
-o test/gpr_3865_foo.cmi test/gpr_3865_foo.cmj : cc test/gpr_3865_foo.re | $stdlib
-o test/gpr_3875_test.cmi test/gpr_3875_test.cmj : cc test/gpr_3875_test.ml | test/mt.cmj $stdlib
-o test/gpr_3877_test.cmi test/gpr_3877_test.cmj : cc test/gpr_3877_test.ml | $stdlib
-o test/gpr_3895_test.cmi test/gpr_3895_test.cmj : cc test/gpr_3895_test.ml | $stdlib
-o test/gpr_3897_test.cmi test/gpr_3897_test.cmj : cc test/gpr_3897_test.ml | $stdlib
-o test/gpr_3931_test.cmi test/gpr_3931_test.cmj : cc test/gpr_3931_test.ml | $stdlib
-o test/gpr_3980_test.cmi test/gpr_3980_test.cmj : cc test/gpr_3980_test.ml | $stdlib
-o test/gpr_4025_test.cmi test/gpr_4025_test.cmj : cc test/gpr_4025_test.ml | $stdlib
-o test/gpr_405_test.cmj : cc_cmi test/gpr_405_test.ml | test/gpr_405_test.cmi $stdlib
-o test/gpr_405_test.cmi : cc test/gpr_405_test.mli | $stdlib
-o test/gpr_4069_test.cmi test/gpr_4069_test.cmj : cc test/gpr_4069_test.ml | $stdlib
-o test/gpr_4265_test.cmi test/gpr_4265_test.cmj : cc test/gpr_4265_test.ml | test/mt.cmj $stdlib
-o test/gpr_4274_test.cmi test/gpr_4274_test.cmj : cc test/gpr_4274_test.ml | $stdlib
-o test/gpr_4280_test.cmi test/gpr_4280_test.cmj : cc test/gpr_4280_test.ml | test/mt.cmj $stdlib
-o test/gpr_4407_test.cmi test/gpr_4407_test.cmj : cc test/gpr_4407_test.ml | test/debug_mode_value.cmj test/mt.cmj $stdlib
-o test/gpr_441.cmi test/gpr_441.cmj : cc test/gpr_441.ml | $stdlib
-o test/gpr_4442_test.cmi test/gpr_4442_test.cmj : cc test/gpr_4442_test.ml | test/mt.cmj $stdlib
-o test/gpr_4491_test.cmi test/gpr_4491_test.cmj : cc test/gpr_4491_test.ml | $stdlib
-o test/gpr_4494_test.cmi test/gpr_4494_test.cmj : cc test/gpr_4494_test.ml | $stdlib
-o test/gpr_4519_test.cmi test/gpr_4519_test.cmj : cc test/gpr_4519_test.ml | test/mt.cmj $stdlib
-o test/gpr_459_test.cmi test/gpr_459_test.cmj : cc test/gpr_459_test.ml | test/mt.cmj $stdlib
-o test/gpr_4639_test.cmi test/gpr_4639_test.cmj : cc test/gpr_4639_test.ml | $stdlib
-o test/gpr_4900_test.cmi test/gpr_4900_test.cmj : cc test/gpr_4900_test.ml | test/mt.cmj $stdlib
-o test/gpr_4924_test.cmi test/gpr_4924_test.cmj : cc test/gpr_4924_test.ml | test/mt.cmj $stdlib
-o test/gpr_4931.cmi test/gpr_4931.cmj : cc test/gpr_4931.ml | $stdlib
-o test/gpr_5071_test.cmi test/gpr_5071_test.cmj : cc test/gpr_5071_test.res | test/react.cmj $stdlib
-o test/gpr_5169_test.cmi test/gpr_5169_test.cmj : cc test/gpr_5169_test.ml | $stdlib
-o test/gpr_5218_test.cmi test/gpr_5218_test.cmj : cc test/gpr_5218_test.res | test/mt.cmj $stdlib
-o test/gpr_627_test.cmi test/gpr_627_test.cmj : cc test/gpr_627_test.ml | test/mt.cmj $stdlib
-o test/gpr_658.cmi test/gpr_658.cmj : cc test/gpr_658.ml | $stdlib
-o test/gpr_858_test.cmi test/gpr_858_test.cmj : cc test/gpr_858_test.ml | $stdlib
-o test/gpr_858_unit2_test.cmi test/gpr_858_unit2_test.cmj : cc test/gpr_858_unit2_test.ml | $stdlib
-o test/gpr_904_test.cmi test/gpr_904_test.cmj : cc test/gpr_904_test.ml | test/mt.cmj $stdlib
-o test/gpr_974_test.cmi test/gpr_974_test.cmj : cc test/gpr_974_test.ml | $stdlib
-o test/gpr_977_test.cmi test/gpr_977_test.cmj : cc test/gpr_977_test.ml | test/mt.cmj $stdlib
-o test/gpr_return_type_unused_attribute.cmi test/gpr_return_type_unused_attribute.cmj : cc test/gpr_return_type_unused_attribute.ml | $stdlib
-o test/gray_code_test.cmi test/gray_code_test.cmj : cc test/gray_code_test.ml | $stdlib
-o test/guide_for_ext.cmi test/guide_for_ext.cmj : cc test/guide_for_ext.ml | $stdlib
-o test/hamming_test.cmi test/hamming_test.cmj : cc test/hamming_test.ml | test/mt.cmj $stdlib
-o test/hash_collision_test.cmi test/hash_collision_test.cmj : cc test/hash_collision_test.ml | test/mt.cmj $stdlib
-o test/hash_sugar_desugar.cmj : cc_cmi test/hash_sugar_desugar.ml | test/hash_sugar_desugar.cmi $stdlib
-o test/hash_sugar_desugar.cmi : cc test/hash_sugar_desugar.mli | $stdlib
-o test/hash_test.cmi test/hash_test.cmj : cc test/hash_test.ml | test/mt.cmj test/mt_global.cmj $stdlib
-o test/hashtbl_test.cmi test/hashtbl_test.cmj : cc test/hashtbl_test.ml | test/mt.cmj $stdlib
-o test/hello.foo.cmi test/hello.foo.cmj : cc test/hello.foo.ml | $stdlib
-o test/hello_res.cmj : cc_cmi test/hello_res.res | test/hello_res.cmi $stdlib
-o test/hello_res.cmi : cc test/hello_res.resi | $stdlib
-o test/http_types.cmi test/http_types.cmj : cc test/http_types.ml | $stdlib
-o test/ignore_test.cmi test/ignore_test.cmj : cc test/ignore_test.ml | test/mt.cmj $stdlib
-o test/imm_map_bench.cmi test/imm_map_bench.cmj : cc test/imm_map_bench.ml | $stdlib
-o test/include_side_effect.cmi test/include_side_effect.cmj : cc test/include_side_effect.ml | test/side_effect.cmj $stdlib
-o test/include_side_effect_free.cmi test/include_side_effect_free.cmj : cc test/include_side_effect_free.ml | test/side_effect_free.cmj $stdlib
-o test/incomplete_toplevel_test.cmi test/incomplete_toplevel_test.cmj : cc test/incomplete_toplevel_test.ml | $stdlib
-o test/infer_type_test.cmj : cc_cmi test/infer_type_test.ml | test/infer_type_test.cmi $stdlib
-o test/infer_type_test.cmi : cc test/infer_type_test.mli | $stdlib
-o test/inline_const.cmj : cc_cmi test/inline_const.ml | test/inline_const.cmi $stdlib
-o test/inline_const.cmi : cc test/inline_const.mli | $stdlib
-o test/inline_const_test.cmi test/inline_const_test.cmj : cc test/inline_const_test.ml | test/inline_const.cmj test/mt.cmj $stdlib
-o test/inline_edge_cases.cmj : cc_cmi test/inline_edge_cases.ml | test/inline_edge_cases.cmi $stdlib
-o test/inline_edge_cases.cmi : cc test/inline_edge_cases.mli | $stdlib
-o test/inline_map2_test.cmi test/inline_map2_test.cmj : cc test/inline_map2_test.ml | test/mt.cmj $stdlib
-o test/inline_map_demo.cmi test/inline_map_demo.cmj : cc test/inline_map_demo.res | test/mt.cmj $stdlib
-o test/inline_map_test.cmj : cc_cmi test/inline_map_test.ml | test/inline_map_test.cmi test/mt.cmj $stdlib
-o test/inline_map_test.cmi : cc test/inline_map_test.mli | $stdlib
-o test/inline_record_test.cmi test/inline_record_test.cmj : cc test/inline_record_test.ml | test/mt.cmj $stdlib
-o test/inline_regression_test.cmi test/inline_regression_test.cmj : cc test/inline_regression_test.ml | test/mt.cmj $stdlib
-o test/inline_string_test.cmi test/inline_string_test.cmj : cc test/inline_string_test.ml | $stdlib
-o test/inner_call.cmi test/inner_call.cmj : cc test/inner_call.ml | test/inner_define.cmj $stdlib
-o test/inner_define.cmj : cc_cmi test/inner_define.ml | test/inner_define.cmi $stdlib
-o test/inner_define.cmi : cc test/inner_define.mli | $stdlib
-o test/inner_unused.cmi test/inner_unused.cmj : cc test/inner_unused.ml | $stdlib
-o test/installation_test.cmi test/installation_test.cmj : cc test/installation_test.ml | test/mt.cmj $stdlib
-o test/int32_test.cmi test/int32_test.cmj : cc test/int32_test.ml | test/ext_array_test.cmj test/mt.cmj $stdlib
-o test/int64_mul_div_test.cmi test/int64_mul_div_test.cmj : cc test/int64_mul_div_test.ml | test/mt.cmj $stdlib
-o test/int64_string_bench.cmi test/int64_string_bench.cmj : cc test/int64_string_bench.ml | $stdlib
-o test/int64_string_test.cmi test/int64_string_test.cmj : cc test/int64_string_test.ml | test/mt.cmj $stdlib
-o test/int64_test.cmi test/int64_test.cmj : cc test/int64_test.ml | test/ext_array_test.cmj test/mt.cmj $stdlib
-o test/int_hashtbl_test.cmi test/int_hashtbl_test.cmj : cc test/int_hashtbl_test.ml | test/mt.cmj $stdlib
-o test/int_map.cmi test/int_map.cmj : cc test/int_map.ml | $stdlib
-o test/int_overflow_test.cmi test/int_overflow_test.cmj : cc test/int_overflow_test.ml | test/mt.cmj $stdlib
-o test/int_poly_var.cmi test/int_poly_var.cmj : cc test/int_poly_var.res | test/mt.cmj test/test2.cmj $stdlib
-o test/int_switch_test.cmi test/int_switch_test.cmj : cc test/int_switch_test.ml | test/mt.cmj $stdlib
-o test/internal_unused_test.cmi test/internal_unused_test.cmj : cc test/internal_unused_test.ml | $stdlib
-o test/io_test.cmi test/io_test.cmj : cc test/io_test.ml | $stdlib
-o test/js_array_test.cmi test/js_array_test.cmj : cc test/js_array_test.ml | test/mt.cmj $stdlib
-o test/js_bool_test.cmi test/js_bool_test.cmj : cc test/js_bool_test.ml | test/mt.cmj $stdlib
-o test/js_cast_test.cmi test/js_cast_test.cmj : cc test/js_cast_test.ml | test/mt.cmj $stdlib
-o test/js_date_test.cmi test/js_date_test.cmj : cc test/js_date_test.ml | test/mt.cmj $stdlib
-o test/js_dict_test.cmi test/js_dict_test.cmj : cc test/js_dict_test.ml | test/mt.cmj $stdlib
-o test/js_exception_catch_test.cmi test/js_exception_catch_test.cmj : cc test/js_exception_catch_test.ml | test/mt.cmj $stdlib
-o test/js_float_test.cmi test/js_float_test.cmj : cc test/js_float_test.ml | test/mt.cmj $stdlib
-o test/js_global_test.cmi test/js_global_test.cmj : cc test/js_global_test.ml | test/mt.cmj $stdlib
-o test/js_int_test.cmi test/js_int_test.cmj : cc test/js_int_test.ml | test/mt.cmj $stdlib
-o test/js_json_test.cmi test/js_json_test.cmj : cc test/js_json_test.ml | test/mt.cmj $stdlib
-o test/js_list_test.cmi test/js_list_test.cmj : cc test/js_list_test.ml | test/mt.cmj $stdlib
-o test/js_math_test.cmi test/js_math_test.cmj : cc test/js_math_test.ml | test/mt.cmj $stdlib
-o test/js_null_test.cmi test/js_null_test.cmj : cc test/js_null_test.ml | test/mt.cmj $stdlib
-o test/js_null_undefined_test.cmi test/js_null_undefined_test.cmj : cc test/js_null_undefined_test.ml | test/mt.cmj $stdlib
-o test/js_nullable_test.cmi test/js_nullable_test.cmj : cc test/js_nullable_test.ml | test/mt.cmj $stdlib
-o test/js_obj_test.cmi test/js_obj_test.cmj : cc test/js_obj_test.ml | test/mt.cmj $stdlib
-o test/js_option_test.cmi test/js_option_test.cmj : cc test/js_option_test.ml | test/mt.cmj $stdlib
-o test/js_promise_basic_test.cmi test/js_promise_basic_test.cmj : cc test/js_promise_basic_test.ml | test/mt.cmj $stdlib
-o test/js_re_test.cmi test/js_re_test.cmj : cc test/js_re_test.ml | test/mt.cmj $stdlib
-o test/js_string_test.cmi test/js_string_test.cmj : cc test/js_string_test.ml | test/mt.cmj $stdlib
-o test/js_typed_array_test.cmi test/js_typed_array_test.cmj : cc test/js_typed_array_test.ml | test/mt.cmj $stdlib
-o test/js_undefined_test.cmi test/js_undefined_test.cmj : cc test/js_undefined_test.ml | test/mt.cmj $stdlib
-o test/js_val.cmi test/js_val.cmj : cc test/js_val.ml | $stdlib
-o test/jsoo_400_test.cmi test/jsoo_400_test.cmj : cc test/jsoo_400_test.ml | test/mt.cmj $stdlib
-o test/jsoo_485_test.cmi test/jsoo_485_test.cmj : cc test/jsoo_485_test.ml | $stdlib
-o test/key_word_property.cmi test/key_word_property.cmj : cc test/key_word_property.ml | $stdlib
-o test/key_word_property2.cmi test/key_word_property2.cmj : cc test/key_word_property2.ml | test/export_keyword.cmj $stdlib
-o test/key_word_property_plus_test.cmi test/key_word_property_plus_test.cmj : cc test/key_word_property_plus_test.ml | test/global_mangles.cmj test/mt.cmj $stdlib
-o test/label_uncurry.cmi test/label_uncurry.cmj : cc test/label_uncurry.ml | $stdlib
-o test/large_integer_pat.cmi test/large_integer_pat.cmj : cc test/large_integer_pat.ml | $stdlib
-o test/large_record_duplication_test.cmi test/large_record_duplication_test.cmj : cc test/large_record_duplication_test.ml | test/mt.cmj $stdlib
-o test/largest_int_flow.cmi test/largest_int_flow.cmj : cc test/largest_int_flow.ml | $stdlib
-o test/lazy_demo.cmi test/lazy_demo.cmj : cc test/lazy_demo.re | $stdlib
-o test/lazy_test.cmi test/lazy_test.cmj : cc test/lazy_test.ml | test/mt.cmj $stdlib
-o test/lexer_test.cmi test/lexer_test.cmj : cc test/lexer_test.ml | test/arith_lexer.cmj test/arith_parser.cmj test/arith_syntax.cmj test/mt.cmj test/number_lexer.cmj $stdlib
-o test/lib_js_test.cmi test/lib_js_test.cmj : cc test/lib_js_test.ml | test/mt.cmj $stdlib
-o test/libarg_test.cmi test/libarg_test.cmj : cc test/libarg_test.ml | test/mt.cmj $stdlib
-o test/libqueue_test.cmi test/libqueue_test.cmj : cc test/libqueue_test.ml | $stdlib
-o test/limits_test.cmi test/limits_test.cmj : cc test/limits_test.ml | test/mt.cmj $stdlib
-o test/list_stack.cmi test/list_stack.cmj : cc test/list_stack.ml | $stdlib
-o test/list_test.cmi test/list_test.cmj : cc test/list_test.ml | test/mt.cmj $stdlib
-o test/local_class_type.cmi test/local_class_type.cmj : cc test/local_class_type.ml | $stdlib
-o test/local_exception_test.cmi test/local_exception_test.cmj : cc test/local_exception_test.ml | $stdlib
-o test/loop_regression_test.cmi test/loop_regression_test.cmj : cc test/loop_regression_test.ml | test/mt.cmj $stdlib
-o test/loop_suites_test.cmi test/loop_suites_test.cmj : cc test/loop_suites_test.ml | test/for_loop_test.cmj test/mt.cmj $stdlib
-o test/map_find_test.cmi test/map_find_test.cmj : cc test/map_find_test.ml | test/mt.cmj $stdlib
-o test/map_test.cmj : cc_cmi test/map_test.ml | test/map_test.cmi test/mt.cmj $stdlib
-o test/map_test.cmi : cc test/map_test.mli | $stdlib
-o test/mario_game.cmi test/mario_game.cmj : cc test/mario_game.ml | $stdlib
-o test/marshal.cmi test/marshal.cmj : cc test/marshal.ml | $stdlib
-o test/method_chain.cmi test/method_chain.cmj : cc test/method_chain.ml | $stdlib
-o test/method_name_test.cmi test/method_name_test.cmj : cc test/method_name_test.ml | test/mt.cmj $stdlib
-o test/method_string_name.cmi test/method_string_name.cmj : cc test/method_string_name.re | $stdlib
-o test/minimal_test.cmi test/minimal_test.cmj : cc test/minimal_test.ml | $stdlib
-o test/miss_colon_test.cmi test/miss_colon_test.cmj : cc test/miss_colon_test.ml | $stdlib
-o test/mock_mt.cmi test/mock_mt.cmj : cc test/mock_mt.ml | test/mt.cmj $stdlib
-o test/module_alias_test.cmi test/module_alias_test.cmj : cc test/module_alias_test.ml | test/ext_pervasives_test.cmj test/mt.cmj $stdlib
-o test/module_as_class_ffi.cmi test/module_as_class_ffi.cmj : cc test/module_as_class_ffi.ml | $stdlib
-o test/module_as_function.cmi test/module_as_function.cmj : cc test/module_as_function.ml | $stdlib
-o test/module_missing_conversion.cmi test/module_missing_conversion.cmj : cc test/module_missing_conversion.ml | $stdlib
-o test/module_parameter_test.cmi test/module_parameter_test.cmj : cc test/module_parameter_test.ml | test/mt.cmj $stdlib
-o test/module_splice_test.cmi test/module_splice_test.cmj : cc test/module_splice_test.ml | test/mt.cmj $stdlib
-o test/more_poly_variant_test.cmi test/more_poly_variant_test.cmj : cc test/more_poly_variant_test.ml | $stdlib
-o test/more_uncurry.cmi test/more_uncurry.cmj : cc test/more_uncurry.ml | $stdlib
-o test/mpr_6033_test.cmi test/mpr_6033_test.cmj : cc test/mpr_6033_test.ml | test/mt.cmj $stdlib
-o test/mt.cmj : cc_cmi test/mt.ml | test/mt.cmi $stdlib
-o test/mt.cmi : cc test/mt.mli | $stdlib
-o test/mt_global.cmj : cc_cmi test/mt_global.ml | test/mt.cmj test/mt_global.cmi $stdlib
-o test/mt_global.cmi : cc test/mt_global.mli | test/mt.cmi $stdlib
-o test/mutable_obj_test.cmi test/mutable_obj_test.cmj : cc test/mutable_obj_test.ml | $stdlib
-o test/mutable_uncurry_test.cmi test/mutable_uncurry_test.cmj : cc test/mutable_uncurry_test.ml | test/mt.cmj $stdlib
-o test/mutual_non_recursive_type.cmi test/mutual_non_recursive_type.cmj : cc test/mutual_non_recursive_type.ml | $stdlib
-o test/name_mangle_test.cmi test/name_mangle_test.cmj : cc test/name_mangle_test.ml | test/mt.cmj $stdlib
-o test/nested_include.cmi test/nested_include.cmj : cc test/nested_include.ml | $stdlib
-o test/nested_module_alias.cmi test/nested_module_alias.cmj : cc test/nested_module_alias.ml | $stdlib
-o test/nested_obj_literal.cmi test/nested_obj_literal.cmj : cc test/nested_obj_literal.ml | $stdlib
-o test/nested_obj_test.cmi test/nested_obj_test.cmj : cc test/nested_obj_test.ml | $stdlib
-o test/nested_pattern_match_test.cmi test/nested_pattern_match_test.cmj : cc test/nested_pattern_match_test.ml | $stdlib
-o test/noassert.cmi test/noassert.cmj : cc test/noassert.ml | $stdlib
-o test/node_fs_test.cmi test/node_fs_test.cmj : cc test/node_fs_test.ml | $stdlib
-o test/node_path_test.cmi test/node_path_test.cmj : cc test/node_path_test.ml | $stdlib
-o test/null_list_test.cmi test/null_list_test.cmj : cc test/null_list_test.ml | $stdlib
-o test/number_lexer.cmi test/number_lexer.cmj : cc test/number_lexer.ml | $stdlib
-o test/obj_literal_ppx.cmi test/obj_literal_ppx.cmj : cc test/obj_literal_ppx.ml | $stdlib
-o test/obj_literal_ppx_test.cmi test/obj_literal_ppx_test.cmj : cc test/obj_literal_ppx_test.ml | $stdlib
-o test/obj_magic_test.cmi test/obj_magic_test.cmj : cc test/obj_magic_test.ml | test/mt.cmj $stdlib
-o test/obj_type_test.cmi test/obj_type_test.cmj : cc test/obj_type_test.ml | $stdlib
-o test/ocaml_re_test.cmi test/ocaml_re_test.cmj : cc test/ocaml_re_test.ml | test/mt.cmj $stdlib
-o test/of_string_test.cmi test/of_string_test.cmj : cc test/of_string_test.ml | test/mt.cmj $stdlib
-o test/offset.cmi test/offset.cmj : cc test/offset.ml | $stdlib
-o test/oo_js_test_date.cmi test/oo_js_test_date.cmj : cc test/oo_js_test_date.ml | test/mt.cmj $stdlib
-o test/option_encoding_test.cmi test/option_encoding_test.cmj : cc test/option_encoding_test.ml | $stdlib
-o test/option_repr_test.cmi test/option_repr_test.cmj : cc test/option_repr_test.ml | test/mt.cmj $stdlib
-o test/optional_ffi_test.cmi test/optional_ffi_test.cmj : cc test/optional_ffi_test.ml | test/mt.cmj $stdlib
-o test/optional_regression_test.cmi test/optional_regression_test.cmj : cc test/optional_regression_test.ml | test/mt.cmj $stdlib
-o test/pipe_send_readline.cmi test/pipe_send_readline.cmj : cc test/pipe_send_readline.ml | $stdlib
-o test/pipe_syntax.cmi test/pipe_syntax.cmj : cc test/pipe_syntax.ml | $stdlib
-o test/poly_empty_array.cmi test/poly_empty_array.cmj : cc test/poly_empty_array.ml | $stdlib
-o test/poly_type.cmi test/poly_type.cmj : cc test/poly_type.ml | $stdlib
-o test/poly_variant_test.cmj : cc_cmi test/poly_variant_test.ml | test/mt.cmj test/poly_variant_test.cmi $stdlib
-o test/poly_variant_test.cmi : cc test/poly_variant_test.mli | $stdlib
-o test/polymorphic_raw_test.cmi test/polymorphic_raw_test.cmj : cc test/polymorphic_raw_test.ml | test/mt.cmj $stdlib
-o test/polymorphism_test.cmj : cc_cmi test/polymorphism_test.ml | test/polymorphism_test.cmi $stdlib
-o test/polymorphism_test.cmi : cc test/polymorphism_test.mli | $stdlib
-o test/polyvar_convert.cmi test/polyvar_convert.cmj : cc test/polyvar_convert.ml | $stdlib
-o test/polyvar_test.cmi test/polyvar_test.cmj : cc test/polyvar_test.ml | $stdlib
-o test/ppx_apply_test.cmi test/ppx_apply_test.cmj : cc test/ppx_apply_test.ml | test/mt.cmj $stdlib
-o test/ppx_this_obj_field.cmi test/ppx_this_obj_field.cmj : cc test/ppx_this_obj_field.ml | test/mt.cmj $stdlib
-o test/ppx_this_obj_test.cmi test/ppx_this_obj_test.cmj : cc test/ppx_this_obj_test.ml | test/mt.cmj $stdlib
-o test/pq_test.cmi test/pq_test.cmj : cc test/pq_test.ml | $stdlib
-o test/pr6726.cmi test/pr6726.cmj : cc test/pr6726.ml | $stdlib
-o test/pr_regression_test.cmi test/pr_regression_test.cmj : cc test/pr_regression_test.ml | test/mt.cmj $stdlib
-o test/prepend_data_ffi.cmi test/prepend_data_ffi.cmj : cc test/prepend_data_ffi.ml | $stdlib
-o test/primitive_reg_test.cmi test/primitive_reg_test.cmj : cc test/primitive_reg_test.ml | $stdlib
-o test/print_alpha_test.cmi test/print_alpha_test.cmj : cc test/print_alpha_test.ml | test/mt.cmj $stdlib
-o test/promise.cmi test/promise.cmj : cc test/promise.ml | $stdlib
-o test/promise_catch_test.cmi test/promise_catch_test.cmj : cc test/promise_catch_test.ml | test/mt.cmj $stdlib
-o test/queue_402.cmi test/queue_402.cmj : cc test/queue_402.ml | $stdlib
-o test/queue_test.cmi test/queue_test.cmj : cc test/queue_test.ml | test/mt.cmj test/queue_402.cmj $stdlib
-o test/random_test.cmi test/random_test.cmj : cc test/random_test.ml | test/mt.cmj test/mt_global.cmj $stdlib
-o test/raw_hash_tbl_bench.cmi test/raw_hash_tbl_bench.cmj : cc test/raw_hash_tbl_bench.ml | $stdlib
-o test/raw_output_test.cmi test/raw_output_test.cmj : cc test/raw_output_test.ml | $stdlib
-o test/raw_pure_test.cmi test/raw_pure_test.cmj : cc test/raw_pure_test.ml | $stdlib
-o test/rbset.cmi test/rbset.cmj : cc test/rbset.ml | $stdlib
-o test/re_first_test.cmi test/re_first_test.cmj : cc test/re_first_test.re | $stdlib
-o test/react.cmi test/react.cmj : cc test/react.re | $stdlib
-o test/reactDOMRe.cmi test/reactDOMRe.cmj : cc test/reactDOMRe.re | test/react.cmj test/reactEvent.cmj test/reasonReact.cmj $stdlib
-o test/reactDOMServerRe.cmi test/reactDOMServerRe.cmj : cc test/reactDOMServerRe.re | test/react.cmj $stdlib
-o test/reactEvent.cmj : cc_cmi test/reactEvent.re | test/reactEvent.cmi $stdlib
-o test/reactEvent.cmi : cc test/reactEvent.rei | $stdlib
-o test/reactTestUtils.cmj : cc_cmi test/reactTestUtils.re | test/react.cmj test/reactTestUtils.cmi $stdlib
-o test/reactTestUtils.cmi : cc test/reactTestUtils.rei | test/react.cmi $stdlib
-o test/reasonReact.cmj : cc_cmi test/reasonReact.re | test/react.cmj test/reasonReact.cmi test/reasonReactOptimizedCreateClass.cmj test/reasonReactRouter.cmj $stdlib
-o test/reasonReact.cmi : cc test/reasonReact.rei | test/react.cmi test/reasonReactRouter.cmi $stdlib
-o test/reasonReactCompat.cmj : cc_cmi test/reasonReactCompat.re | test/react.cmj test/reasonReact.cmj test/reasonReactCompat.cmi $stdlib
-o test/reasonReactCompat.cmi : cc test/reasonReactCompat.rei | test/react.cmi test/reasonReact.cmi $stdlib
-o test/reasonReactOptimizedCreateClass.cmi test/reasonReactOptimizedCreateClass.cmj : cc test/reasonReactOptimizedCreateClass.re | $stdlib
-o test/reasonReactRouter.cmj : cc_cmi test/reasonReactRouter.re | test/react.cmj test/reasonReactRouter.cmi $stdlib
-o test/reasonReactRouter.cmi : cc test/reasonReactRouter.rei | $stdlib
-o test/rebind_module.cmi test/rebind_module.cmj : cc test/rebind_module.ml | $stdlib
-o test/rebind_module_test.cmi test/rebind_module_test.cmj : cc test/rebind_module_test.ml | test/rebind_module.cmj $stdlib
-o test/rec_fun_test.cmi test/rec_fun_test.cmj : cc test/rec_fun_test.ml | test/mt.cmj $stdlib
-o test/rec_module_opt.cmi test/rec_module_opt.cmj : cc test/rec_module_opt.ml | $stdlib
-o test/rec_module_test.cmi test/rec_module_test.cmj : cc test/rec_module_test.ml | test/mt.cmj $stdlib
-o test/rec_value_test.cmi test/rec_value_test.cmj : cc test/rec_value_test.ml | test/mt.cmj $stdlib
-o test/record_debug_test.cmi test/record_debug_test.cmj : cc test/record_debug_test.ml | test/mt.cmj $stdlib
-o test/record_extension_test.cmi test/record_extension_test.cmj : cc test/record_extension_test.ml | test/mt.cmj $stdlib
-o test/record_name_test.cmi test/record_name_test.cmj : cc test/record_name_test.ml | $stdlib
-o test/record_with_test.cmi test/record_with_test.cmj : cc test/record_with_test.ml | test/mt.cmj $stdlib
-o test/recursive_module.cmi test/recursive_module.cmj : cc test/recursive_module.ml | test/mt.cmj $stdlib
-o test/recursive_module_test.cmi test/recursive_module_test.cmj : cc test/recursive_module_test.ml | test/mt.cmj $stdlib
-o test/recursive_react_component.cmi test/recursive_react_component.cmj : cc test/recursive_react_component.re | test/react.cmj $stdlib
-o test/recursive_records_test.cmi test/recursive_records_test.cmj : cc test/recursive_records_test.ml | test/mt.cmj $stdlib
-o test/recursive_unbound_module_test.cmi test/recursive_unbound_module_test.cmj : cc test/recursive_unbound_module_test.ml | $stdlib
-o test/regression_print.cmi test/regression_print.cmj : cc test/regression_print.ml | $stdlib
-o test/relative_path.cmi test/relative_path.cmj : cc test/relative_path.ml | $stdlib
-o test/res_debug.cmi test/res_debug.cmj : cc test/res_debug.res | $stdlib
-o test/return_check.cmi test/return_check.cmj : cc test/return_check.ml | $stdlib
-o test/runtime_encoding_test.cmi test/runtime_encoding_test.cmj : cc test/runtime_encoding_test.ml | $stdlib
-o test/set_gen.cmi test/set_gen.cmj : cc test/set_gen.ml | $stdlib
-o test/sexp.cmj : cc_cmi test/sexp.ml | test/sexp.cmi $stdlib
-o test/sexp.cmi : cc test/sexp.mli | $stdlib
-o test/sexpm.cmj : cc_cmi test/sexpm.ml | test/sexpm.cmi $stdlib
-o test/sexpm.cmi : cc test/sexpm.mli | $stdlib
-o test/sexpm_test.cmi test/sexpm_test.cmj : cc test/sexpm_test.ml | test/mt.cmj test/sexpm.cmj $stdlib
-o test/side_effect.cmi test/side_effect.cmj : cc test/side_effect.ml | $stdlib
-o test/side_effect_free.cmi test/side_effect_free.cmj : cc test/side_effect_free.ml | $stdlib
-o test/simple_derive_test.cmj : cc_cmi test/simple_derive_test.ml | test/simple_derive_test.cmi $stdlib
-o test/simple_derive_test.cmi : cc test/simple_derive_test.mli | $stdlib
-o test/simple_derive_use.cmj : cc_cmi test/simple_derive_use.ml | test/simple_derive_use.cmi $stdlib
-o test/simple_derive_use.cmi : cc test/simple_derive_use.mli | $stdlib
-o test/simple_lexer_test.cmi test/simple_lexer_test.cmj : cc test/simple_lexer_test.ml | test/mt.cmj $stdlib
-o test/simplify_lambda_632o.cmi test/simplify_lambda_632o.cmj : cc test/simplify_lambda_632o.ml | $stdlib
-o test/single_module_alias.cmi test/single_module_alias.cmj : cc test/single_module_alias.ml | $stdlib
-o test/singular_unit_test.cmi test/singular_unit_test.cmj : cc test/singular_unit_test.ml | $stdlib
-o test/small_inline_test.cmi test/small_inline_test.cmj : cc test/small_inline_test.ml | $stdlib
-o test/splice_test.cmi test/splice_test.cmj : cc test/splice_test.ml | test/mt.cmj $stdlib
-o test/stack_comp_test.cmi test/stack_comp_test.cmj : cc test/stack_comp_test.ml | test/mt.cmj test/mt_global.cmj $stdlib
-o test/stack_test.cmi test/stack_test.cmj : cc test/stack_test.ml | test/mt.cmj $stdlib
-o test/stream_parser_test.cmi test/stream_parser_test.cmj : cc test/stream_parser_test.ml | test/mt.cmj $stdlib
-o test/string_bound_get_test.cmi test/string_bound_get_test.cmj : cc test/string_bound_get_test.ml | $stdlib
-o test/string_get_set_test.cmi test/string_get_set_test.cmj : cc test/string_get_set_test.ml | test/mt.cmj $stdlib
-o test/string_interp_test.cmi test/string_interp_test.cmj : cc test/string_interp_test.ml | $stdlib
-o test/string_literal_print_test.cmi test/string_literal_print_test.cmj : cc test/string_literal_print_test.ml | test/mt.cmj $stdlib
-o test/string_runtime_test.cmi test/string_runtime_test.cmj : cc test/string_runtime_test.ml | test/mt.cmj test/test_char.cmj $stdlib
-o test/string_set.cmi test/string_set.cmj : cc test/string_set.ml | test/set_gen.cmj $stdlib
-o test/string_set_test.cmi test/string_set_test.cmj : cc test/string_set_test.ml | test/mt.cmj test/string_set.cmj $stdlib
-o test/string_test.cmi test/string_test.cmj : cc test/string_test.ml | test/ext_string_test.cmj test/mt.cmj $stdlib
-o test/string_unicode_test.cmi test/string_unicode_test.cmj : cc test/string_unicode_test.ml | test/mt.cmj $stdlib
-o test/stringmatch_test.cmi test/stringmatch_test.cmj : cc test/stringmatch_test.ml | $stdlib
-o test/submodule.cmi test/submodule.cmj : cc test/submodule.ml | $stdlib
-o test/submodule_call.cmi test/submodule_call.cmj : cc test/submodule_call.ml | test/submodule.cmj $stdlib
-o test/switch_case_test.cmi test/switch_case_test.cmj : cc test/switch_case_test.ml | test/mt.cmj $stdlib
-o test/tailcall_inline_test.cmi test/tailcall_inline_test.cmj : cc test/tailcall_inline_test.ml | test/mt.cmj $stdlib
-o test/test.cmi test/test.cmj : cc test/test.ml | $stdlib
-o test/test2.cmi test/test2.cmj : cc test/test2.ml | $stdlib
-o test/test_alias.cmi test/test_alias.cmj : cc test/test_alias.ml | test/test_global_print.cmj $stdlib
-o test/test_ari.cmi test/test_ari.cmj : cc test/test_ari.ml | $stdlib
-o test/test_array.cmi test/test_array.cmj : cc test/test_array.ml | $stdlib
-o test/test_array_append.cmi test/test_array_append.cmj : cc test/test_array_append.ml | $stdlib
-o test/test_array_primitive.cmi test/test_array_primitive.cmj : cc test/test_array_primitive.ml | $stdlib
-o test/test_bool_equal.cmi test/test_bool_equal.cmj : cc test/test_bool_equal.ml | $stdlib
-o test/test_bs_this.cmi test/test_bs_this.cmj : cc test/test_bs_this.ml | $stdlib
-o test/test_bug.cmi test/test_bug.cmj : cc test/test_bug.ml | test/test_char.cmj $stdlib
-o test/test_bytes.cmi test/test_bytes.cmj : cc test/test_bytes.ml | $stdlib
-o test/test_case_opt_collision.cmi test/test_case_opt_collision.cmj : cc test/test_case_opt_collision.ml | test/mt.cmj $stdlib
-o test/test_case_set.cmi test/test_case_set.cmj : cc test/test_case_set.ml | $stdlib
-o test/test_char.cmi test/test_char.cmj : cc test/test_char.ml | $stdlib
-o test/test_closure.cmi test/test_closure.cmj : cc test/test_closure.ml | $stdlib
-o test/test_common.cmi test/test_common.cmj : cc test/test_common.ml | $stdlib
-o test/test_const_elim.cmi test/test_const_elim.cmj : cc test/test_const_elim.ml | $stdlib
-o test/test_const_propogate.cmi test/test_const_propogate.cmj : cc test/test_const_propogate.ml | $stdlib
-o test/test_cpp.cmi test/test_cpp.cmj : cc test/test_cpp.ml | $stdlib
-o test/test_cps.cmi test/test_cps.cmj : cc test/test_cps.ml | $stdlib
-o test/test_demo.cmi test/test_demo.cmj : cc test/test_demo.ml | $stdlib
-o test/test_dup_param.cmi test/test_dup_param.cmj : cc test/test_dup_param.ml | $stdlib
-o test/test_eq.cmi test/test_eq.cmj : cc test/test_eq.ml | $stdlib
-o test/test_exception.cmi test/test_exception.cmj : cc test/test_exception.ml | test/test_common.cmj $stdlib
-o test/test_exception_escape.cmi test/test_exception_escape.cmj : cc test/test_exception_escape.ml | $stdlib
-o test/test_export2.cmi test/test_export2.cmj : cc test/test_export2.ml | $stdlib
-o test/test_external.cmi test/test_external.cmj : cc test/test_external.ml | $stdlib
-o test/test_external_unit.cmi test/test_external_unit.cmj : cc test/test_external_unit.ml | $stdlib
-o test/test_ffi.cmi test/test_ffi.cmj : cc test/test_ffi.ml | $stdlib
-o test/test_fib.cmi test/test_fib.cmj : cc test/test_fib.ml | $stdlib
-o test/test_filename.cmi test/test_filename.cmj : cc test/test_filename.ml | $stdlib
-o test/test_for_loop.cmi test/test_for_loop.cmj : cc test/test_for_loop.ml | $stdlib
-o test/test_for_map.cmi test/test_for_map.cmj : cc test/test_for_map.ml | $stdlib
-o test/test_for_map2.cmj : cc_cmi test/test_for_map2.ml | test/int_map.cmj test/test_for_map2.cmi $stdlib
-o test/test_for_map2.cmi : cc test/test_for_map2.mli | $stdlib
-o test/test_format.cmi test/test_format.cmj : cc test/test_format.ml | $stdlib
-o test/test_formatter.cmi test/test_formatter.cmj : cc test/test_formatter.ml | $stdlib
-o test/test_functor_dead_code.cmi test/test_functor_dead_code.cmj : cc test/test_functor_dead_code.ml | $stdlib
-o test/test_generative_module.cmi test/test_generative_module.cmj : cc test/test_generative_module.ml | $stdlib
-o test/test_global_print.cmi test/test_global_print.cmj : cc test/test_global_print.ml | $stdlib
-o test/test_google_closure.cmi test/test_google_closure.cmj : cc test/test_google_closure.ml | $stdlib
-o test/test_http_server.cmj : cc_cmi test/test_http_server.ml | test/http_types.cmj test/test_http_server.cmi $stdlib
-o test/test_http_server.cmi : cc test/test_http_server.mli | $stdlib
-o test/test_include.cmi test/test_include.cmj : cc test/test_include.ml | test/test_order.cmj $stdlib
-o test/test_incomplete.cmi test/test_incomplete.cmj : cc test/test_incomplete.ml | $stdlib
-o test/test_incr_ref.cmi test/test_incr_ref.cmj : cc test/test_incr_ref.ml | $stdlib
-o test/test_index.cmi test/test_index.cmj : cc test/test_index.ml | $stdlib
-o test/test_int_map_find.cmi test/test_int_map_find.cmj : cc test/test_int_map_find.ml | $stdlib
-o test/test_internalOO.cmi test/test_internalOO.cmj : cc test/test_internalOO.ml | $stdlib
-o test/test_is_js.cmj : cc_cmi test/test_is_js.ml | test/mt.cmj test/test_is_js.cmi $stdlib
-o test/test_is_js.cmi : cc test/test_is_js.mli | $stdlib
-o test/test_js_ffi.cmi test/test_js_ffi.cmj : cc test/test_js_ffi.ml | $stdlib
-o test/test_let.cmi test/test_let.cmj : cc test/test_let.ml | $stdlib
-o test/test_list.cmi test/test_list.cmj : cc test/test_list.ml | $stdlib
-o test/test_literal.cmi test/test_literal.cmj : cc test/test_literal.ml | $stdlib
-o test/test_literals.cmi test/test_literals.cmj : cc test/test_literals.ml | $stdlib
-o test/test_match_exception.cmi test/test_match_exception.cmj : cc test/test_match_exception.ml | $stdlib
-o test/test_mutliple.cmi test/test_mutliple.cmj : cc test/test_mutliple.ml | $stdlib
-o test/test_nat64.cmi test/test_nat64.cmj : cc test/test_nat64.ml | $stdlib
-o test/test_nested_let.cmi test/test_nested_let.cmj : cc test/test_nested_let.ml | $stdlib
-o test/test_nested_print.cmi test/test_nested_print.cmj : cc test/test_nested_print.ml | $stdlib
-o test/test_non_export.cmi test/test_non_export.cmj : cc test/test_non_export.ml | $stdlib
-o test/test_nullary.cmi test/test_nullary.cmj : cc test/test_nullary.ml | $stdlib
-o test/test_obj.cmi test/test_obj.cmj : cc test/test_obj.ml | $stdlib
-o test/test_obj_simple_ffi.cmi test/test_obj_simple_ffi.cmj : cc test/test_obj_simple_ffi.ml | $stdlib
-o test/test_order.cmi test/test_order.cmj : cc test/test_order.ml | $stdlib
-o test/test_order_tailcall.cmi test/test_order_tailcall.cmj : cc test/test_order_tailcall.ml | $stdlib
-o test/test_other_exn.cmi test/test_other_exn.cmj : cc test/test_other_exn.ml | $stdlib
-o test/test_pack.cmi test/test_pack.cmj : cc test/test_pack.ml | $stdlib
-o test/test_per.cmi test/test_per.cmj : cc test/test_per.ml | $stdlib
-o test/test_pervasive.cmi test/test_pervasive.cmj : cc test/test_pervasive.ml | $stdlib
-o test/test_pervasives2.cmi test/test_pervasives2.cmj : cc test/test_pervasives2.ml | $stdlib
-o test/test_pervasives3.cmi test/test_pervasives3.cmj : cc test/test_pervasives3.ml | $stdlib
-o test/test_primitive.cmi test/test_primitive.cmj : cc test/test_primitive.ml | $stdlib
-o test/test_promise_bind.cmi test/test_promise_bind.cmj : cc test/test_promise_bind.ml | test/promise.cmj $stdlib
-o test/test_ramification.cmi test/test_ramification.cmj : cc test/test_ramification.ml | $stdlib
-o test/test_react.cmi test/test_react.cmj : cc test/test_react.ml | $stdlib
-o test/test_react_case.cmi test/test_react_case.cmj : cc test/test_react_case.ml | $stdlib
-o test/test_regex.cmi test/test_regex.cmj : cc test/test_regex.ml | $stdlib
-o test/test_require.cmi test/test_require.cmj : cc test/test_require.ml | $stdlib
-o test/test_runtime_encoding.cmi test/test_runtime_encoding.cmj : cc test/test_runtime_encoding.ml | $stdlib
-o test/test_scope.cmi test/test_scope.cmj : cc test/test_scope.ml | $stdlib
-o test/test_seq.cmi test/test_seq.cmj : cc test/test_seq.ml | $stdlib
-o test/test_set.cmi test/test_set.cmj : cc test/test_set.ml | $stdlib
-o test/test_side_effect_functor.cmi test/test_side_effect_functor.cmj : cc test/test_side_effect_functor.ml | $stdlib
-o test/test_simple_include.cmi test/test_simple_include.cmj : cc test/test_simple_include.ml | $stdlib
-o test/test_simple_pattern_match.cmi test/test_simple_pattern_match.cmj : cc test/test_simple_pattern_match.ml | $stdlib
-o test/test_simple_ref.cmi test/test_simple_ref.cmj : cc test/test_simple_ref.ml | $stdlib
-o test/test_simple_tailcall.cmi test/test_simple_tailcall.cmj : cc test/test_simple_tailcall.ml | $stdlib
-o test/test_small.cmi test/test_small.cmj : cc test/test_small.ml | $stdlib
-o test/test_sprintf.cmi test/test_sprintf.cmj : cc test/test_sprintf.ml | $stdlib
-o test/test_stack.cmi test/test_stack.cmj : cc test/test_stack.ml | $stdlib
-o test/test_static_catch_ident.cmi test/test_static_catch_ident.cmj : cc test/test_static_catch_ident.ml | $stdlib
-o test/test_string.cmi test/test_string.cmj : cc test/test_string.ml | $stdlib
-o test/test_string_case.cmi test/test_string_case.cmj : cc test/test_string_case.ml | $stdlib
-o test/test_string_const.cmi test/test_string_const.cmj : cc test/test_string_const.ml | $stdlib
-o test/test_string_map.cmi test/test_string_map.cmj : cc test/test_string_map.ml | $stdlib
-o test/test_string_switch.cmi test/test_string_switch.cmj : cc test/test_string_switch.ml | $stdlib
-o test/test_switch.cmi test/test_switch.cmj : cc test/test_switch.ml | $stdlib
-o test/test_trywith.cmi test/test_trywith.cmj : cc test/test_trywith.ml | $stdlib
-o test/test_tuple.cmi test/test_tuple.cmj : cc test/test_tuple.ml | $stdlib
-o test/test_tuple_destructring.cmi test/test_tuple_destructring.cmj : cc test/test_tuple_destructring.ml | $stdlib
-o test/test_type_based_arity.cmi test/test_type_based_arity.cmj : cc test/test_type_based_arity.ml | test/abstract_type.cmj $stdlib
-o test/test_u.cmi test/test_u.cmj : cc test/test_u.ml | $stdlib
-o test/test_unsafe_cmp.cmi test/test_unsafe_cmp.cmj : cc test/test_unsafe_cmp.ml | $stdlib
-o test/test_unsafe_obj_ffi.cmj : cc_cmi test/test_unsafe_obj_ffi.ml | test/test_unsafe_obj_ffi.cmi $stdlib
-o test/test_unsafe_obj_ffi.cmi : cc test/test_unsafe_obj_ffi.mli | $stdlib
-o test/test_unsafe_obj_ffi_ppx.cmj : cc_cmi test/test_unsafe_obj_ffi_ppx.ml | test/test_unsafe_obj_ffi_ppx.cmi $stdlib
-o test/test_unsafe_obj_ffi_ppx.cmi : cc test/test_unsafe_obj_ffi_ppx.mli | $stdlib
-o test/test_unsupported_primitive.cmi test/test_unsupported_primitive.cmj : cc test/test_unsupported_primitive.ml | $stdlib
-o test/test_while_closure.cmi test/test_while_closure.cmj : cc test/test_while_closure.ml | $stdlib
-o test/test_while_side_effect.cmi test/test_while_side_effect.cmj : cc test/test_while_side_effect.ml | $stdlib
-o test/test_zero_nullable.cmi test/test_zero_nullable.cmj : cc test/test_zero_nullable.ml | test/mt.cmj $stdlib
-o test/then_mangle_test.cmi test/then_mangle_test.cmj : cc test/then_mangle_test.res | test/mt.cmj $stdlib
-o test/ticker.cmi test/ticker.cmj : cc test/ticker.ml | $stdlib
-o test/to_string_test.cmi test/to_string_test.cmj : cc test/to_string_test.ml | test/mt.cmj $stdlib
-o test/topsort_test.cmi test/topsort_test.cmj : cc test/topsort_test.ml | $stdlib
-o test/tramp_fib.cmi test/tramp_fib.cmj : cc test/tramp_fib.ml | test/mt.cmj $stdlib
-o test/tuple_alloc.cmi test/tuple_alloc.cmj : cc test/tuple_alloc.ml | $stdlib
-o test/type_disambiguate.cmi test/type_disambiguate.cmj : cc test/type_disambiguate.ml | $stdlib
-o test/typeof_test.cmi test/typeof_test.cmj : cc test/typeof_test.ml | test/mt.cmj $stdlib
-o test/ui_defs.cmi : cc test/ui_defs.mli | $stdlib
-o test/unboxed_attribute_test.cmi test/unboxed_attribute_test.cmj : cc test/unboxed_attribute_test.ml | test/mt.cmj $stdlib
-o test/unboxed_use_case.cmj : cc_cmi test/unboxed_use_case.ml | test/unboxed_use_case.cmi $stdlib
-o test/unboxed_use_case.cmi : cc test/unboxed_use_case.mli | $stdlib
-o test/uncurry_external_test.cmi test/uncurry_external_test.cmj : cc test/uncurry_external_test.ml | test/mt.cmj $stdlib
-o test/uncurry_glob_test.cmi test/uncurry_glob_test.cmj : cc test/uncurry_glob_test.ml | $stdlib
-o test/uncurry_method.cmi test/uncurry_method.cmj : cc test/uncurry_method.ml | $stdlib
-o test/uncurry_test.cmj : cc_cmi test/uncurry_test.ml | test/uncurry_test.cmi $stdlib
-o test/uncurry_test.cmi : cc test/uncurry_test.mli | $stdlib
-o test/undef_regression2_test.cmi test/undef_regression2_test.cmj : cc test/undef_regression2_test.ml | test/mt.cmj $stdlib
-o test/undef_regression_test.cmi test/undef_regression_test.cmj : cc test/undef_regression_test.ml | $stdlib
-o test/unicode_type_error.cmi test/unicode_type_error.cmj : cc test/unicode_type_error.ml | $stdlib
-o test/unit_undefined_test.cmi test/unit_undefined_test.cmj : cc test/unit_undefined_test.ml | test/mt.cmj $stdlib
-o test/unitest_string.cmi test/unitest_string.cmj : cc test/unitest_string.ml | $stdlib
-o test/unsafe_full_apply_primitive.cmi test/unsafe_full_apply_primitive.cmj : cc test/unsafe_full_apply_primitive.ml | $stdlib
-o test/unsafe_obj_external.cmi test/unsafe_obj_external.cmj : cc test/unsafe_obj_external.ml | $stdlib
-o test/unsafe_ppx_test.cmi test/unsafe_ppx_test.cmj : cc test/unsafe_ppx_test.ml | test/ffi_js_test.cmj test/mt.cmj $stdlib
-o test/unsafe_this.cmj : cc_cmi test/unsafe_this.ml | test/unsafe_this.cmi $stdlib
-o test/unsafe_this.cmi : cc test/unsafe_this.mli | $stdlib
-o test/update_record_test.cmi test/update_record_test.cmj : cc test/update_record_test.ml | test/mt.cmj $stdlib
-o test/utf8_decode_test.cmi test/utf8_decode_test.cmj : cc test/utf8_decode_test.ml | test/mt.cmj $stdlib
-o test/variant.cmi test/variant.cmj : cc test/variant.ml | $stdlib
-o test/watch_test.cmi test/watch_test.cmj : cc test/watch_test.ml | $stdlib
-o test/webpack_config.cmi test/webpack_config.cmj : cc test/webpack_config.ml | $stdlib
+o test/406_primitive_test.cmi test/406_primitive_test.cmj : cc test/406_primitive_test.ml | test/mt.cmj $bsc $stdlib
+o test/a.cmi test/a.cmj : cc test/a.ml | test/test_order.cmj $bsc $stdlib
+o test/a_filename_test.cmi test/a_filename_test.cmj : cc test/a_filename_test.ml | test/ext_filename_test.cmj test/mt.cmj $bsc $stdlib
+o test/a_list_test.cmi test/a_list_test.cmj : cc test/a_list_test.ml | test/ext_list_test.cmj test/mt.cmj $bsc $stdlib
+o test/a_recursive_type.cmj : cc_cmi test/a_recursive_type.ml | test/a_recursive_type.cmi $bsc $stdlib
+o test/a_recursive_type.cmi : cc test/a_recursive_type.mli | $bsc $stdlib
+o test/a_scope_bug.cmi test/a_scope_bug.cmj : cc test/a_scope_bug.ml | $bsc $stdlib
+o test/a_string_test.cmi test/a_string_test.cmj : cc test/a_string_test.ml | test/ext_string_test.cmj test/mt.cmj $bsc $stdlib
+o test/abstract_type.cmj : cc_cmi test/abstract_type.ml | test/abstract_type.cmi $bsc $stdlib
+o test/abstract_type.cmi : cc test/abstract_type.mli | test/mt.cmi $bsc $stdlib
+o test/adt_optimize_test.cmi test/adt_optimize_test.cmj : cc test/adt_optimize_test.ml | $bsc $stdlib
+o test/alias_test.cmj : cc_cmi test/alias_test.ml | test/alias_test.cmi $bsc $stdlib
+o test/alias_test.cmi : cc test/alias_test.mli | $bsc $stdlib
+o test/and_or_tailcall_test.cmi test/and_or_tailcall_test.cmj : cc test/and_or_tailcall_test.ml | test/mt.cmj $bsc $stdlib
+o test/app_root_finder.cmi test/app_root_finder.cmj : cc test/app_root_finder.ml | $bsc $stdlib
+o test/argv_test.cmi test/argv_test.cmj : cc test/argv_test.ml | $bsc $stdlib
+o test/ari_regress_test.cmj : cc_cmi test/ari_regress_test.ml | test/ari_regress_test.cmi test/mt.cmj $bsc $stdlib
+o test/ari_regress_test.cmi : cc test/ari_regress_test.mli | $bsc $stdlib
+o test/arith_lexer.cmi test/arith_lexer.cmj : cc test/arith_lexer.ml | test/arith_parser.cmj test/arith_syntax.cmj $bsc $stdlib
+o test/arith_parser.cmi test/arith_parser.cmj : cc test/arith_parser.ml | test/arith_syntax.cmj $bsc $stdlib
+o test/arith_syntax.cmi test/arith_syntax.cmj : cc test/arith_syntax.ml | $bsc $stdlib
+o test/arity.cmi test/arity.cmj : cc test/arity.re | $bsc $stdlib
+o test/arity_deopt.cmi test/arity_deopt.cmj : cc test/arity_deopt.ml | test/mt.cmj $bsc $stdlib
+o test/arity_infer.cmi test/arity_infer.cmj : cc test/arity_infer.ml | $bsc $stdlib
+o test/arity_ml.cmi test/arity_ml.cmj : cc test/arity_ml.ml | $bsc $stdlib
+o test/array_data_util.cmi test/array_data_util.cmj : cc test/array_data_util.ml | $bsc $stdlib
+o test/array_safe_get.cmi test/array_safe_get.cmj : cc test/array_safe_get.ml | $bsc $stdlib
+o test/array_subtle_test.cmi test/array_subtle_test.cmj : cc test/array_subtle_test.ml | test/mt.cmj $bsc $stdlib
+o test/array_test.cmj : cc_cmi test/array_test.ml | test/array_test.cmi test/mt.cmj $bsc $stdlib
+o test/array_test.cmi : cc test/array_test.mli | $bsc $stdlib
+o test/ast_abstract_test.cmi test/ast_abstract_test.cmj : cc test/ast_abstract_test.ml | test/mt.cmj $bsc $stdlib
+o test/ast_js_mapper_poly_test.cmi test/ast_js_mapper_poly_test.cmj : cc test/ast_js_mapper_poly_test.ml | test/mt.cmj $bsc $stdlib
+o test/ast_js_mapper_test.cmj : cc_cmi test/ast_js_mapper_test.ml | test/ast_js_mapper_test.cmi $bsc $stdlib
+o test/ast_js_mapper_test.cmi : cc test/ast_js_mapper_test.mli | $bsc $stdlib
+o test/ast_mapper_defensive_test.cmi test/ast_mapper_defensive_test.cmj : cc test/ast_mapper_defensive_test.ml | test/mt.cmj $bsc $stdlib
+o test/ast_mapper_unused_warning_test.cmi test/ast_mapper_unused_warning_test.cmj : cc test/ast_mapper_unused_warning_test.ml | $bsc $stdlib
+o test/async_ideas.cmi test/async_ideas.cmj : cc test/async_ideas.ml | $bsc $stdlib
+o test/attr_test.cmi test/attr_test.cmj : cc test/attr_test.ml | $bsc $stdlib
+o test/b.cmi test/b.cmj : cc test/b.ml | $bsc $stdlib
+o test/bal_set_mini.cmi test/bal_set_mini.cmj : cc test/bal_set_mini.ml | $bsc $stdlib
+o test/bang_primitive.cmi test/bang_primitive.cmj : cc test/bang_primitive.ml | $bsc $stdlib
+o test/basic_module_test.cmj : cc_cmi test/basic_module_test.ml | test/basic_module_test.cmi test/mt.cmj test/mt_global.cmj test/offset.cmj test/pr6726.cmj $bsc $stdlib
+o test/basic_module_test.cmi : cc test/basic_module_test.mli | $bsc $stdlib
+o test/bb.cmi test/bb.cmj : cc test/bb.ml | $bsc $stdlib
+o test/bdd.cmi test/bdd.cmj : cc test/bdd.ml | $bsc $stdlib
+o test/belt_internal_test.cmi test/belt_internal_test.cmj : cc test/belt_internal_test.ml | $bsc $stdlib
+o test/belt_result_alias_test.cmi test/belt_result_alias_test.cmj : cc test/belt_result_alias_test.ml | $bsc $stdlib
+o test/bench.cmi test/bench.cmj : cc test/bench.ml | $bsc $stdlib
+o test/big_enum.cmi test/big_enum.cmj : cc test/big_enum.ml | $bsc $stdlib
+o test/big_polyvar_test.cmi test/big_polyvar_test.cmj : cc test/big_polyvar_test.ml | $bsc $stdlib
+o test/block_alias_test.cmi test/block_alias_test.cmj : cc test/block_alias_test.ml | test/mt.cmj $bsc $stdlib
+o test/boolean_test.cmi test/boolean_test.cmj : cc test/boolean_test.ml | test/mt.cmj test/test_bool_equal.cmj $bsc $stdlib
+o test/bs_MapInt_test.cmi test/bs_MapInt_test.cmj : cc test/bs_MapInt_test.ml | $bsc $stdlib
+o test/bs_abstract_test.cmj : cc_cmi test/bs_abstract_test.ml | test/bs_abstract_test.cmi $bsc $stdlib
+o test/bs_abstract_test.cmi : cc test/bs_abstract_test.mli | $bsc $stdlib
+o test/bs_array_test.cmi test/bs_array_test.cmj : cc test/bs_array_test.ml | test/mt.cmj $bsc $stdlib
+o test/bs_auto_uncurry.cmi test/bs_auto_uncurry.cmj : cc test/bs_auto_uncurry.ml | $bsc $stdlib
+o test/bs_auto_uncurry_test.cmi test/bs_auto_uncurry_test.cmj : cc test/bs_auto_uncurry_test.ml | test/mt.cmj $bsc $stdlib
+o test/bs_float_test.cmi test/bs_float_test.cmj : cc test/bs_float_test.ml | test/mt.cmj $bsc $stdlib
+o test/bs_hashmap_test.cmi test/bs_hashmap_test.cmj : cc test/bs_hashmap_test.ml | test/array_data_util.cmj test/mt.cmj $bsc $stdlib
+o test/bs_hashset_int_test.cmi test/bs_hashset_int_test.cmj : cc test/bs_hashset_int_test.ml | test/array_data_util.cmj test/mt.cmj $bsc $stdlib
+o test/bs_hashtbl_string_test.cmi test/bs_hashtbl_string_test.cmj : cc test/bs_hashtbl_string_test.ml | $bsc $stdlib
+o test/bs_ignore_effect.cmi test/bs_ignore_effect.cmj : cc test/bs_ignore_effect.ml | test/mt.cmj $bsc $stdlib
+o test/bs_ignore_test.cmi test/bs_ignore_test.cmj : cc test/bs_ignore_test.ml | $bsc $stdlib
+o test/bs_int_test.cmi test/bs_int_test.cmj : cc test/bs_int_test.ml | test/mt.cmj $bsc $stdlib
+o test/bs_list_test.cmi test/bs_list_test.cmj : cc test/bs_list_test.ml | test/mt.cmj $bsc $stdlib
+o test/bs_map_set_dict_test.cmi test/bs_map_set_dict_test.cmj : cc test/bs_map_set_dict_test.ml | test/array_data_util.cmj test/mt.cmj $bsc $stdlib
+o test/bs_map_test.cmi test/bs_map_test.cmj : cc test/bs_map_test.ml | test/mt.cmj $bsc $stdlib
+o test/bs_min_max_test.cmi test/bs_min_max_test.cmj : cc test/bs_min_max_test.ml | test/mt.cmj $bsc $stdlib
+o test/bs_mutable_set_test.cmi test/bs_mutable_set_test.cmj : cc test/bs_mutable_set_test.ml | test/array_data_util.cmj test/mt.cmj $bsc $stdlib
+o test/bs_node_string_buffer_test.cmi test/bs_node_string_buffer_test.cmj : cc test/bs_node_string_buffer_test.ml | $bsc $stdlib
+o test/bs_poly_map_test.cmi test/bs_poly_map_test.cmj : cc test/bs_poly_map_test.ml | test/array_data_util.cmj test/mt.cmj $bsc $stdlib
+o test/bs_poly_mutable_map_test.cmi test/bs_poly_mutable_map_test.cmj : cc test/bs_poly_mutable_map_test.ml | test/array_data_util.cmj test/mt.cmj $bsc $stdlib
+o test/bs_poly_mutable_set_test.cmi test/bs_poly_mutable_set_test.cmj : cc test/bs_poly_mutable_set_test.ml | test/array_data_util.cmj test/mt.cmj $bsc $stdlib
+o test/bs_poly_set_test.cmi test/bs_poly_set_test.cmj : cc test/bs_poly_set_test.ml | test/array_data_util.cmj test/mt.cmj $bsc $stdlib
+o test/bs_qualified.cmi test/bs_qualified.cmj : cc test/bs_qualified.ml | $bsc $stdlib
+o test/bs_queue_test.cmi test/bs_queue_test.cmj : cc test/bs_queue_test.ml | test/mt.cmj $bsc $stdlib
+o test/bs_rbset_int_bench.cmi test/bs_rbset_int_bench.cmj : cc test/bs_rbset_int_bench.ml | test/rbset.cmj $bsc $stdlib
+o test/bs_rest_test.cmi test/bs_rest_test.cmj : cc test/bs_rest_test.ml | $bsc $stdlib
+o test/bs_set_bench.cmi test/bs_set_bench.cmj : cc test/bs_set_bench.ml | $bsc $stdlib
+o test/bs_set_int_test.cmi test/bs_set_int_test.cmj : cc test/bs_set_int_test.ml | test/array_data_util.cmj test/mt.cmj $bsc $stdlib
+o test/bs_sort_test.cmi test/bs_sort_test.cmj : cc test/bs_sort_test.ml | test/array_data_util.cmj test/mt.cmj $bsc $stdlib
+o test/bs_splice_partial.cmi test/bs_splice_partial.cmj : cc test/bs_splice_partial.ml | $bsc $stdlib
+o test/bs_stack_test.cmi test/bs_stack_test.cmj : cc test/bs_stack_test.ml | test/mt.cmj $bsc $stdlib
+o test/bs_string_test.cmi test/bs_string_test.cmj : cc test/bs_string_test.ml | test/mt.cmj $bsc $stdlib
+o test/bs_unwrap_test.cmi test/bs_unwrap_test.cmj : cc test/bs_unwrap_test.ml | $bsc $stdlib
+o test/buffer_test.cmi test/buffer_test.cmj : cc test/buffer_test.ml | test/mt.cmj $bsc $stdlib
+o test/bytes_split_gpr_743_test.cmi test/bytes_split_gpr_743_test.cmj : cc test/bytes_split_gpr_743_test.ml | test/mt.cmj $bsc $stdlib
+o test/caml_compare_test.cmi test/caml_compare_test.cmj : cc test/caml_compare_test.ml | test/mt.cmj $bsc $stdlib
+o test/caml_format_test.cmi test/caml_format_test.cmj : cc test/caml_format_test.ml | test/mt.cmj $bsc $stdlib
+o test/caml_sys_poly_fill_test.cmi test/caml_sys_poly_fill_test.cmj : cc test/caml_sys_poly_fill_test.ml | test/mt.cmj $bsc $stdlib
+o test/chain_code_test.cmi test/chain_code_test.cmj : cc test/chain_code_test.ml | test/mt.cmj $bsc $stdlib
+o test/chn_test.cmi test/chn_test.cmj : cc test/chn_test.ml | test/mt.cmj $bsc $stdlib
+o test/class_setter_getter.cmj : cc_cmi test/class_setter_getter.ml | test/class_setter_getter.cmi $bsc $stdlib
+o test/class_setter_getter.cmi : cc test/class_setter_getter.mli | $bsc $stdlib
+o test/class_type_ffi_test.cmi test/class_type_ffi_test.cmj : cc test/class_type_ffi_test.ml | $bsc $stdlib
+o test/compare_test.cmi test/compare_test.cmj : cc test/compare_test.ml | $bsc $stdlib
+o test/complete_parmatch_test.cmi test/complete_parmatch_test.cmj : cc test/complete_parmatch_test.ml | $bsc $stdlib
+o test/complex_if_test.cmi test/complex_if_test.cmj : cc test/complex_if_test.ml | test/mt.cmj $bsc $stdlib
+o test/complex_test.cmi test/complex_test.cmj : cc test/complex_test.ml | test/mt.cmj $bsc $stdlib
+o test/complex_while_loop.cmi test/complex_while_loop.cmj : cc test/complex_while_loop.ml | $bsc $stdlib
+o test/condition_compilation_test.cmi test/condition_compilation_test.cmj : cc test/condition_compilation_test.ml | test/mt.cmj $bsc $stdlib
+o test/config1_test.cmi test/config1_test.cmj : cc test/config1_test.ml | $bsc $stdlib
+o test/config2_test.cmj : cc_cmi test/config2_test.ml | test/config2_test.cmi $bsc $stdlib
+o test/config2_test.cmi : cc test/config2_test.mli | $bsc $stdlib
+o test/console_log_test.cmi test/console_log_test.cmj : cc test/console_log_test.ml | $bsc $stdlib
+o test/const_block_test.cmj : cc_cmi test/const_block_test.ml | test/const_block_test.cmi test/mt.cmj $bsc $stdlib
+o test/const_block_test.cmi : cc test/const_block_test.mli | $bsc $stdlib
+o test/const_defs.cmi test/const_defs.cmj : cc test/const_defs.ml | $bsc $stdlib
+o test/const_defs_test.cmi test/const_defs_test.cmj : cc test/const_defs_test.ml | test/const_defs.cmj $bsc $stdlib
+o test/const_test.cmi test/const_test.cmj : cc test/const_test.ml | $bsc $stdlib
+o test/cont_int_fold_test.cmi test/cont_int_fold_test.cmj : cc test/cont_int_fold_test.ml | $bsc $stdlib
+o test/cps_test.cmi test/cps_test.cmj : cc test/cps_test.ml | test/mt.cmj $bsc $stdlib
+o test/cross_module_inline_test.cmi test/cross_module_inline_test.cmj : cc test/cross_module_inline_test.ml | test/test_char.cmj $bsc $stdlib
+o test/custom_error_test.cmi test/custom_error_test.cmj : cc test/custom_error_test.ml | $bsc $stdlib
+o test/debug_keep_test.cmi test/debug_keep_test.cmj : cc test/debug_keep_test.ml | $bsc $stdlib
+o test/debug_mode_value.cmi test/debug_mode_value.cmj : cc test/debug_mode_value.ml | $bsc $stdlib
+o test/debug_tmp.cmi test/debug_tmp.cmj : cc test/debug_tmp.ml | $bsc $stdlib
+o test/debugger_test.cmi test/debugger_test.cmj : cc test/debugger_test.ml | $bsc $stdlib
+o test/default_export_test.cmi test/default_export_test.cmj : cc test/default_export_test.ml | $bsc $stdlib
+o test/defunctor_make_test.cmi test/defunctor_make_test.cmj : cc test/defunctor_make_test.ml | $bsc $stdlib
+o test/demo.cmi test/demo.cmj : cc test/demo.ml | test/demo_binding.cmj $bsc $stdlib
+o test/demo_binding.cmi test/demo_binding.cmj : cc test/demo_binding.ml | $bsc $stdlib
+o test/demo_int_map.cmj : cc_cmi test/demo_int_map.ml | test/demo_int_map.cmi $bsc $stdlib
+o test/demo_int_map.cmi : cc test/demo_int_map.mli | $bsc $stdlib
+o test/demo_page.cmi test/demo_page.cmj : cc test/demo_page.ml | $bsc $stdlib
+o test/demo_pipe.cmi test/demo_pipe.cmj : cc test/demo_pipe.ml | $bsc $stdlib
+o test/derive_dyntype.cmi test/derive_dyntype.cmj : cc test/derive_dyntype.ml | $bsc $stdlib
+o test/derive_projector_test.cmj : cc_cmi test/derive_projector_test.ml | test/derive_projector_test.cmi $bsc $stdlib
+o test/derive_projector_test.cmi : cc test/derive_projector_test.mli | $bsc $stdlib
+o test/derive_type_test.cmi test/derive_type_test.cmj : cc test/derive_type_test.ml | $bsc $stdlib
+o test/digest_test.cmi test/digest_test.cmj : cc test/digest_test.ml | test/ext_array_test.cmj test/mt.cmj $bsc $stdlib
+o test/div_by_zero_test.cmi test/div_by_zero_test.cmj : cc test/div_by_zero_test.ml | test/mt.cmj $bsc $stdlib
+o test/dollar_escape_test.cmi test/dollar_escape_test.cmj : cc test/dollar_escape_test.ml | test/mt.cmj $bsc $stdlib
+o test/earger_curry_test.cmi test/earger_curry_test.cmj : cc test/earger_curry_test.ml | test/mt.cmj $bsc $stdlib
+o test/effect.cmi test/effect.cmj : cc test/effect.ml | $bsc $stdlib
+o test/epsilon_test.cmi test/epsilon_test.cmj : cc test/epsilon_test.ml | test/mt.cmj $bsc $stdlib
+o test/equal_box_test.cmi test/equal_box_test.cmj : cc test/equal_box_test.ml | test/mt.cmj $bsc $stdlib
+o test/equal_exception_test.cmi test/equal_exception_test.cmj : cc test/equal_exception_test.ml | test/mt.cmj $bsc $stdlib
+o test/equal_test.cmi test/equal_test.cmj : cc test/equal_test.ml | $bsc $stdlib
+o test/es6_export.cmi test/es6_export.cmj : cc test/es6_export.ml | $bsc $stdlib
+o test/es6_import.cmi test/es6_import.cmj : cc test/es6_import.ml | test/es6_export.cmj $bsc $stdlib
+o test/es6_module_test.cmi test/es6_module_test.cmj : cc test/es6_module_test.ml | test/mt.cmj $bsc $stdlib
+o test/escape_esmodule.cmi test/escape_esmodule.cmj : cc test/escape_esmodule.ml | $bsc $stdlib
+o test/esmodule_ref.cmi test/esmodule_ref.cmj : cc test/esmodule_ref.ml | test/escape_esmodule.cmj $bsc $stdlib
+o test/event_ffi.cmi test/event_ffi.cmj : cc test/event_ffi.ml | $bsc $stdlib
+o test/exception_alias.cmi test/exception_alias.cmj : cc test/exception_alias.ml | $bsc $stdlib
+o test/exception_def.cmi test/exception_def.cmj : cc test/exception_def.ml | test/mt.cmj test/test_other_exn.cmj $bsc $stdlib
+o test/exception_raise_test.cmi test/exception_raise_test.cmj : cc test/exception_raise_test.ml | test/mt.cmj $bsc $stdlib
+o test/exception_rebind_test.cmi test/exception_rebind_test.cmj : cc test/exception_rebind_test.ml | test/exception_def.cmj $bsc $stdlib
+o test/exception_rebound_err_test.cmi test/exception_rebound_err_test.cmj : cc test/exception_rebound_err_test.ml | test/mt.cmj $bsc $stdlib
+o test/exception_repr_test.cmi test/exception_repr_test.cmj : cc test/exception_repr_test.ml | test/exception_def.cmj test/mt.cmj $bsc $stdlib
+o test/exception_value_test.cmi test/exception_value_test.cmj : cc test/exception_value_test.ml | $bsc $stdlib
+o test/exn_error_pattern.cmi test/exn_error_pattern.cmj : cc test/exn_error_pattern.ml | test/mt.cmj $bsc $stdlib
+o test/export_keyword.cmi test/export_keyword.cmj : cc test/export_keyword.ml | $bsc $stdlib
+o test/ext_array_test.cmi test/ext_array_test.cmj : cc test/ext_array_test.ml | $bsc $stdlib
+o test/ext_bytes_test.cmi test/ext_bytes_test.cmj : cc test/ext_bytes_test.ml | test/mt.cmj $bsc $stdlib
+o test/ext_filename_test.cmi test/ext_filename_test.cmj : cc test/ext_filename_test.ml | test/ext_string_test.cmj test/test_literals.cmj $bsc $stdlib
+o test/ext_list_test.cmi test/ext_list_test.cmj : cc test/ext_list_test.ml | test/ext_string_test.cmj $bsc $stdlib
+o test/ext_pervasives_test.cmj : cc_cmi test/ext_pervasives_test.ml | test/ext_pervasives_test.cmi $bsc $stdlib
+o test/ext_pervasives_test.cmi : cc test/ext_pervasives_test.mli | $bsc $stdlib
+o test/ext_string_test.cmi test/ext_string_test.cmj : cc test/ext_string_test.ml | test/ext_bytes_test.cmj $bsc $stdlib
+o test/ext_sys_test.cmj : cc_cmi test/ext_sys_test.ml | test/ext_sys_test.cmi $bsc $stdlib
+o test/ext_sys_test.cmi : cc test/ext_sys_test.mli | $bsc $stdlib
+o test/extensible_variant_test.cmi test/extensible_variant_test.cmj : cc test/extensible_variant_test.ml | test/mt.cmj $bsc $stdlib
+o test/external_polyfill_test.cmi test/external_polyfill_test.cmj : cc test/external_polyfill_test.ml | test/mt.cmj $bsc $stdlib
+o test/external_ppx.cmi test/external_ppx.cmj : cc test/external_ppx.ml | $bsc $stdlib
+o test/fail_comp.cmi test/fail_comp.cmj : cc test/fail_comp.ml | $bsc $stdlib
+o test/ffi_arity_test.cmi test/ffi_arity_test.cmj : cc test/ffi_arity_test.ml | test/mt.cmj $bsc $stdlib
+o test/ffi_array_test.cmi test/ffi_array_test.cmj : cc test/ffi_array_test.ml | test/mt.cmj $bsc $stdlib
+o test/ffi_js_test.cmi test/ffi_js_test.cmj : cc test/ffi_js_test.ml | test/mt.cmj $bsc $stdlib
+o test/ffi_splice_test.cmi test/ffi_splice_test.cmj : cc test/ffi_splice_test.ml | test/mt.cmj $bsc $stdlib
+o test/ffi_test.cmi test/ffi_test.cmj : cc test/ffi_test.ml | $bsc $stdlib
+o test/fib.cmi test/fib.cmj : cc test/fib.ml | $bsc $stdlib
+o test/flattern_order_test.cmi test/flattern_order_test.cmj : cc test/flattern_order_test.ml | $bsc $stdlib
+o test/flexible_array_test.cmi test/flexible_array_test.cmj : cc test/flexible_array_test.ml | $bsc $stdlib
+o test/float_array.cmi test/float_array.cmj : cc test/float_array.ml | $bsc $stdlib
+o test/float_of_bits_test.cmi test/float_of_bits_test.cmj : cc test/float_of_bits_test.ml | test/mt.cmj $bsc $stdlib
+o test/float_record.cmj : cc_cmi test/float_record.ml | test/float_record.cmi $bsc $stdlib
+o test/float_record.cmi : cc test/float_record.mli | $bsc $stdlib
+o test/float_test.cmi test/float_test.cmj : cc test/float_test.ml | test/mt.cmj test/mt_global.cmj $bsc $stdlib
+o test/floatarray_test.cmi test/floatarray_test.cmj : cc test/floatarray_test.ml | test/mt.cmj $bsc $stdlib
+o test/flow_parser_reg_test.cmj : cc_cmi test/flow_parser_reg_test.ml | test/flow_parser_reg_test.cmi test/mt.cmj $bsc $stdlib
+o test/flow_parser_reg_test.cmi : cc test/flow_parser_reg_test.mli | $bsc $stdlib
+o test/for_loop_test.cmi test/for_loop_test.cmj : cc test/for_loop_test.ml | test/mt.cmj $bsc $stdlib
+o test/for_side_effect_test.cmi test/for_side_effect_test.cmj : cc test/for_side_effect_test.ml | test/mt.cmj $bsc $stdlib
+o test/format_regression.cmi test/format_regression.cmj : cc test/format_regression.ml | $bsc $stdlib
+o test/format_test.cmi test/format_test.cmj : cc test/format_test.ml | test/mt.cmj $bsc $stdlib
+o test/fs_test.cmi test/fs_test.cmj : cc test/fs_test.ml | test/mt.cmj $bsc $stdlib
+o test/fun_pattern_match.cmi test/fun_pattern_match.cmj : cc test/fun_pattern_match.ml | $bsc $stdlib
+o test/functor_app_test.cmi test/functor_app_test.cmj : cc test/functor_app_test.ml | test/functor_def.cmj test/functor_inst.cmj test/mt.cmj $bsc $stdlib
+o test/functor_def.cmi test/functor_def.cmj : cc test/functor_def.ml | $bsc $stdlib
+o test/functor_ffi.cmi test/functor_ffi.cmj : cc test/functor_ffi.ml | $bsc $stdlib
+o test/functor_inst.cmi test/functor_inst.cmj : cc test/functor_inst.ml | $bsc $stdlib
+o test/functors.cmi test/functors.cmj : cc test/functors.ml | $bsc $stdlib
+o test/gbk.cmi test/gbk.cmj : cc test/gbk.ml | $bsc $stdlib
+o test/genlex_test.cmi test/genlex_test.cmj : cc test/genlex_test.ml | test/mt.cmj $bsc $stdlib
+o test/gentTypeReTest.cmi test/gentTypeReTest.cmj : cc test/gentTypeReTest.re | $bsc $stdlib
+o test/global_exception_regression_test.cmi test/global_exception_regression_test.cmj : cc test/global_exception_regression_test.ml | test/mt.cmj $bsc $stdlib
+o test/global_mangles.cmi test/global_mangles.cmj : cc test/global_mangles.ml | $bsc $stdlib
+o test/global_module_alias_test.cmi test/global_module_alias_test.cmj : cc test/global_module_alias_test.ml | test/mt.cmj $bsc $stdlib
+o test/google_closure_test.cmi test/google_closure_test.cmj : cc test/google_closure_test.ml | test/mt.cmj test/test_google_closure.cmj $bsc $stdlib
+o test/gpr496_test.cmi test/gpr496_test.cmj : cc test/gpr496_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_1063_test.cmi test/gpr_1063_test.cmj : cc test/gpr_1063_test.ml | $bsc $stdlib
+o test/gpr_1072.cmi test/gpr_1072.cmj : cc test/gpr_1072.ml | $bsc $stdlib
+o test/gpr_1072_reg.cmi test/gpr_1072_reg.cmj : cc test/gpr_1072_reg.ml | $bsc $stdlib
+o test/gpr_1150.cmi test/gpr_1150.cmj : cc test/gpr_1150.ml | $bsc $stdlib
+o test/gpr_1154_test.cmi test/gpr_1154_test.cmj : cc test/gpr_1154_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_1170.cmi test/gpr_1170.cmj : cc test/gpr_1170.ml | $bsc $stdlib
+o test/gpr_1240_missing_unbox.cmi test/gpr_1240_missing_unbox.cmj : cc test/gpr_1240_missing_unbox.ml | $bsc $stdlib
+o test/gpr_1245_test.cmi test/gpr_1245_test.cmj : cc test/gpr_1245_test.ml | $bsc $stdlib
+o test/gpr_1268.cmi test/gpr_1268.cmj : cc test/gpr_1268.ml | $bsc $stdlib
+o test/gpr_1409_test.cmi test/gpr_1409_test.cmj : cc test/gpr_1409_test.ml | test/mt.cmj test/string_set.cmj $bsc $stdlib
+o test/gpr_1423_app_test.cmi test/gpr_1423_app_test.cmj : cc test/gpr_1423_app_test.ml | test/gpr_1423_nav.cmj test/mt.cmj $bsc $stdlib
+o test/gpr_1423_nav.cmi test/gpr_1423_nav.cmj : cc test/gpr_1423_nav.ml | $bsc $stdlib
+o test/gpr_1438.cmi test/gpr_1438.cmj : cc test/gpr_1438.ml | $bsc $stdlib
+o test/gpr_1481.cmi test/gpr_1481.cmj : cc test/gpr_1481.ml | $bsc $stdlib
+o test/gpr_1484.cmi test/gpr_1484.cmj : cc test/gpr_1484.ml | $bsc $stdlib
+o test/gpr_1501_test.cmi test/gpr_1501_test.cmj : cc test/gpr_1501_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_1503_test.cmi test/gpr_1503_test.cmj : cc test/gpr_1503_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_1539_test.cmi test/gpr_1539_test.cmj : cc test/gpr_1539_test.ml | $bsc $stdlib
+o test/gpr_1600_test.cmi test/gpr_1600_test.cmj : cc test/gpr_1600_test.ml | $bsc $stdlib
+o test/gpr_1658_test.cmi test/gpr_1658_test.cmj : cc test/gpr_1658_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_1667_test.cmi test/gpr_1667_test.cmj : cc test/gpr_1667_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_1692_test.cmi test/gpr_1692_test.cmj : cc test/gpr_1692_test.ml | $bsc $stdlib
+o test/gpr_1698_test.cmi test/gpr_1698_test.cmj : cc test/gpr_1698_test.ml | $bsc $stdlib
+o test/gpr_1701_test.cmi test/gpr_1701_test.cmj : cc test/gpr_1701_test.ml | $bsc $stdlib
+o test/gpr_1716_test.cmi test/gpr_1716_test.cmj : cc test/gpr_1716_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_1717_test.cmi test/gpr_1717_test.cmj : cc test/gpr_1717_test.ml | $bsc $stdlib
+o test/gpr_1728_test.cmi test/gpr_1728_test.cmj : cc test/gpr_1728_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_1749_test.cmi test/gpr_1749_test.cmj : cc test/gpr_1749_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_1759_test.cmi test/gpr_1759_test.cmj : cc test/gpr_1759_test.ml | $bsc $stdlib
+o test/gpr_1760_test.cmi test/gpr_1760_test.cmj : cc test/gpr_1760_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_1762_test.cmi test/gpr_1762_test.cmj : cc test/gpr_1762_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_1817_test.cmi test/gpr_1817_test.cmj : cc test/gpr_1817_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_1822_test.cmi test/gpr_1822_test.cmj : cc test/gpr_1822_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_1891_test.cmi test/gpr_1891_test.cmj : cc test/gpr_1891_test.ml | $bsc $stdlib
+o test/gpr_1943_test.cmi test/gpr_1943_test.cmj : cc test/gpr_1943_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_1946_test.cmi test/gpr_1946_test.cmj : cc test/gpr_1946_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_2316_test.cmi test/gpr_2316_test.cmj : cc test/gpr_2316_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_2352_test.cmi test/gpr_2352_test.cmj : cc test/gpr_2352_test.ml | $bsc $stdlib
+o test/gpr_2413_test.cmi test/gpr_2413_test.cmj : cc test/gpr_2413_test.ml | $bsc $stdlib
+o test/gpr_2474.cmi test/gpr_2474.cmj : cc test/gpr_2474.ml | $bsc $stdlib
+o test/gpr_2487.cmi test/gpr_2487.cmj : cc test/gpr_2487.ml | $bsc $stdlib
+o test/gpr_2503_test.cmi test/gpr_2503_test.cmj : cc test/gpr_2503_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_2608_test.cmi test/gpr_2608_test.cmj : cc test/gpr_2608_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_2614_test.cmi test/gpr_2614_test.cmj : cc test/gpr_2614_test.ml | $bsc $stdlib
+o test/gpr_2633_test.cmi test/gpr_2633_test.cmj : cc test/gpr_2633_test.ml | $bsc $stdlib
+o test/gpr_2642_test.cmi test/gpr_2642_test.cmj : cc test/gpr_2642_test.ml | $bsc $stdlib
+o test/gpr_2652_test.cmi test/gpr_2652_test.cmj : cc test/gpr_2652_test.ml | $bsc $stdlib
+o test/gpr_2682_test.cmi test/gpr_2682_test.cmj : cc test/gpr_2682_test.ml | $bsc $stdlib
+o test/gpr_2700_test.cmi test/gpr_2700_test.cmj : cc test/gpr_2700_test.ml | $bsc $stdlib
+o test/gpr_2731_test.cmi test/gpr_2731_test.cmj : cc test/gpr_2731_test.ml | $bsc $stdlib
+o test/gpr_2789_test.cmi test/gpr_2789_test.cmj : cc test/gpr_2789_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_2863_test.cmi test/gpr_2863_test.cmj : cc test/gpr_2863_test.ml | $bsc $stdlib
+o test/gpr_2931_test.cmi test/gpr_2931_test.cmj : cc test/gpr_2931_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_3142_test.cmi test/gpr_3142_test.cmj : cc test/gpr_3142_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_3154_test.cmi test/gpr_3154_test.cmj : cc test/gpr_3154_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_3209_test.cmi test/gpr_3209_test.cmj : cc test/gpr_3209_test.ml | $bsc $stdlib
+o test/gpr_3492_test.cmi test/gpr_3492_test.cmj : cc test/gpr_3492_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_3502_test.cmi test/gpr_3502_test.cmj : cc test/gpr_3502_test.ml | $bsc $stdlib
+o test/gpr_3519_jsx_test.cmi test/gpr_3519_jsx_test.cmj : cc test/gpr_3519_jsx_test.ml | $bsc $stdlib
+o test/gpr_3519_test.cmi test/gpr_3519_test.cmj : cc test/gpr_3519_test.ml | $bsc $stdlib
+o test/gpr_3536_test.cmi test/gpr_3536_test.cmj : cc test/gpr_3536_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_3546_test.cmi test/gpr_3546_test.cmj : cc test/gpr_3546_test.ml | $bsc $stdlib
+o test/gpr_3548_test.cmi test/gpr_3548_test.cmj : cc test/gpr_3548_test.ml | $bsc $stdlib
+o test/gpr_3549_test.cmi test/gpr_3549_test.cmj : cc test/gpr_3549_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_3566_drive_test.cmi test/gpr_3566_drive_test.cmj : cc test/gpr_3566_drive_test.ml | test/gpr_3566_test.cmj test/mt.cmj $bsc $stdlib
+o test/gpr_3566_test.cmi test/gpr_3566_test.cmj : cc test/gpr_3566_test.ml | $bsc $stdlib
+o test/gpr_3595_test.cmi test/gpr_3595_test.cmj : cc test/gpr_3595_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_3609_test.cmi test/gpr_3609_test.cmj : cc test/gpr_3609_test.ml | $bsc $stdlib
+o test/gpr_3697_test.cmi test/gpr_3697_test.cmj : cc test/gpr_3697_test.ml | $bsc $stdlib
+o test/gpr_373_test.cmi test/gpr_373_test.cmj : cc test/gpr_373_test.ml | $bsc $stdlib
+o test/gpr_3770_test.cmi test/gpr_3770_test.cmj : cc test/gpr_3770_test.ml | $bsc $stdlib
+o test/gpr_3852_alias.cmi test/gpr_3852_alias.cmj : cc test/gpr_3852_alias.ml | test/gpr_3852_effect.cmj $bsc $stdlib
+o test/gpr_3852_alias_reify.cmj : cc_cmi test/gpr_3852_alias_reify.ml | test/gpr_3852_alias_reify.cmi test/gpr_3852_effect.cmj $bsc $stdlib
+o test/gpr_3852_alias_reify.cmi : cc test/gpr_3852_alias_reify.mli | $bsc $stdlib
+o test/gpr_3852_effect.cmi test/gpr_3852_effect.cmj : cc test/gpr_3852_effect.ml | $bsc $stdlib
+o test/gpr_3865.cmi test/gpr_3865.cmj : cc test/gpr_3865.re | test/gpr_3865_bar.cmj test/gpr_3865_foo.cmj $bsc $stdlib
+o test/gpr_3865_bar.cmi test/gpr_3865_bar.cmj : cc test/gpr_3865_bar.re | $bsc $stdlib
+o test/gpr_3865_foo.cmi test/gpr_3865_foo.cmj : cc test/gpr_3865_foo.re | $bsc $stdlib
+o test/gpr_3875_test.cmi test/gpr_3875_test.cmj : cc test/gpr_3875_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_3877_test.cmi test/gpr_3877_test.cmj : cc test/gpr_3877_test.ml | $bsc $stdlib
+o test/gpr_3895_test.cmi test/gpr_3895_test.cmj : cc test/gpr_3895_test.ml | $bsc $stdlib
+o test/gpr_3897_test.cmi test/gpr_3897_test.cmj : cc test/gpr_3897_test.ml | $bsc $stdlib
+o test/gpr_3931_test.cmi test/gpr_3931_test.cmj : cc test/gpr_3931_test.ml | $bsc $stdlib
+o test/gpr_3980_test.cmi test/gpr_3980_test.cmj : cc test/gpr_3980_test.ml | $bsc $stdlib
+o test/gpr_4025_test.cmi test/gpr_4025_test.cmj : cc test/gpr_4025_test.ml | $bsc $stdlib
+o test/gpr_405_test.cmj : cc_cmi test/gpr_405_test.ml | test/gpr_405_test.cmi $bsc $stdlib
+o test/gpr_405_test.cmi : cc test/gpr_405_test.mli | $bsc $stdlib
+o test/gpr_4069_test.cmi test/gpr_4069_test.cmj : cc test/gpr_4069_test.ml | $bsc $stdlib
+o test/gpr_4265_test.cmi test/gpr_4265_test.cmj : cc test/gpr_4265_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_4274_test.cmi test/gpr_4274_test.cmj : cc test/gpr_4274_test.ml | $bsc $stdlib
+o test/gpr_4280_test.cmi test/gpr_4280_test.cmj : cc test/gpr_4280_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_4407_test.cmi test/gpr_4407_test.cmj : cc test/gpr_4407_test.ml | test/debug_mode_value.cmj test/mt.cmj $bsc $stdlib
+o test/gpr_441.cmi test/gpr_441.cmj : cc test/gpr_441.ml | $bsc $stdlib
+o test/gpr_4442_test.cmi test/gpr_4442_test.cmj : cc test/gpr_4442_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_4491_test.cmi test/gpr_4491_test.cmj : cc test/gpr_4491_test.ml | $bsc $stdlib
+o test/gpr_4494_test.cmi test/gpr_4494_test.cmj : cc test/gpr_4494_test.ml | $bsc $stdlib
+o test/gpr_4519_test.cmi test/gpr_4519_test.cmj : cc test/gpr_4519_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_459_test.cmi test/gpr_459_test.cmj : cc test/gpr_459_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_4639_test.cmi test/gpr_4639_test.cmj : cc test/gpr_4639_test.ml | $bsc $stdlib
+o test/gpr_4900_test.cmi test/gpr_4900_test.cmj : cc test/gpr_4900_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_4924_test.cmi test/gpr_4924_test.cmj : cc test/gpr_4924_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_4931.cmi test/gpr_4931.cmj : cc test/gpr_4931.ml | $bsc $stdlib
+o test/gpr_5071_test.cmi test/gpr_5071_test.cmj : cc test/gpr_5071_test.res | test/react.cmj $bsc $stdlib
+o test/gpr_5169_test.cmi test/gpr_5169_test.cmj : cc test/gpr_5169_test.ml | $bsc $stdlib
+o test/gpr_5218_test.cmi test/gpr_5218_test.cmj : cc test/gpr_5218_test.res | test/mt.cmj $bsc $stdlib
+o test/gpr_627_test.cmi test/gpr_627_test.cmj : cc test/gpr_627_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_658.cmi test/gpr_658.cmj : cc test/gpr_658.ml | $bsc $stdlib
+o test/gpr_858_test.cmi test/gpr_858_test.cmj : cc test/gpr_858_test.ml | $bsc $stdlib
+o test/gpr_858_unit2_test.cmi test/gpr_858_unit2_test.cmj : cc test/gpr_858_unit2_test.ml | $bsc $stdlib
+o test/gpr_904_test.cmi test/gpr_904_test.cmj : cc test/gpr_904_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_974_test.cmi test/gpr_974_test.cmj : cc test/gpr_974_test.ml | $bsc $stdlib
+o test/gpr_977_test.cmi test/gpr_977_test.cmj : cc test/gpr_977_test.ml | test/mt.cmj $bsc $stdlib
+o test/gpr_return_type_unused_attribute.cmi test/gpr_return_type_unused_attribute.cmj : cc test/gpr_return_type_unused_attribute.ml | $bsc $stdlib
+o test/gray_code_test.cmi test/gray_code_test.cmj : cc test/gray_code_test.ml | $bsc $stdlib
+o test/guide_for_ext.cmi test/guide_for_ext.cmj : cc test/guide_for_ext.ml | $bsc $stdlib
+o test/hamming_test.cmi test/hamming_test.cmj : cc test/hamming_test.ml | test/mt.cmj $bsc $stdlib
+o test/hash_collision_test.cmi test/hash_collision_test.cmj : cc test/hash_collision_test.ml | test/mt.cmj $bsc $stdlib
+o test/hash_sugar_desugar.cmj : cc_cmi test/hash_sugar_desugar.ml | test/hash_sugar_desugar.cmi $bsc $stdlib
+o test/hash_sugar_desugar.cmi : cc test/hash_sugar_desugar.mli | $bsc $stdlib
+o test/hash_test.cmi test/hash_test.cmj : cc test/hash_test.ml | test/mt.cmj test/mt_global.cmj $bsc $stdlib
+o test/hashtbl_test.cmi test/hashtbl_test.cmj : cc test/hashtbl_test.ml | test/mt.cmj $bsc $stdlib
+o test/hello.foo.cmi test/hello.foo.cmj : cc test/hello.foo.ml | $bsc $stdlib
+o test/hello_res.cmj : cc_cmi test/hello_res.res | test/hello_res.cmi $bsc $stdlib
+o test/hello_res.cmi : cc test/hello_res.resi | $bsc $stdlib
+o test/http_types.cmi test/http_types.cmj : cc test/http_types.ml | $bsc $stdlib
+o test/ignore_test.cmi test/ignore_test.cmj : cc test/ignore_test.ml | test/mt.cmj $bsc $stdlib
+o test/imm_map_bench.cmi test/imm_map_bench.cmj : cc test/imm_map_bench.ml | $bsc $stdlib
+o test/include_side_effect.cmi test/include_side_effect.cmj : cc test/include_side_effect.ml | test/side_effect.cmj $bsc $stdlib
+o test/include_side_effect_free.cmi test/include_side_effect_free.cmj : cc test/include_side_effect_free.ml | test/side_effect_free.cmj $bsc $stdlib
+o test/incomplete_toplevel_test.cmi test/incomplete_toplevel_test.cmj : cc test/incomplete_toplevel_test.ml | $bsc $stdlib
+o test/infer_type_test.cmj : cc_cmi test/infer_type_test.ml | test/infer_type_test.cmi $bsc $stdlib
+o test/infer_type_test.cmi : cc test/infer_type_test.mli | $bsc $stdlib
+o test/inline_const.cmj : cc_cmi test/inline_const.ml | test/inline_const.cmi $bsc $stdlib
+o test/inline_const.cmi : cc test/inline_const.mli | $bsc $stdlib
+o test/inline_const_test.cmi test/inline_const_test.cmj : cc test/inline_const_test.ml | test/inline_const.cmj test/mt.cmj $bsc $stdlib
+o test/inline_edge_cases.cmj : cc_cmi test/inline_edge_cases.ml | test/inline_edge_cases.cmi $bsc $stdlib
+o test/inline_edge_cases.cmi : cc test/inline_edge_cases.mli | $bsc $stdlib
+o test/inline_map2_test.cmi test/inline_map2_test.cmj : cc test/inline_map2_test.ml | test/mt.cmj $bsc $stdlib
+o test/inline_map_demo.cmi test/inline_map_demo.cmj : cc test/inline_map_demo.res | test/mt.cmj $bsc $stdlib
+o test/inline_map_test.cmj : cc_cmi test/inline_map_test.ml | test/inline_map_test.cmi test/mt.cmj $bsc $stdlib
+o test/inline_map_test.cmi : cc test/inline_map_test.mli | $bsc $stdlib
+o test/inline_record_test.cmi test/inline_record_test.cmj : cc test/inline_record_test.ml | test/mt.cmj $bsc $stdlib
+o test/inline_regression_test.cmi test/inline_regression_test.cmj : cc test/inline_regression_test.ml | test/mt.cmj $bsc $stdlib
+o test/inline_string_test.cmi test/inline_string_test.cmj : cc test/inline_string_test.ml | $bsc $stdlib
+o test/inner_call.cmi test/inner_call.cmj : cc test/inner_call.ml | test/inner_define.cmj $bsc $stdlib
+o test/inner_define.cmj : cc_cmi test/inner_define.ml | test/inner_define.cmi $bsc $stdlib
+o test/inner_define.cmi : cc test/inner_define.mli | $bsc $stdlib
+o test/inner_unused.cmi test/inner_unused.cmj : cc test/inner_unused.ml | $bsc $stdlib
+o test/installation_test.cmi test/installation_test.cmj : cc test/installation_test.ml | test/mt.cmj $bsc $stdlib
+o test/int32_test.cmi test/int32_test.cmj : cc test/int32_test.ml | test/ext_array_test.cmj test/mt.cmj $bsc $stdlib
+o test/int64_mul_div_test.cmi test/int64_mul_div_test.cmj : cc test/int64_mul_div_test.ml | test/mt.cmj $bsc $stdlib
+o test/int64_string_bench.cmi test/int64_string_bench.cmj : cc test/int64_string_bench.ml | $bsc $stdlib
+o test/int64_string_test.cmi test/int64_string_test.cmj : cc test/int64_string_test.ml | test/mt.cmj $bsc $stdlib
+o test/int64_test.cmi test/int64_test.cmj : cc test/int64_test.ml | test/ext_array_test.cmj test/mt.cmj $bsc $stdlib
+o test/int_hashtbl_test.cmi test/int_hashtbl_test.cmj : cc test/int_hashtbl_test.ml | test/mt.cmj $bsc $stdlib
+o test/int_map.cmi test/int_map.cmj : cc test/int_map.ml | $bsc $stdlib
+o test/int_overflow_test.cmi test/int_overflow_test.cmj : cc test/int_overflow_test.ml | test/mt.cmj $bsc $stdlib
+o test/int_poly_var.cmi test/int_poly_var.cmj : cc test/int_poly_var.res | test/mt.cmj test/test2.cmj $bsc $stdlib
+o test/int_switch_test.cmi test/int_switch_test.cmj : cc test/int_switch_test.ml | test/mt.cmj $bsc $stdlib
+o test/internal_unused_test.cmi test/internal_unused_test.cmj : cc test/internal_unused_test.ml | $bsc $stdlib
+o test/io_test.cmi test/io_test.cmj : cc test/io_test.ml | $bsc $stdlib
+o test/js_array_test.cmi test/js_array_test.cmj : cc test/js_array_test.ml | test/mt.cmj $bsc $stdlib
+o test/js_bool_test.cmi test/js_bool_test.cmj : cc test/js_bool_test.ml | test/mt.cmj $bsc $stdlib
+o test/js_cast_test.cmi test/js_cast_test.cmj : cc test/js_cast_test.ml | test/mt.cmj $bsc $stdlib
+o test/js_date_test.cmi test/js_date_test.cmj : cc test/js_date_test.ml | test/mt.cmj $bsc $stdlib
+o test/js_dict_test.cmi test/js_dict_test.cmj : cc test/js_dict_test.ml | test/mt.cmj $bsc $stdlib
+o test/js_exception_catch_test.cmi test/js_exception_catch_test.cmj : cc test/js_exception_catch_test.ml | test/mt.cmj $bsc $stdlib
+o test/js_float_test.cmi test/js_float_test.cmj : cc test/js_float_test.ml | test/mt.cmj $bsc $stdlib
+o test/js_global_test.cmi test/js_global_test.cmj : cc test/js_global_test.ml | test/mt.cmj $bsc $stdlib
+o test/js_int_test.cmi test/js_int_test.cmj : cc test/js_int_test.ml | test/mt.cmj $bsc $stdlib
+o test/js_json_test.cmi test/js_json_test.cmj : cc test/js_json_test.ml | test/mt.cmj $bsc $stdlib
+o test/js_list_test.cmi test/js_list_test.cmj : cc test/js_list_test.ml | test/mt.cmj $bsc $stdlib
+o test/js_math_test.cmi test/js_math_test.cmj : cc test/js_math_test.ml | test/mt.cmj $bsc $stdlib
+o test/js_null_test.cmi test/js_null_test.cmj : cc test/js_null_test.ml | test/mt.cmj $bsc $stdlib
+o test/js_null_undefined_test.cmi test/js_null_undefined_test.cmj : cc test/js_null_undefined_test.ml | test/mt.cmj $bsc $stdlib
+o test/js_nullable_test.cmi test/js_nullable_test.cmj : cc test/js_nullable_test.ml | test/mt.cmj $bsc $stdlib
+o test/js_obj_test.cmi test/js_obj_test.cmj : cc test/js_obj_test.ml | test/mt.cmj $bsc $stdlib
+o test/js_option_test.cmi test/js_option_test.cmj : cc test/js_option_test.ml | test/mt.cmj $bsc $stdlib
+o test/js_promise_basic_test.cmi test/js_promise_basic_test.cmj : cc test/js_promise_basic_test.ml | test/mt.cmj $bsc $stdlib
+o test/js_re_test.cmi test/js_re_test.cmj : cc test/js_re_test.ml | test/mt.cmj $bsc $stdlib
+o test/js_string_test.cmi test/js_string_test.cmj : cc test/js_string_test.ml | test/mt.cmj $bsc $stdlib
+o test/js_typed_array_test.cmi test/js_typed_array_test.cmj : cc test/js_typed_array_test.ml | test/mt.cmj $bsc $stdlib
+o test/js_undefined_test.cmi test/js_undefined_test.cmj : cc test/js_undefined_test.ml | test/mt.cmj $bsc $stdlib
+o test/js_val.cmi test/js_val.cmj : cc test/js_val.ml | $bsc $stdlib
+o test/jsoo_400_test.cmi test/jsoo_400_test.cmj : cc test/jsoo_400_test.ml | test/mt.cmj $bsc $stdlib
+o test/jsoo_485_test.cmi test/jsoo_485_test.cmj : cc test/jsoo_485_test.ml | $bsc $stdlib
+o test/key_word_property.cmi test/key_word_property.cmj : cc test/key_word_property.ml | $bsc $stdlib
+o test/key_word_property2.cmi test/key_word_property2.cmj : cc test/key_word_property2.ml | test/export_keyword.cmj $bsc $stdlib
+o test/key_word_property_plus_test.cmi test/key_word_property_plus_test.cmj : cc test/key_word_property_plus_test.ml | test/global_mangles.cmj test/mt.cmj $bsc $stdlib
+o test/label_uncurry.cmi test/label_uncurry.cmj : cc test/label_uncurry.ml | $bsc $stdlib
+o test/large_integer_pat.cmi test/large_integer_pat.cmj : cc test/large_integer_pat.ml | $bsc $stdlib
+o test/large_record_duplication_test.cmi test/large_record_duplication_test.cmj : cc test/large_record_duplication_test.ml | test/mt.cmj $bsc $stdlib
+o test/largest_int_flow.cmi test/largest_int_flow.cmj : cc test/largest_int_flow.ml | $bsc $stdlib
+o test/lazy_demo.cmi test/lazy_demo.cmj : cc test/lazy_demo.re | $bsc $stdlib
+o test/lazy_test.cmi test/lazy_test.cmj : cc test/lazy_test.ml | test/mt.cmj $bsc $stdlib
+o test/lexer_test.cmi test/lexer_test.cmj : cc test/lexer_test.ml | test/arith_lexer.cmj test/arith_parser.cmj test/arith_syntax.cmj test/mt.cmj test/number_lexer.cmj $bsc $stdlib
+o test/lib_js_test.cmi test/lib_js_test.cmj : cc test/lib_js_test.ml | test/mt.cmj $bsc $stdlib
+o test/libarg_test.cmi test/libarg_test.cmj : cc test/libarg_test.ml | test/mt.cmj $bsc $stdlib
+o test/libqueue_test.cmi test/libqueue_test.cmj : cc test/libqueue_test.ml | $bsc $stdlib
+o test/limits_test.cmi test/limits_test.cmj : cc test/limits_test.ml | test/mt.cmj $bsc $stdlib
+o test/list_stack.cmi test/list_stack.cmj : cc test/list_stack.ml | $bsc $stdlib
+o test/list_test.cmi test/list_test.cmj : cc test/list_test.ml | test/mt.cmj $bsc $stdlib
+o test/local_class_type.cmi test/local_class_type.cmj : cc test/local_class_type.ml | $bsc $stdlib
+o test/local_exception_test.cmi test/local_exception_test.cmj : cc test/local_exception_test.ml | $bsc $stdlib
+o test/loop_regression_test.cmi test/loop_regression_test.cmj : cc test/loop_regression_test.ml | test/mt.cmj $bsc $stdlib
+o test/loop_suites_test.cmi test/loop_suites_test.cmj : cc test/loop_suites_test.ml | test/for_loop_test.cmj test/mt.cmj $bsc $stdlib
+o test/map_find_test.cmi test/map_find_test.cmj : cc test/map_find_test.ml | test/mt.cmj $bsc $stdlib
+o test/map_test.cmj : cc_cmi test/map_test.ml | test/map_test.cmi test/mt.cmj $bsc $stdlib
+o test/map_test.cmi : cc test/map_test.mli | $bsc $stdlib
+o test/mario_game.cmi test/mario_game.cmj : cc test/mario_game.ml | $bsc $stdlib
+o test/marshal.cmi test/marshal.cmj : cc test/marshal.ml | $bsc $stdlib
+o test/method_chain.cmi test/method_chain.cmj : cc test/method_chain.ml | $bsc $stdlib
+o test/method_name_test.cmi test/method_name_test.cmj : cc test/method_name_test.ml | test/mt.cmj $bsc $stdlib
+o test/method_string_name.cmi test/method_string_name.cmj : cc test/method_string_name.re | $bsc $stdlib
+o test/minimal_test.cmi test/minimal_test.cmj : cc test/minimal_test.ml | $bsc $stdlib
+o test/miss_colon_test.cmi test/miss_colon_test.cmj : cc test/miss_colon_test.ml | $bsc $stdlib
+o test/mock_mt.cmi test/mock_mt.cmj : cc test/mock_mt.ml | test/mt.cmj $bsc $stdlib
+o test/module_alias_test.cmi test/module_alias_test.cmj : cc test/module_alias_test.ml | test/ext_pervasives_test.cmj test/mt.cmj $bsc $stdlib
+o test/module_as_class_ffi.cmi test/module_as_class_ffi.cmj : cc test/module_as_class_ffi.ml | $bsc $stdlib
+o test/module_as_function.cmi test/module_as_function.cmj : cc test/module_as_function.ml | $bsc $stdlib
+o test/module_missing_conversion.cmi test/module_missing_conversion.cmj : cc test/module_missing_conversion.ml | $bsc $stdlib
+o test/module_parameter_test.cmi test/module_parameter_test.cmj : cc test/module_parameter_test.ml | test/mt.cmj $bsc $stdlib
+o test/module_splice_test.cmi test/module_splice_test.cmj : cc test/module_splice_test.ml | test/mt.cmj $bsc $stdlib
+o test/more_poly_variant_test.cmi test/more_poly_variant_test.cmj : cc test/more_poly_variant_test.ml | $bsc $stdlib
+o test/more_uncurry.cmi test/more_uncurry.cmj : cc test/more_uncurry.ml | $bsc $stdlib
+o test/mpr_6033_test.cmi test/mpr_6033_test.cmj : cc test/mpr_6033_test.ml | test/mt.cmj $bsc $stdlib
+o test/mt.cmj : cc_cmi test/mt.ml | test/mt.cmi $bsc $stdlib
+o test/mt.cmi : cc test/mt.mli | $bsc $stdlib
+o test/mt_global.cmj : cc_cmi test/mt_global.ml | test/mt.cmj test/mt_global.cmi $bsc $stdlib
+o test/mt_global.cmi : cc test/mt_global.mli | test/mt.cmi $bsc $stdlib
+o test/mutable_obj_test.cmi test/mutable_obj_test.cmj : cc test/mutable_obj_test.ml | $bsc $stdlib
+o test/mutable_uncurry_test.cmi test/mutable_uncurry_test.cmj : cc test/mutable_uncurry_test.ml | test/mt.cmj $bsc $stdlib
+o test/mutual_non_recursive_type.cmi test/mutual_non_recursive_type.cmj : cc test/mutual_non_recursive_type.ml | $bsc $stdlib
+o test/name_mangle_test.cmi test/name_mangle_test.cmj : cc test/name_mangle_test.ml | test/mt.cmj $bsc $stdlib
+o test/nested_include.cmi test/nested_include.cmj : cc test/nested_include.ml | $bsc $stdlib
+o test/nested_module_alias.cmi test/nested_module_alias.cmj : cc test/nested_module_alias.ml | $bsc $stdlib
+o test/nested_obj_literal.cmi test/nested_obj_literal.cmj : cc test/nested_obj_literal.ml | $bsc $stdlib
+o test/nested_obj_test.cmi test/nested_obj_test.cmj : cc test/nested_obj_test.ml | $bsc $stdlib
+o test/nested_pattern_match_test.cmi test/nested_pattern_match_test.cmj : cc test/nested_pattern_match_test.ml | $bsc $stdlib
+o test/noassert.cmi test/noassert.cmj : cc test/noassert.ml | $bsc $stdlib
+o test/node_fs_test.cmi test/node_fs_test.cmj : cc test/node_fs_test.ml | $bsc $stdlib
+o test/node_path_test.cmi test/node_path_test.cmj : cc test/node_path_test.ml | $bsc $stdlib
+o test/null_list_test.cmi test/null_list_test.cmj : cc test/null_list_test.ml | $bsc $stdlib
+o test/number_lexer.cmi test/number_lexer.cmj : cc test/number_lexer.ml | $bsc $stdlib
+o test/obj_literal_ppx.cmi test/obj_literal_ppx.cmj : cc test/obj_literal_ppx.ml | $bsc $stdlib
+o test/obj_literal_ppx_test.cmi test/obj_literal_ppx_test.cmj : cc test/obj_literal_ppx_test.ml | $bsc $stdlib
+o test/obj_magic_test.cmi test/obj_magic_test.cmj : cc test/obj_magic_test.ml | test/mt.cmj $bsc $stdlib
+o test/obj_type_test.cmi test/obj_type_test.cmj : cc test/obj_type_test.ml | $bsc $stdlib
+o test/ocaml_re_test.cmi test/ocaml_re_test.cmj : cc test/ocaml_re_test.ml | test/mt.cmj $bsc $stdlib
+o test/of_string_test.cmi test/of_string_test.cmj : cc test/of_string_test.ml | test/mt.cmj $bsc $stdlib
+o test/offset.cmi test/offset.cmj : cc test/offset.ml | $bsc $stdlib
+o test/oo_js_test_date.cmi test/oo_js_test_date.cmj : cc test/oo_js_test_date.ml | test/mt.cmj $bsc $stdlib
+o test/option_encoding_test.cmi test/option_encoding_test.cmj : cc test/option_encoding_test.ml | $bsc $stdlib
+o test/option_repr_test.cmi test/option_repr_test.cmj : cc test/option_repr_test.ml | test/mt.cmj $bsc $stdlib
+o test/optional_ffi_test.cmi test/optional_ffi_test.cmj : cc test/optional_ffi_test.ml | test/mt.cmj $bsc $stdlib
+o test/optional_regression_test.cmi test/optional_regression_test.cmj : cc test/optional_regression_test.ml | test/mt.cmj $bsc $stdlib
+o test/pipe_send_readline.cmi test/pipe_send_readline.cmj : cc test/pipe_send_readline.ml | $bsc $stdlib
+o test/pipe_syntax.cmi test/pipe_syntax.cmj : cc test/pipe_syntax.ml | $bsc $stdlib
+o test/poly_empty_array.cmi test/poly_empty_array.cmj : cc test/poly_empty_array.ml | $bsc $stdlib
+o test/poly_type.cmi test/poly_type.cmj : cc test/poly_type.ml | $bsc $stdlib
+o test/poly_variant_test.cmj : cc_cmi test/poly_variant_test.ml | test/mt.cmj test/poly_variant_test.cmi $bsc $stdlib
+o test/poly_variant_test.cmi : cc test/poly_variant_test.mli | $bsc $stdlib
+o test/polymorphic_raw_test.cmi test/polymorphic_raw_test.cmj : cc test/polymorphic_raw_test.ml | test/mt.cmj $bsc $stdlib
+o test/polymorphism_test.cmj : cc_cmi test/polymorphism_test.ml | test/polymorphism_test.cmi $bsc $stdlib
+o test/polymorphism_test.cmi : cc test/polymorphism_test.mli | $bsc $stdlib
+o test/polyvar_convert.cmi test/polyvar_convert.cmj : cc test/polyvar_convert.ml | $bsc $stdlib
+o test/polyvar_test.cmi test/polyvar_test.cmj : cc test/polyvar_test.ml | $bsc $stdlib
+o test/ppx_apply_test.cmi test/ppx_apply_test.cmj : cc test/ppx_apply_test.ml | test/mt.cmj $bsc $stdlib
+o test/ppx_this_obj_field.cmi test/ppx_this_obj_field.cmj : cc test/ppx_this_obj_field.ml | test/mt.cmj $bsc $stdlib
+o test/ppx_this_obj_test.cmi test/ppx_this_obj_test.cmj : cc test/ppx_this_obj_test.ml | test/mt.cmj $bsc $stdlib
+o test/pq_test.cmi test/pq_test.cmj : cc test/pq_test.ml | $bsc $stdlib
+o test/pr6726.cmi test/pr6726.cmj : cc test/pr6726.ml | $bsc $stdlib
+o test/pr_regression_test.cmi test/pr_regression_test.cmj : cc test/pr_regression_test.ml | test/mt.cmj $bsc $stdlib
+o test/prepend_data_ffi.cmi test/prepend_data_ffi.cmj : cc test/prepend_data_ffi.ml | $bsc $stdlib
+o test/primitive_reg_test.cmi test/primitive_reg_test.cmj : cc test/primitive_reg_test.ml | $bsc $stdlib
+o test/print_alpha_test.cmi test/print_alpha_test.cmj : cc test/print_alpha_test.ml | test/mt.cmj $bsc $stdlib
+o test/promise.cmi test/promise.cmj : cc test/promise.ml | $bsc $stdlib
+o test/promise_catch_test.cmi test/promise_catch_test.cmj : cc test/promise_catch_test.ml | test/mt.cmj $bsc $stdlib
+o test/queue_402.cmi test/queue_402.cmj : cc test/queue_402.ml | $bsc $stdlib
+o test/queue_test.cmi test/queue_test.cmj : cc test/queue_test.ml | test/mt.cmj test/queue_402.cmj $bsc $stdlib
+o test/random_test.cmi test/random_test.cmj : cc test/random_test.ml | test/mt.cmj test/mt_global.cmj $bsc $stdlib
+o test/raw_hash_tbl_bench.cmi test/raw_hash_tbl_bench.cmj : cc test/raw_hash_tbl_bench.ml | $bsc $stdlib
+o test/raw_output_test.cmi test/raw_output_test.cmj : cc test/raw_output_test.ml | $bsc $stdlib
+o test/raw_pure_test.cmi test/raw_pure_test.cmj : cc test/raw_pure_test.ml | $bsc $stdlib
+o test/rbset.cmi test/rbset.cmj : cc test/rbset.ml | $bsc $stdlib
+o test/re_first_test.cmi test/re_first_test.cmj : cc test/re_first_test.re | $bsc $stdlib
+o test/react.cmi test/react.cmj : cc test/react.re | $bsc $stdlib
+o test/reactDOMRe.cmi test/reactDOMRe.cmj : cc test/reactDOMRe.re | test/react.cmj test/reactEvent.cmj test/reasonReact.cmj $bsc $stdlib
+o test/reactDOMServerRe.cmi test/reactDOMServerRe.cmj : cc test/reactDOMServerRe.re | test/react.cmj $bsc $stdlib
+o test/reactEvent.cmj : cc_cmi test/reactEvent.re | test/reactEvent.cmi $bsc $stdlib
+o test/reactEvent.cmi : cc test/reactEvent.rei | $bsc $stdlib
+o test/reactTestUtils.cmj : cc_cmi test/reactTestUtils.re | test/react.cmj test/reactTestUtils.cmi $bsc $stdlib
+o test/reactTestUtils.cmi : cc test/reactTestUtils.rei | test/react.cmi $bsc $stdlib
+o test/reasonReact.cmj : cc_cmi test/reasonReact.re | test/react.cmj test/reasonReact.cmi test/reasonReactOptimizedCreateClass.cmj test/reasonReactRouter.cmj $bsc $stdlib
+o test/reasonReact.cmi : cc test/reasonReact.rei | test/react.cmi test/reasonReactRouter.cmi $bsc $stdlib
+o test/reasonReactCompat.cmj : cc_cmi test/reasonReactCompat.re | test/react.cmj test/reasonReact.cmj test/reasonReactCompat.cmi $bsc $stdlib
+o test/reasonReactCompat.cmi : cc test/reasonReactCompat.rei | test/react.cmi test/reasonReact.cmi $bsc $stdlib
+o test/reasonReactOptimizedCreateClass.cmi test/reasonReactOptimizedCreateClass.cmj : cc test/reasonReactOptimizedCreateClass.re | $bsc $stdlib
+o test/reasonReactRouter.cmj : cc_cmi test/reasonReactRouter.re | test/react.cmj test/reasonReactRouter.cmi $bsc $stdlib
+o test/reasonReactRouter.cmi : cc test/reasonReactRouter.rei | $bsc $stdlib
+o test/rebind_module.cmi test/rebind_module.cmj : cc test/rebind_module.ml | $bsc $stdlib
+o test/rebind_module_test.cmi test/rebind_module_test.cmj : cc test/rebind_module_test.ml | test/rebind_module.cmj $bsc $stdlib
+o test/rec_fun_test.cmi test/rec_fun_test.cmj : cc test/rec_fun_test.ml | test/mt.cmj $bsc $stdlib
+o test/rec_module_opt.cmi test/rec_module_opt.cmj : cc test/rec_module_opt.ml | $bsc $stdlib
+o test/rec_module_test.cmi test/rec_module_test.cmj : cc test/rec_module_test.ml | test/mt.cmj $bsc $stdlib
+o test/rec_value_test.cmi test/rec_value_test.cmj : cc test/rec_value_test.ml | test/mt.cmj $bsc $stdlib
+o test/record_debug_test.cmi test/record_debug_test.cmj : cc test/record_debug_test.ml | test/mt.cmj $bsc $stdlib
+o test/record_extension_test.cmi test/record_extension_test.cmj : cc test/record_extension_test.ml | test/mt.cmj $bsc $stdlib
+o test/record_name_test.cmi test/record_name_test.cmj : cc test/record_name_test.ml | $bsc $stdlib
+o test/record_with_test.cmi test/record_with_test.cmj : cc test/record_with_test.ml | test/mt.cmj $bsc $stdlib
+o test/recursive_module.cmi test/recursive_module.cmj : cc test/recursive_module.ml | test/mt.cmj $bsc $stdlib
+o test/recursive_module_test.cmi test/recursive_module_test.cmj : cc test/recursive_module_test.ml | test/mt.cmj $bsc $stdlib
+o test/recursive_react_component.cmi test/recursive_react_component.cmj : cc test/recursive_react_component.re | test/react.cmj $bsc $stdlib
+o test/recursive_records_test.cmi test/recursive_records_test.cmj : cc test/recursive_records_test.ml | test/mt.cmj $bsc $stdlib
+o test/recursive_unbound_module_test.cmi test/recursive_unbound_module_test.cmj : cc test/recursive_unbound_module_test.ml | $bsc $stdlib
+o test/regression_print.cmi test/regression_print.cmj : cc test/regression_print.ml | $bsc $stdlib
+o test/relative_path.cmi test/relative_path.cmj : cc test/relative_path.ml | $bsc $stdlib
+o test/res_debug.cmi test/res_debug.cmj : cc test/res_debug.res | $bsc $stdlib
+o test/return_check.cmi test/return_check.cmj : cc test/return_check.ml | $bsc $stdlib
+o test/runtime_encoding_test.cmi test/runtime_encoding_test.cmj : cc test/runtime_encoding_test.ml | $bsc $stdlib
+o test/set_gen.cmi test/set_gen.cmj : cc test/set_gen.ml | $bsc $stdlib
+o test/sexp.cmj : cc_cmi test/sexp.ml | test/sexp.cmi $bsc $stdlib
+o test/sexp.cmi : cc test/sexp.mli | $bsc $stdlib
+o test/sexpm.cmj : cc_cmi test/sexpm.ml | test/sexpm.cmi $bsc $stdlib
+o test/sexpm.cmi : cc test/sexpm.mli | $bsc $stdlib
+o test/sexpm_test.cmi test/sexpm_test.cmj : cc test/sexpm_test.ml | test/mt.cmj test/sexpm.cmj $bsc $stdlib
+o test/side_effect.cmi test/side_effect.cmj : cc test/side_effect.ml | $bsc $stdlib
+o test/side_effect_free.cmi test/side_effect_free.cmj : cc test/side_effect_free.ml | $bsc $stdlib
+o test/simple_derive_test.cmj : cc_cmi test/simple_derive_test.ml | test/simple_derive_test.cmi $bsc $stdlib
+o test/simple_derive_test.cmi : cc test/simple_derive_test.mli | $bsc $stdlib
+o test/simple_derive_use.cmj : cc_cmi test/simple_derive_use.ml | test/simple_derive_use.cmi $bsc $stdlib
+o test/simple_derive_use.cmi : cc test/simple_derive_use.mli | $bsc $stdlib
+o test/simple_lexer_test.cmi test/simple_lexer_test.cmj : cc test/simple_lexer_test.ml | test/mt.cmj $bsc $stdlib
+o test/simplify_lambda_632o.cmi test/simplify_lambda_632o.cmj : cc test/simplify_lambda_632o.ml | $bsc $stdlib
+o test/single_module_alias.cmi test/single_module_alias.cmj : cc test/single_module_alias.ml | $bsc $stdlib
+o test/singular_unit_test.cmi test/singular_unit_test.cmj : cc test/singular_unit_test.ml | $bsc $stdlib
+o test/small_inline_test.cmi test/small_inline_test.cmj : cc test/small_inline_test.ml | $bsc $stdlib
+o test/splice_test.cmi test/splice_test.cmj : cc test/splice_test.ml | test/mt.cmj $bsc $stdlib
+o test/stack_comp_test.cmi test/stack_comp_test.cmj : cc test/stack_comp_test.ml | test/mt.cmj test/mt_global.cmj $bsc $stdlib
+o test/stack_test.cmi test/stack_test.cmj : cc test/stack_test.ml | test/mt.cmj $bsc $stdlib
+o test/stream_parser_test.cmi test/stream_parser_test.cmj : cc test/stream_parser_test.ml | test/mt.cmj $bsc $stdlib
+o test/string_bound_get_test.cmi test/string_bound_get_test.cmj : cc test/string_bound_get_test.ml | $bsc $stdlib
+o test/string_get_set_test.cmi test/string_get_set_test.cmj : cc test/string_get_set_test.ml | test/mt.cmj $bsc $stdlib
+o test/string_interp_test.cmi test/string_interp_test.cmj : cc test/string_interp_test.ml | $bsc $stdlib
+o test/string_literal_print_test.cmi test/string_literal_print_test.cmj : cc test/string_literal_print_test.ml | test/mt.cmj $bsc $stdlib
+o test/string_runtime_test.cmi test/string_runtime_test.cmj : cc test/string_runtime_test.ml | test/mt.cmj test/test_char.cmj $bsc $stdlib
+o test/string_set.cmi test/string_set.cmj : cc test/string_set.ml | test/set_gen.cmj $bsc $stdlib
+o test/string_set_test.cmi test/string_set_test.cmj : cc test/string_set_test.ml | test/mt.cmj test/string_set.cmj $bsc $stdlib
+o test/string_test.cmi test/string_test.cmj : cc test/string_test.ml | test/ext_string_test.cmj test/mt.cmj $bsc $stdlib
+o test/string_unicode_test.cmi test/string_unicode_test.cmj : cc test/string_unicode_test.ml | test/mt.cmj $bsc $stdlib
+o test/stringmatch_test.cmi test/stringmatch_test.cmj : cc test/stringmatch_test.ml | $bsc $stdlib
+o test/submodule.cmi test/submodule.cmj : cc test/submodule.ml | $bsc $stdlib
+o test/submodule_call.cmi test/submodule_call.cmj : cc test/submodule_call.ml | test/submodule.cmj $bsc $stdlib
+o test/switch_case_test.cmi test/switch_case_test.cmj : cc test/switch_case_test.ml | test/mt.cmj $bsc $stdlib
+o test/tailcall_inline_test.cmi test/tailcall_inline_test.cmj : cc test/tailcall_inline_test.ml | test/mt.cmj $bsc $stdlib
+o test/test.cmi test/test.cmj : cc test/test.ml | $bsc $stdlib
+o test/test2.cmi test/test2.cmj : cc test/test2.ml | $bsc $stdlib
+o test/test_alias.cmi test/test_alias.cmj : cc test/test_alias.ml | test/test_global_print.cmj $bsc $stdlib
+o test/test_ari.cmi test/test_ari.cmj : cc test/test_ari.ml | $bsc $stdlib
+o test/test_array.cmi test/test_array.cmj : cc test/test_array.ml | $bsc $stdlib
+o test/test_array_append.cmi test/test_array_append.cmj : cc test/test_array_append.ml | $bsc $stdlib
+o test/test_array_primitive.cmi test/test_array_primitive.cmj : cc test/test_array_primitive.ml | $bsc $stdlib
+o test/test_bool_equal.cmi test/test_bool_equal.cmj : cc test/test_bool_equal.ml | $bsc $stdlib
+o test/test_bs_this.cmi test/test_bs_this.cmj : cc test/test_bs_this.ml | $bsc $stdlib
+o test/test_bug.cmi test/test_bug.cmj : cc test/test_bug.ml | test/test_char.cmj $bsc $stdlib
+o test/test_bytes.cmi test/test_bytes.cmj : cc test/test_bytes.ml | $bsc $stdlib
+o test/test_case_opt_collision.cmi test/test_case_opt_collision.cmj : cc test/test_case_opt_collision.ml | test/mt.cmj $bsc $stdlib
+o test/test_case_set.cmi test/test_case_set.cmj : cc test/test_case_set.ml | $bsc $stdlib
+o test/test_char.cmi test/test_char.cmj : cc test/test_char.ml | $bsc $stdlib
+o test/test_closure.cmi test/test_closure.cmj : cc test/test_closure.ml | $bsc $stdlib
+o test/test_common.cmi test/test_common.cmj : cc test/test_common.ml | $bsc $stdlib
+o test/test_const_elim.cmi test/test_const_elim.cmj : cc test/test_const_elim.ml | $bsc $stdlib
+o test/test_const_propogate.cmi test/test_const_propogate.cmj : cc test/test_const_propogate.ml | $bsc $stdlib
+o test/test_cpp.cmi test/test_cpp.cmj : cc test/test_cpp.ml | $bsc $stdlib
+o test/test_cps.cmi test/test_cps.cmj : cc test/test_cps.ml | $bsc $stdlib
+o test/test_demo.cmi test/test_demo.cmj : cc test/test_demo.ml | $bsc $stdlib
+o test/test_dup_param.cmi test/test_dup_param.cmj : cc test/test_dup_param.ml | $bsc $stdlib
+o test/test_eq.cmi test/test_eq.cmj : cc test/test_eq.ml | $bsc $stdlib
+o test/test_exception.cmi test/test_exception.cmj : cc test/test_exception.ml | test/test_common.cmj $bsc $stdlib
+o test/test_exception_escape.cmi test/test_exception_escape.cmj : cc test/test_exception_escape.ml | $bsc $stdlib
+o test/test_export2.cmi test/test_export2.cmj : cc test/test_export2.ml | $bsc $stdlib
+o test/test_external.cmi test/test_external.cmj : cc test/test_external.ml | $bsc $stdlib
+o test/test_external_unit.cmi test/test_external_unit.cmj : cc test/test_external_unit.ml | $bsc $stdlib
+o test/test_ffi.cmi test/test_ffi.cmj : cc test/test_ffi.ml | $bsc $stdlib
+o test/test_fib.cmi test/test_fib.cmj : cc test/test_fib.ml | $bsc $stdlib
+o test/test_filename.cmi test/test_filename.cmj : cc test/test_filename.ml | $bsc $stdlib
+o test/test_for_loop.cmi test/test_for_loop.cmj : cc test/test_for_loop.ml | $bsc $stdlib
+o test/test_for_map.cmi test/test_for_map.cmj : cc test/test_for_map.ml | $bsc $stdlib
+o test/test_for_map2.cmj : cc_cmi test/test_for_map2.ml | test/int_map.cmj test/test_for_map2.cmi $bsc $stdlib
+o test/test_for_map2.cmi : cc test/test_for_map2.mli | $bsc $stdlib
+o test/test_format.cmi test/test_format.cmj : cc test/test_format.ml | $bsc $stdlib
+o test/test_formatter.cmi test/test_formatter.cmj : cc test/test_formatter.ml | $bsc $stdlib
+o test/test_functor_dead_code.cmi test/test_functor_dead_code.cmj : cc test/test_functor_dead_code.ml | $bsc $stdlib
+o test/test_generative_module.cmi test/test_generative_module.cmj : cc test/test_generative_module.ml | $bsc $stdlib
+o test/test_global_print.cmi test/test_global_print.cmj : cc test/test_global_print.ml | $bsc $stdlib
+o test/test_google_closure.cmi test/test_google_closure.cmj : cc test/test_google_closure.ml | $bsc $stdlib
+o test/test_http_server.cmj : cc_cmi test/test_http_server.ml | test/http_types.cmj test/test_http_server.cmi $bsc $stdlib
+o test/test_http_server.cmi : cc test/test_http_server.mli | $bsc $stdlib
+o test/test_include.cmi test/test_include.cmj : cc test/test_include.ml | test/test_order.cmj $bsc $stdlib
+o test/test_incomplete.cmi test/test_incomplete.cmj : cc test/test_incomplete.ml | $bsc $stdlib
+o test/test_incr_ref.cmi test/test_incr_ref.cmj : cc test/test_incr_ref.ml | $bsc $stdlib
+o test/test_index.cmi test/test_index.cmj : cc test/test_index.ml | $bsc $stdlib
+o test/test_int_map_find.cmi test/test_int_map_find.cmj : cc test/test_int_map_find.ml | $bsc $stdlib
+o test/test_internalOO.cmi test/test_internalOO.cmj : cc test/test_internalOO.ml | $bsc $stdlib
+o test/test_is_js.cmj : cc_cmi test/test_is_js.ml | test/mt.cmj test/test_is_js.cmi $bsc $stdlib
+o test/test_is_js.cmi : cc test/test_is_js.mli | $bsc $stdlib
+o test/test_js_ffi.cmi test/test_js_ffi.cmj : cc test/test_js_ffi.ml | $bsc $stdlib
+o test/test_let.cmi test/test_let.cmj : cc test/test_let.ml | $bsc $stdlib
+o test/test_list.cmi test/test_list.cmj : cc test/test_list.ml | $bsc $stdlib
+o test/test_literal.cmi test/test_literal.cmj : cc test/test_literal.ml | $bsc $stdlib
+o test/test_literals.cmi test/test_literals.cmj : cc test/test_literals.ml | $bsc $stdlib
+o test/test_match_exception.cmi test/test_match_exception.cmj : cc test/test_match_exception.ml | $bsc $stdlib
+o test/test_mutliple.cmi test/test_mutliple.cmj : cc test/test_mutliple.ml | $bsc $stdlib
+o test/test_nat64.cmi test/test_nat64.cmj : cc test/test_nat64.ml | $bsc $stdlib
+o test/test_nested_let.cmi test/test_nested_let.cmj : cc test/test_nested_let.ml | $bsc $stdlib
+o test/test_nested_print.cmi test/test_nested_print.cmj : cc test/test_nested_print.ml | $bsc $stdlib
+o test/test_non_export.cmi test/test_non_export.cmj : cc test/test_non_export.ml | $bsc $stdlib
+o test/test_nullary.cmi test/test_nullary.cmj : cc test/test_nullary.ml | $bsc $stdlib
+o test/test_obj.cmi test/test_obj.cmj : cc test/test_obj.ml | $bsc $stdlib
+o test/test_obj_simple_ffi.cmi test/test_obj_simple_ffi.cmj : cc test/test_obj_simple_ffi.ml | $bsc $stdlib
+o test/test_order.cmi test/test_order.cmj : cc test/test_order.ml | $bsc $stdlib
+o test/test_order_tailcall.cmi test/test_order_tailcall.cmj : cc test/test_order_tailcall.ml | $bsc $stdlib
+o test/test_other_exn.cmi test/test_other_exn.cmj : cc test/test_other_exn.ml | $bsc $stdlib
+o test/test_pack.cmi test/test_pack.cmj : cc test/test_pack.ml | $bsc $stdlib
+o test/test_per.cmi test/test_per.cmj : cc test/test_per.ml | $bsc $stdlib
+o test/test_pervasive.cmi test/test_pervasive.cmj : cc test/test_pervasive.ml | $bsc $stdlib
+o test/test_pervasives2.cmi test/test_pervasives2.cmj : cc test/test_pervasives2.ml | $bsc $stdlib
+o test/test_pervasives3.cmi test/test_pervasives3.cmj : cc test/test_pervasives3.ml | $bsc $stdlib
+o test/test_primitive.cmi test/test_primitive.cmj : cc test/test_primitive.ml | $bsc $stdlib
+o test/test_promise_bind.cmi test/test_promise_bind.cmj : cc test/test_promise_bind.ml | test/promise.cmj $bsc $stdlib
+o test/test_ramification.cmi test/test_ramification.cmj : cc test/test_ramification.ml | $bsc $stdlib
+o test/test_react.cmi test/test_react.cmj : cc test/test_react.ml | $bsc $stdlib
+o test/test_react_case.cmi test/test_react_case.cmj : cc test/test_react_case.ml | $bsc $stdlib
+o test/test_regex.cmi test/test_regex.cmj : cc test/test_regex.ml | $bsc $stdlib
+o test/test_require.cmi test/test_require.cmj : cc test/test_require.ml | $bsc $stdlib
+o test/test_runtime_encoding.cmi test/test_runtime_encoding.cmj : cc test/test_runtime_encoding.ml | $bsc $stdlib
+o test/test_scope.cmi test/test_scope.cmj : cc test/test_scope.ml | $bsc $stdlib
+o test/test_seq.cmi test/test_seq.cmj : cc test/test_seq.ml | $bsc $stdlib
+o test/test_set.cmi test/test_set.cmj : cc test/test_set.ml | $bsc $stdlib
+o test/test_side_effect_functor.cmi test/test_side_effect_functor.cmj : cc test/test_side_effect_functor.ml | $bsc $stdlib
+o test/test_simple_include.cmi test/test_simple_include.cmj : cc test/test_simple_include.ml | $bsc $stdlib
+o test/test_simple_pattern_match.cmi test/test_simple_pattern_match.cmj : cc test/test_simple_pattern_match.ml | $bsc $stdlib
+o test/test_simple_ref.cmi test/test_simple_ref.cmj : cc test/test_simple_ref.ml | $bsc $stdlib
+o test/test_simple_tailcall.cmi test/test_simple_tailcall.cmj : cc test/test_simple_tailcall.ml | $bsc $stdlib
+o test/test_small.cmi test/test_small.cmj : cc test/test_small.ml | $bsc $stdlib
+o test/test_sprintf.cmi test/test_sprintf.cmj : cc test/test_sprintf.ml | $bsc $stdlib
+o test/test_stack.cmi test/test_stack.cmj : cc test/test_stack.ml | $bsc $stdlib
+o test/test_static_catch_ident.cmi test/test_static_catch_ident.cmj : cc test/test_static_catch_ident.ml | $bsc $stdlib
+o test/test_string.cmi test/test_string.cmj : cc test/test_string.ml | $bsc $stdlib
+o test/test_string_case.cmi test/test_string_case.cmj : cc test/test_string_case.ml | $bsc $stdlib
+o test/test_string_const.cmi test/test_string_const.cmj : cc test/test_string_const.ml | $bsc $stdlib
+o test/test_string_map.cmi test/test_string_map.cmj : cc test/test_string_map.ml | $bsc $stdlib
+o test/test_string_switch.cmi test/test_string_switch.cmj : cc test/test_string_switch.ml | $bsc $stdlib
+o test/test_switch.cmi test/test_switch.cmj : cc test/test_switch.ml | $bsc $stdlib
+o test/test_trywith.cmi test/test_trywith.cmj : cc test/test_trywith.ml | $bsc $stdlib
+o test/test_tuple.cmi test/test_tuple.cmj : cc test/test_tuple.ml | $bsc $stdlib
+o test/test_tuple_destructring.cmi test/test_tuple_destructring.cmj : cc test/test_tuple_destructring.ml | $bsc $stdlib
+o test/test_type_based_arity.cmi test/test_type_based_arity.cmj : cc test/test_type_based_arity.ml | test/abstract_type.cmj $bsc $stdlib
+o test/test_u.cmi test/test_u.cmj : cc test/test_u.ml | $bsc $stdlib
+o test/test_unsafe_cmp.cmi test/test_unsafe_cmp.cmj : cc test/test_unsafe_cmp.ml | $bsc $stdlib
+o test/test_unsafe_obj_ffi.cmj : cc_cmi test/test_unsafe_obj_ffi.ml | test/test_unsafe_obj_ffi.cmi $bsc $stdlib
+o test/test_unsafe_obj_ffi.cmi : cc test/test_unsafe_obj_ffi.mli | $bsc $stdlib
+o test/test_unsafe_obj_ffi_ppx.cmj : cc_cmi test/test_unsafe_obj_ffi_ppx.ml | test/test_unsafe_obj_ffi_ppx.cmi $bsc $stdlib
+o test/test_unsafe_obj_ffi_ppx.cmi : cc test/test_unsafe_obj_ffi_ppx.mli | $bsc $stdlib
+o test/test_unsupported_primitive.cmi test/test_unsupported_primitive.cmj : cc test/test_unsupported_primitive.ml | $bsc $stdlib
+o test/test_while_closure.cmi test/test_while_closure.cmj : cc test/test_while_closure.ml | $bsc $stdlib
+o test/test_while_side_effect.cmi test/test_while_side_effect.cmj : cc test/test_while_side_effect.ml | $bsc $stdlib
+o test/test_zero_nullable.cmi test/test_zero_nullable.cmj : cc test/test_zero_nullable.ml | test/mt.cmj $bsc $stdlib
+o test/then_mangle_test.cmi test/then_mangle_test.cmj : cc test/then_mangle_test.res | test/mt.cmj $bsc $stdlib
+o test/ticker.cmi test/ticker.cmj : cc test/ticker.ml | $bsc $stdlib
+o test/to_string_test.cmi test/to_string_test.cmj : cc test/to_string_test.ml | test/mt.cmj $bsc $stdlib
+o test/topsort_test.cmi test/topsort_test.cmj : cc test/topsort_test.ml | $bsc $stdlib
+o test/tramp_fib.cmi test/tramp_fib.cmj : cc test/tramp_fib.ml | test/mt.cmj $bsc $stdlib
+o test/tuple_alloc.cmi test/tuple_alloc.cmj : cc test/tuple_alloc.ml | $bsc $stdlib
+o test/type_disambiguate.cmi test/type_disambiguate.cmj : cc test/type_disambiguate.ml | $bsc $stdlib
+o test/typeof_test.cmi test/typeof_test.cmj : cc test/typeof_test.ml | test/mt.cmj $bsc $stdlib
+o test/ui_defs.cmi : cc test/ui_defs.mli | $bsc $stdlib
+o test/unboxed_attribute_test.cmi test/unboxed_attribute_test.cmj : cc test/unboxed_attribute_test.ml | test/mt.cmj $bsc $stdlib
+o test/unboxed_use_case.cmj : cc_cmi test/unboxed_use_case.ml | test/unboxed_use_case.cmi $bsc $stdlib
+o test/unboxed_use_case.cmi : cc test/unboxed_use_case.mli | $bsc $stdlib
+o test/uncurry_external_test.cmi test/uncurry_external_test.cmj : cc test/uncurry_external_test.ml | test/mt.cmj $bsc $stdlib
+o test/uncurry_glob_test.cmi test/uncurry_glob_test.cmj : cc test/uncurry_glob_test.ml | $bsc $stdlib
+o test/uncurry_method.cmi test/uncurry_method.cmj : cc test/uncurry_method.ml | $bsc $stdlib
+o test/uncurry_test.cmj : cc_cmi test/uncurry_test.ml | test/uncurry_test.cmi $bsc $stdlib
+o test/uncurry_test.cmi : cc test/uncurry_test.mli | $bsc $stdlib
+o test/undef_regression2_test.cmi test/undef_regression2_test.cmj : cc test/undef_regression2_test.ml | test/mt.cmj $bsc $stdlib
+o test/undef_regression_test.cmi test/undef_regression_test.cmj : cc test/undef_regression_test.ml | $bsc $stdlib
+o test/unicode_type_error.cmi test/unicode_type_error.cmj : cc test/unicode_type_error.ml | $bsc $stdlib
+o test/unit_undefined_test.cmi test/unit_undefined_test.cmj : cc test/unit_undefined_test.ml | test/mt.cmj $bsc $stdlib
+o test/unitest_string.cmi test/unitest_string.cmj : cc test/unitest_string.ml | $bsc $stdlib
+o test/unsafe_full_apply_primitive.cmi test/unsafe_full_apply_primitive.cmj : cc test/unsafe_full_apply_primitive.ml | $bsc $stdlib
+o test/unsafe_obj_external.cmi test/unsafe_obj_external.cmj : cc test/unsafe_obj_external.ml | $bsc $stdlib
+o test/unsafe_ppx_test.cmi test/unsafe_ppx_test.cmj : cc test/unsafe_ppx_test.ml | test/ffi_js_test.cmj test/mt.cmj $bsc $stdlib
+o test/unsafe_this.cmj : cc_cmi test/unsafe_this.ml | test/unsafe_this.cmi $bsc $stdlib
+o test/unsafe_this.cmi : cc test/unsafe_this.mli | $bsc $stdlib
+o test/update_record_test.cmi test/update_record_test.cmj : cc test/update_record_test.ml | test/mt.cmj $bsc $stdlib
+o test/utf8_decode_test.cmi test/utf8_decode_test.cmj : cc test/utf8_decode_test.ml | test/mt.cmj $bsc $stdlib
+o test/variant.cmi test/variant.cmj : cc test/variant.ml | $bsc $stdlib
+o test/watch_test.cmi test/watch_test.cmj : cc test/watch_test.ml | $bsc $stdlib
+o test/webpack_config.cmi test/webpack_config.cmj : cc test/webpack_config.ml | $bsc $stdlib
+o test : phony test/406_primitive_test.cmi test/406_primitive_test.cmj test/a.cmi test/a.cmj test/a_filename_test.cmi test/a_filename_test.cmj test/a_list_test.cmi test/a_list_test.cmj test/a_recursive_type.cmi test/a_recursive_type.cmj test/a_scope_bug.cmi test/a_scope_bug.cmj test/a_string_test.cmi test/a_string_test.cmj test/abstract_type.cmi test/abstract_type.cmj test/adt_optimize_test.cmi test/adt_optimize_test.cmj test/alias_test.cmi test/alias_test.cmj test/and_or_tailcall_test.cmi test/and_or_tailcall_test.cmj test/app_root_finder.cmi test/app_root_finder.cmj test/argv_test.cmi test/argv_test.cmj test/ari_regress_test.cmi test/ari_regress_test.cmj test/arith_lexer.cmi test/arith_lexer.cmj test/arith_parser.cmi test/arith_parser.cmj test/arith_syntax.cmi test/arith_syntax.cmj test/arity.cmi test/arity.cmj test/arity_deopt.cmi test/arity_deopt.cmj test/arity_infer.cmi test/arity_infer.cmj test/arity_ml.cmi test/arity_ml.cmj test/array_data_util.cmi test/array_data_util.cmj test/array_safe_get.cmi test/array_safe_get.cmj test/array_subtle_test.cmi test/array_subtle_test.cmj test/array_test.cmi test/array_test.cmj test/ast_abstract_test.cmi test/ast_abstract_test.cmj test/ast_js_mapper_poly_test.cmi test/ast_js_mapper_poly_test.cmj test/ast_js_mapper_test.cmi test/ast_js_mapper_test.cmj test/ast_mapper_defensive_test.cmi test/ast_mapper_defensive_test.cmj test/ast_mapper_unused_warning_test.cmi test/ast_mapper_unused_warning_test.cmj test/async_ideas.cmi test/async_ideas.cmj test/attr_test.cmi test/attr_test.cmj test/b.cmi test/b.cmj test/bal_set_mini.cmi test/bal_set_mini.cmj test/bang_primitive.cmi test/bang_primitive.cmj test/basic_module_test.cmi test/basic_module_test.cmj test/bb.cmi test/bb.cmj test/bdd.cmi test/bdd.cmj test/belt_internal_test.cmi test/belt_internal_test.cmj test/belt_result_alias_test.cmi test/belt_result_alias_test.cmj test/bench.cmi test/bench.cmj test/big_enum.cmi test/big_enum.cmj test/big_polyvar_test.cmi test/big_polyvar_test.cmj test/block_alias_test.cmi test/block_alias_test.cmj test/boolean_test.cmi test/boolean_test.cmj test/bs_MapInt_test.cmi test/bs_MapInt_test.cmj test/bs_abstract_test.cmi test/bs_abstract_test.cmj test/bs_array_test.cmi test/bs_array_test.cmj test/bs_auto_uncurry.cmi test/bs_auto_uncurry.cmj test/bs_auto_uncurry_test.cmi test/bs_auto_uncurry_test.cmj test/bs_float_test.cmi test/bs_float_test.cmj test/bs_hashmap_test.cmi test/bs_hashmap_test.cmj test/bs_hashset_int_test.cmi test/bs_hashset_int_test.cmj test/bs_hashtbl_string_test.cmi test/bs_hashtbl_string_test.cmj test/bs_ignore_effect.cmi test/bs_ignore_effect.cmj test/bs_ignore_test.cmi test/bs_ignore_test.cmj test/bs_int_test.cmi test/bs_int_test.cmj test/bs_list_test.cmi test/bs_list_test.cmj test/bs_map_set_dict_test.cmi test/bs_map_set_dict_test.cmj test/bs_map_test.cmi test/bs_map_test.cmj test/bs_min_max_test.cmi test/bs_min_max_test.cmj test/bs_mutable_set_test.cmi test/bs_mutable_set_test.cmj test/bs_node_string_buffer_test.cmi test/bs_node_string_buffer_test.cmj test/bs_poly_map_test.cmi test/bs_poly_map_test.cmj test/bs_poly_mutable_map_test.cmi test/bs_poly_mutable_map_test.cmj test/bs_poly_mutable_set_test.cmi test/bs_poly_mutable_set_test.cmj test/bs_poly_set_test.cmi test/bs_poly_set_test.cmj test/bs_qualified.cmi test/bs_qualified.cmj test/bs_queue_test.cmi test/bs_queue_test.cmj test/bs_rbset_int_bench.cmi test/bs_rbset_int_bench.cmj test/bs_rest_test.cmi test/bs_rest_test.cmj test/bs_set_bench.cmi test/bs_set_bench.cmj test/bs_set_int_test.cmi test/bs_set_int_test.cmj test/bs_sort_test.cmi test/bs_sort_test.cmj test/bs_splice_partial.cmi test/bs_splice_partial.cmj test/bs_stack_test.cmi test/bs_stack_test.cmj test/bs_string_test.cmi test/bs_string_test.cmj test/bs_unwrap_test.cmi test/bs_unwrap_test.cmj test/buffer_test.cmi test/buffer_test.cmj test/bytes_split_gpr_743_test.cmi test/bytes_split_gpr_743_test.cmj test/caml_compare_test.cmi test/caml_compare_test.cmj test/caml_format_test.cmi test/caml_format_test.cmj test/caml_sys_poly_fill_test.cmi test/caml_sys_poly_fill_test.cmj test/chain_code_test.cmi test/chain_code_test.cmj test/chn_test.cmi test/chn_test.cmj test/class_setter_getter.cmi test/class_setter_getter.cmj test/class_type_ffi_test.cmi test/class_type_ffi_test.cmj test/compare_test.cmi test/compare_test.cmj test/complete_parmatch_test.cmi test/complete_parmatch_test.cmj test/complex_if_test.cmi test/complex_if_test.cmj test/complex_test.cmi test/complex_test.cmj test/complex_while_loop.cmi test/complex_while_loop.cmj test/condition_compilation_test.cmi test/condition_compilation_test.cmj test/config1_test.cmi test/config1_test.cmj test/config2_test.cmi test/config2_test.cmj test/console_log_test.cmi test/console_log_test.cmj test/const_block_test.cmi test/const_block_test.cmj test/const_defs.cmi test/const_defs.cmj test/const_defs_test.cmi test/const_defs_test.cmj test/const_test.cmi test/const_test.cmj test/cont_int_fold_test.cmi test/cont_int_fold_test.cmj test/cps_test.cmi test/cps_test.cmj test/cross_module_inline_test.cmi test/cross_module_inline_test.cmj test/custom_error_test.cmi test/custom_error_test.cmj test/debug_keep_test.cmi test/debug_keep_test.cmj test/debug_mode_value.cmi test/debug_mode_value.cmj test/debug_tmp.cmi test/debug_tmp.cmj test/debugger_test.cmi test/debugger_test.cmj test/default_export_test.cmi test/default_export_test.cmj test/defunctor_make_test.cmi test/defunctor_make_test.cmj test/demo.cmi test/demo.cmj test/demo_binding.cmi test/demo_binding.cmj test/demo_int_map.cmi test/demo_int_map.cmj test/demo_page.cmi test/demo_page.cmj test/demo_pipe.cmi test/demo_pipe.cmj test/derive_dyntype.cmi test/derive_dyntype.cmj test/derive_projector_test.cmi test/derive_projector_test.cmj test/derive_type_test.cmi test/derive_type_test.cmj test/digest_test.cmi test/digest_test.cmj test/div_by_zero_test.cmi test/div_by_zero_test.cmj test/dollar_escape_test.cmi test/dollar_escape_test.cmj test/earger_curry_test.cmi test/earger_curry_test.cmj test/effect.cmi test/effect.cmj test/epsilon_test.cmi test/epsilon_test.cmj test/equal_box_test.cmi test/equal_box_test.cmj test/equal_exception_test.cmi test/equal_exception_test.cmj test/equal_test.cmi test/equal_test.cmj test/es6_export.cmi test/es6_export.cmj test/es6_import.cmi test/es6_import.cmj test/es6_module_test.cmi test/es6_module_test.cmj test/escape_esmodule.cmi test/escape_esmodule.cmj test/esmodule_ref.cmi test/esmodule_ref.cmj test/event_ffi.cmi test/event_ffi.cmj test/exception_alias.cmi test/exception_alias.cmj test/exception_def.cmi test/exception_def.cmj test/exception_raise_test.cmi test/exception_raise_test.cmj test/exception_rebind_test.cmi test/exception_rebind_test.cmj test/exception_rebound_err_test.cmi test/exception_rebound_err_test.cmj test/exception_repr_test.cmi test/exception_repr_test.cmj test/exception_value_test.cmi test/exception_value_test.cmj test/exn_error_pattern.cmi test/exn_error_pattern.cmj test/export_keyword.cmi test/export_keyword.cmj test/ext_array_test.cmi test/ext_array_test.cmj test/ext_bytes_test.cmi test/ext_bytes_test.cmj test/ext_filename_test.cmi test/ext_filename_test.cmj test/ext_list_test.cmi test/ext_list_test.cmj test/ext_pervasives_test.cmi test/ext_pervasives_test.cmj test/ext_string_test.cmi test/ext_string_test.cmj test/ext_sys_test.cmi test/ext_sys_test.cmj test/extensible_variant_test.cmi test/extensible_variant_test.cmj test/external_polyfill_test.cmi test/external_polyfill_test.cmj test/external_ppx.cmi test/external_ppx.cmj test/fail_comp.cmi test/fail_comp.cmj test/ffi_arity_test.cmi test/ffi_arity_test.cmj test/ffi_array_test.cmi test/ffi_array_test.cmj test/ffi_js_test.cmi test/ffi_js_test.cmj test/ffi_splice_test.cmi test/ffi_splice_test.cmj test/ffi_test.cmi test/ffi_test.cmj test/fib.cmi test/fib.cmj test/flattern_order_test.cmi test/flattern_order_test.cmj test/flexible_array_test.cmi test/flexible_array_test.cmj test/float_array.cmi test/float_array.cmj test/float_of_bits_test.cmi test/float_of_bits_test.cmj test/float_record.cmi test/float_record.cmj test/float_test.cmi test/float_test.cmj test/floatarray_test.cmi test/floatarray_test.cmj test/flow_parser_reg_test.cmi test/flow_parser_reg_test.cmj test/for_loop_test.cmi test/for_loop_test.cmj test/for_side_effect_test.cmi test/for_side_effect_test.cmj test/format_regression.cmi test/format_regression.cmj test/format_test.cmi test/format_test.cmj test/fs_test.cmi test/fs_test.cmj test/fun_pattern_match.cmi test/fun_pattern_match.cmj test/functor_app_test.cmi test/functor_app_test.cmj test/functor_def.cmi test/functor_def.cmj test/functor_ffi.cmi test/functor_ffi.cmj test/functor_inst.cmi test/functor_inst.cmj test/functors.cmi test/functors.cmj test/gbk.cmi test/gbk.cmj test/genlex_test.cmi test/genlex_test.cmj test/gentTypeReTest.cmi test/gentTypeReTest.cmj test/global_exception_regression_test.cmi test/global_exception_regression_test.cmj test/global_mangles.cmi test/global_mangles.cmj test/global_module_alias_test.cmi test/global_module_alias_test.cmj test/google_closure_test.cmi test/google_closure_test.cmj test/gpr496_test.cmi test/gpr496_test.cmj test/gpr_1063_test.cmi test/gpr_1063_test.cmj test/gpr_1072.cmi test/gpr_1072.cmj test/gpr_1072_reg.cmi test/gpr_1072_reg.cmj test/gpr_1150.cmi test/gpr_1150.cmj test/gpr_1154_test.cmi test/gpr_1154_test.cmj test/gpr_1170.cmi test/gpr_1170.cmj test/gpr_1240_missing_unbox.cmi test/gpr_1240_missing_unbox.cmj test/gpr_1245_test.cmi test/gpr_1245_test.cmj test/gpr_1268.cmi test/gpr_1268.cmj test/gpr_1409_test.cmi test/gpr_1409_test.cmj test/gpr_1423_app_test.cmi test/gpr_1423_app_test.cmj test/gpr_1423_nav.cmi test/gpr_1423_nav.cmj test/gpr_1438.cmi test/gpr_1438.cmj test/gpr_1481.cmi test/gpr_1481.cmj test/gpr_1484.cmi test/gpr_1484.cmj test/gpr_1501_test.cmi test/gpr_1501_test.cmj test/gpr_1503_test.cmi test/gpr_1503_test.cmj test/gpr_1539_test.cmi test/gpr_1539_test.cmj test/gpr_1600_test.cmi test/gpr_1600_test.cmj test/gpr_1658_test.cmi test/gpr_1658_test.cmj test/gpr_1667_test.cmi test/gpr_1667_test.cmj test/gpr_1692_test.cmi test/gpr_1692_test.cmj test/gpr_1698_test.cmi test/gpr_1698_test.cmj test/gpr_1701_test.cmi test/gpr_1701_test.cmj test/gpr_1716_test.cmi test/gpr_1716_test.cmj test/gpr_1717_test.cmi test/gpr_1717_test.cmj test/gpr_1728_test.cmi test/gpr_1728_test.cmj test/gpr_1749_test.cmi test/gpr_1749_test.cmj test/gpr_1759_test.cmi test/gpr_1759_test.cmj test/gpr_1760_test.cmi test/gpr_1760_test.cmj test/gpr_1762_test.cmi test/gpr_1762_test.cmj test/gpr_1817_test.cmi test/gpr_1817_test.cmj test/gpr_1822_test.cmi test/gpr_1822_test.cmj test/gpr_1891_test.cmi test/gpr_1891_test.cmj test/gpr_1943_test.cmi test/gpr_1943_test.cmj test/gpr_1946_test.cmi test/gpr_1946_test.cmj test/gpr_2316_test.cmi test/gpr_2316_test.cmj test/gpr_2352_test.cmi test/gpr_2352_test.cmj test/gpr_2413_test.cmi test/gpr_2413_test.cmj test/gpr_2474.cmi test/gpr_2474.cmj test/gpr_2487.cmi test/gpr_2487.cmj test/gpr_2503_test.cmi test/gpr_2503_test.cmj test/gpr_2608_test.cmi test/gpr_2608_test.cmj test/gpr_2614_test.cmi test/gpr_2614_test.cmj test/gpr_2633_test.cmi test/gpr_2633_test.cmj test/gpr_2642_test.cmi test/gpr_2642_test.cmj test/gpr_2652_test.cmi test/gpr_2652_test.cmj test/gpr_2682_test.cmi test/gpr_2682_test.cmj test/gpr_2700_test.cmi test/gpr_2700_test.cmj test/gpr_2731_test.cmi test/gpr_2731_test.cmj test/gpr_2789_test.cmi test/gpr_2789_test.cmj test/gpr_2863_test.cmi test/gpr_2863_test.cmj test/gpr_2931_test.cmi test/gpr_2931_test.cmj test/gpr_3142_test.cmi test/gpr_3142_test.cmj test/gpr_3154_test.cmi test/gpr_3154_test.cmj test/gpr_3209_test.cmi test/gpr_3209_test.cmj test/gpr_3492_test.cmi test/gpr_3492_test.cmj test/gpr_3502_test.cmi test/gpr_3502_test.cmj test/gpr_3519_jsx_test.cmi test/gpr_3519_jsx_test.cmj test/gpr_3519_test.cmi test/gpr_3519_test.cmj test/gpr_3536_test.cmi test/gpr_3536_test.cmj test/gpr_3546_test.cmi test/gpr_3546_test.cmj test/gpr_3548_test.cmi test/gpr_3548_test.cmj test/gpr_3549_test.cmi test/gpr_3549_test.cmj test/gpr_3566_drive_test.cmi test/gpr_3566_drive_test.cmj test/gpr_3566_test.cmi test/gpr_3566_test.cmj test/gpr_3595_test.cmi test/gpr_3595_test.cmj test/gpr_3609_test.cmi test/gpr_3609_test.cmj test/gpr_3697_test.cmi test/gpr_3697_test.cmj test/gpr_373_test.cmi test/gpr_373_test.cmj test/gpr_3770_test.cmi test/gpr_3770_test.cmj test/gpr_3852_alias.cmi test/gpr_3852_alias.cmj test/gpr_3852_alias_reify.cmi test/gpr_3852_alias_reify.cmj test/gpr_3852_effect.cmi test/gpr_3852_effect.cmj test/gpr_3865.cmi test/gpr_3865.cmj test/gpr_3865_bar.cmi test/gpr_3865_bar.cmj test/gpr_3865_foo.cmi test/gpr_3865_foo.cmj test/gpr_3875_test.cmi test/gpr_3875_test.cmj test/gpr_3877_test.cmi test/gpr_3877_test.cmj test/gpr_3895_test.cmi test/gpr_3895_test.cmj test/gpr_3897_test.cmi test/gpr_3897_test.cmj test/gpr_3931_test.cmi test/gpr_3931_test.cmj test/gpr_3980_test.cmi test/gpr_3980_test.cmj test/gpr_4025_test.cmi test/gpr_4025_test.cmj test/gpr_405_test.cmi test/gpr_405_test.cmj test/gpr_4069_test.cmi test/gpr_4069_test.cmj test/gpr_4265_test.cmi test/gpr_4265_test.cmj test/gpr_4274_test.cmi test/gpr_4274_test.cmj test/gpr_4280_test.cmi test/gpr_4280_test.cmj test/gpr_4407_test.cmi test/gpr_4407_test.cmj test/gpr_441.cmi test/gpr_441.cmj test/gpr_4442_test.cmi test/gpr_4442_test.cmj test/gpr_4491_test.cmi test/gpr_4491_test.cmj test/gpr_4494_test.cmi test/gpr_4494_test.cmj test/gpr_4519_test.cmi test/gpr_4519_test.cmj test/gpr_459_test.cmi test/gpr_459_test.cmj test/gpr_4639_test.cmi test/gpr_4639_test.cmj test/gpr_4900_test.cmi test/gpr_4900_test.cmj test/gpr_4924_test.cmi test/gpr_4924_test.cmj test/gpr_4931.cmi test/gpr_4931.cmj test/gpr_5071_test.cmi test/gpr_5071_test.cmj test/gpr_5169_test.cmi test/gpr_5169_test.cmj test/gpr_5218_test.cmi test/gpr_5218_test.cmj test/gpr_627_test.cmi test/gpr_627_test.cmj test/gpr_658.cmi test/gpr_658.cmj test/gpr_858_test.cmi test/gpr_858_test.cmj test/gpr_858_unit2_test.cmi test/gpr_858_unit2_test.cmj test/gpr_904_test.cmi test/gpr_904_test.cmj test/gpr_974_test.cmi test/gpr_974_test.cmj test/gpr_977_test.cmi test/gpr_977_test.cmj test/gpr_return_type_unused_attribute.cmi test/gpr_return_type_unused_attribute.cmj test/gray_code_test.cmi test/gray_code_test.cmj test/guide_for_ext.cmi test/guide_for_ext.cmj test/hamming_test.cmi test/hamming_test.cmj test/hash_collision_test.cmi test/hash_collision_test.cmj test/hash_sugar_desugar.cmi test/hash_sugar_desugar.cmj test/hash_test.cmi test/hash_test.cmj test/hashtbl_test.cmi test/hashtbl_test.cmj test/hello.foo.cmi test/hello.foo.cmj test/hello_res.cmi test/hello_res.cmj test/http_types.cmi test/http_types.cmj test/ignore_test.cmi test/ignore_test.cmj test/imm_map_bench.cmi test/imm_map_bench.cmj test/include_side_effect.cmi test/include_side_effect.cmj test/include_side_effect_free.cmi test/include_side_effect_free.cmj test/incomplete_toplevel_test.cmi test/incomplete_toplevel_test.cmj test/infer_type_test.cmi test/infer_type_test.cmj test/inline_const.cmi test/inline_const.cmj test/inline_const_test.cmi test/inline_const_test.cmj test/inline_edge_cases.cmi test/inline_edge_cases.cmj test/inline_map2_test.cmi test/inline_map2_test.cmj test/inline_map_demo.cmi test/inline_map_demo.cmj test/inline_map_test.cmi test/inline_map_test.cmj test/inline_record_test.cmi test/inline_record_test.cmj test/inline_regression_test.cmi test/inline_regression_test.cmj test/inline_string_test.cmi test/inline_string_test.cmj test/inner_call.cmi test/inner_call.cmj test/inner_define.cmi test/inner_define.cmj test/inner_unused.cmi test/inner_unused.cmj test/installation_test.cmi test/installation_test.cmj test/int32_test.cmi test/int32_test.cmj test/int64_mul_div_test.cmi test/int64_mul_div_test.cmj test/int64_string_bench.cmi test/int64_string_bench.cmj test/int64_string_test.cmi test/int64_string_test.cmj test/int64_test.cmi test/int64_test.cmj test/int_hashtbl_test.cmi test/int_hashtbl_test.cmj test/int_map.cmi test/int_map.cmj test/int_overflow_test.cmi test/int_overflow_test.cmj test/int_poly_var.cmi test/int_poly_var.cmj test/int_switch_test.cmi test/int_switch_test.cmj test/internal_unused_test.cmi test/internal_unused_test.cmj test/io_test.cmi test/io_test.cmj test/js_array_test.cmi test/js_array_test.cmj test/js_bool_test.cmi test/js_bool_test.cmj test/js_cast_test.cmi test/js_cast_test.cmj test/js_date_test.cmi test/js_date_test.cmj test/js_dict_test.cmi test/js_dict_test.cmj test/js_exception_catch_test.cmi test/js_exception_catch_test.cmj test/js_float_test.cmi test/js_float_test.cmj test/js_global_test.cmi test/js_global_test.cmj test/js_int_test.cmi test/js_int_test.cmj test/js_json_test.cmi test/js_json_test.cmj test/js_list_test.cmi test/js_list_test.cmj test/js_math_test.cmi test/js_math_test.cmj test/js_null_test.cmi test/js_null_test.cmj test/js_null_undefined_test.cmi test/js_null_undefined_test.cmj test/js_nullable_test.cmi test/js_nullable_test.cmj test/js_obj_test.cmi test/js_obj_test.cmj test/js_option_test.cmi test/js_option_test.cmj test/js_promise_basic_test.cmi test/js_promise_basic_test.cmj test/js_re_test.cmi test/js_re_test.cmj test/js_string_test.cmi test/js_string_test.cmj test/js_typed_array_test.cmi test/js_typed_array_test.cmj test/js_undefined_test.cmi test/js_undefined_test.cmj test/js_val.cmi test/js_val.cmj test/jsoo_400_test.cmi test/jsoo_400_test.cmj test/jsoo_485_test.cmi test/jsoo_485_test.cmj test/key_word_property.cmi test/key_word_property.cmj test/key_word_property2.cmi test/key_word_property2.cmj test/key_word_property_plus_test.cmi test/key_word_property_plus_test.cmj test/label_uncurry.cmi test/label_uncurry.cmj test/large_integer_pat.cmi test/large_integer_pat.cmj test/large_record_duplication_test.cmi test/large_record_duplication_test.cmj test/largest_int_flow.cmi test/largest_int_flow.cmj test/lazy_demo.cmi test/lazy_demo.cmj test/lazy_test.cmi test/lazy_test.cmj test/lexer_test.cmi test/lexer_test.cmj test/lib_js_test.cmi test/lib_js_test.cmj test/libarg_test.cmi test/libarg_test.cmj test/libqueue_test.cmi test/libqueue_test.cmj test/limits_test.cmi test/limits_test.cmj test/list_stack.cmi test/list_stack.cmj test/list_test.cmi test/list_test.cmj test/local_class_type.cmi test/local_class_type.cmj test/local_exception_test.cmi test/local_exception_test.cmj test/loop_regression_test.cmi test/loop_regression_test.cmj test/loop_suites_test.cmi test/loop_suites_test.cmj test/map_find_test.cmi test/map_find_test.cmj test/map_test.cmi test/map_test.cmj test/mario_game.cmi test/mario_game.cmj test/marshal.cmi test/marshal.cmj test/method_chain.cmi test/method_chain.cmj test/method_name_test.cmi test/method_name_test.cmj test/method_string_name.cmi test/method_string_name.cmj test/minimal_test.cmi test/minimal_test.cmj test/miss_colon_test.cmi test/miss_colon_test.cmj test/mock_mt.cmi test/mock_mt.cmj test/module_alias_test.cmi test/module_alias_test.cmj test/module_as_class_ffi.cmi test/module_as_class_ffi.cmj test/module_as_function.cmi test/module_as_function.cmj test/module_missing_conversion.cmi test/module_missing_conversion.cmj test/module_parameter_test.cmi test/module_parameter_test.cmj test/module_splice_test.cmi test/module_splice_test.cmj test/more_poly_variant_test.cmi test/more_poly_variant_test.cmj test/more_uncurry.cmi test/more_uncurry.cmj test/mpr_6033_test.cmi test/mpr_6033_test.cmj test/mt.cmi test/mt.cmj test/mt_global.cmi test/mt_global.cmj test/mutable_obj_test.cmi test/mutable_obj_test.cmj test/mutable_uncurry_test.cmi test/mutable_uncurry_test.cmj test/mutual_non_recursive_type.cmi test/mutual_non_recursive_type.cmj test/name_mangle_test.cmi test/name_mangle_test.cmj test/nested_include.cmi test/nested_include.cmj test/nested_module_alias.cmi test/nested_module_alias.cmj test/nested_obj_literal.cmi test/nested_obj_literal.cmj test/nested_obj_test.cmi test/nested_obj_test.cmj test/nested_pattern_match_test.cmi test/nested_pattern_match_test.cmj test/noassert.cmi test/noassert.cmj test/node_fs_test.cmi test/node_fs_test.cmj test/node_path_test.cmi test/node_path_test.cmj test/null_list_test.cmi test/null_list_test.cmj test/number_lexer.cmi test/number_lexer.cmj test/obj_literal_ppx.cmi test/obj_literal_ppx.cmj test/obj_literal_ppx_test.cmi test/obj_literal_ppx_test.cmj test/obj_magic_test.cmi test/obj_magic_test.cmj test/obj_type_test.cmi test/obj_type_test.cmj test/ocaml_re_test.cmi test/ocaml_re_test.cmj test/of_string_test.cmi test/of_string_test.cmj test/offset.cmi test/offset.cmj test/oo_js_test_date.cmi test/oo_js_test_date.cmj test/option_encoding_test.cmi test/option_encoding_test.cmj test/option_repr_test.cmi test/option_repr_test.cmj test/optional_ffi_test.cmi test/optional_ffi_test.cmj test/optional_regression_test.cmi test/optional_regression_test.cmj test/pipe_send_readline.cmi test/pipe_send_readline.cmj test/pipe_syntax.cmi test/pipe_syntax.cmj test/poly_empty_array.cmi test/poly_empty_array.cmj test/poly_type.cmi test/poly_type.cmj test/poly_variant_test.cmi test/poly_variant_test.cmj test/polymorphic_raw_test.cmi test/polymorphic_raw_test.cmj test/polymorphism_test.cmi test/polymorphism_test.cmj test/polyvar_convert.cmi test/polyvar_convert.cmj test/polyvar_test.cmi test/polyvar_test.cmj test/ppx_apply_test.cmi test/ppx_apply_test.cmj test/ppx_this_obj_field.cmi test/ppx_this_obj_field.cmj test/ppx_this_obj_test.cmi test/ppx_this_obj_test.cmj test/pq_test.cmi test/pq_test.cmj test/pr6726.cmi test/pr6726.cmj test/pr_regression_test.cmi test/pr_regression_test.cmj test/prepend_data_ffi.cmi test/prepend_data_ffi.cmj test/primitive_reg_test.cmi test/primitive_reg_test.cmj test/print_alpha_test.cmi test/print_alpha_test.cmj test/promise.cmi test/promise.cmj test/promise_catch_test.cmi test/promise_catch_test.cmj test/queue_402.cmi test/queue_402.cmj test/queue_test.cmi test/queue_test.cmj test/random_test.cmi test/random_test.cmj test/raw_hash_tbl_bench.cmi test/raw_hash_tbl_bench.cmj test/raw_output_test.cmi test/raw_output_test.cmj test/raw_pure_test.cmi test/raw_pure_test.cmj test/rbset.cmi test/rbset.cmj test/re_first_test.cmi test/re_first_test.cmj test/react.cmi test/react.cmj test/reactDOMRe.cmi test/reactDOMRe.cmj test/reactDOMServerRe.cmi test/reactDOMServerRe.cmj test/reactEvent.cmi test/reactEvent.cmj test/reactTestUtils.cmi test/reactTestUtils.cmj test/reasonReact.cmi test/reasonReact.cmj test/reasonReactCompat.cmi test/reasonReactCompat.cmj test/reasonReactOptimizedCreateClass.cmi test/reasonReactOptimizedCreateClass.cmj test/reasonReactRouter.cmi test/reasonReactRouter.cmj test/rebind_module.cmi test/rebind_module.cmj test/rebind_module_test.cmi test/rebind_module_test.cmj test/rec_fun_test.cmi test/rec_fun_test.cmj test/rec_module_opt.cmi test/rec_module_opt.cmj test/rec_module_test.cmi test/rec_module_test.cmj test/rec_value_test.cmi test/rec_value_test.cmj test/record_debug_test.cmi test/record_debug_test.cmj test/record_extension_test.cmi test/record_extension_test.cmj test/record_name_test.cmi test/record_name_test.cmj test/record_with_test.cmi test/record_with_test.cmj test/recursive_module.cmi test/recursive_module.cmj test/recursive_module_test.cmi test/recursive_module_test.cmj test/recursive_react_component.cmi test/recursive_react_component.cmj test/recursive_records_test.cmi test/recursive_records_test.cmj test/recursive_unbound_module_test.cmi test/recursive_unbound_module_test.cmj test/regression_print.cmi test/regression_print.cmj test/relative_path.cmi test/relative_path.cmj test/res_debug.cmi test/res_debug.cmj test/return_check.cmi test/return_check.cmj test/runtime_encoding_test.cmi test/runtime_encoding_test.cmj test/set_gen.cmi test/set_gen.cmj test/sexp.cmi test/sexp.cmj test/sexpm.cmi test/sexpm.cmj test/sexpm_test.cmi test/sexpm_test.cmj test/side_effect.cmi test/side_effect.cmj test/side_effect_free.cmi test/side_effect_free.cmj test/simple_derive_test.cmi test/simple_derive_test.cmj test/simple_derive_use.cmi test/simple_derive_use.cmj test/simple_lexer_test.cmi test/simple_lexer_test.cmj test/simplify_lambda_632o.cmi test/simplify_lambda_632o.cmj test/single_module_alias.cmi test/single_module_alias.cmj test/singular_unit_test.cmi test/singular_unit_test.cmj test/small_inline_test.cmi test/small_inline_test.cmj test/splice_test.cmi test/splice_test.cmj test/stack_comp_test.cmi test/stack_comp_test.cmj test/stack_test.cmi test/stack_test.cmj test/stream_parser_test.cmi test/stream_parser_test.cmj test/string_bound_get_test.cmi test/string_bound_get_test.cmj test/string_get_set_test.cmi test/string_get_set_test.cmj test/string_interp_test.cmi test/string_interp_test.cmj test/string_literal_print_test.cmi test/string_literal_print_test.cmj test/string_runtime_test.cmi test/string_runtime_test.cmj test/string_set.cmi test/string_set.cmj test/string_set_test.cmi test/string_set_test.cmj test/string_test.cmi test/string_test.cmj test/string_unicode_test.cmi test/string_unicode_test.cmj test/stringmatch_test.cmi test/stringmatch_test.cmj test/submodule.cmi test/submodule.cmj test/submodule_call.cmi test/submodule_call.cmj test/switch_case_test.cmi test/switch_case_test.cmj test/tailcall_inline_test.cmi test/tailcall_inline_test.cmj test/test.cmi test/test.cmj test/test2.cmi test/test2.cmj test/test_alias.cmi test/test_alias.cmj test/test_ari.cmi test/test_ari.cmj test/test_array.cmi test/test_array.cmj test/test_array_append.cmi test/test_array_append.cmj test/test_array_primitive.cmi test/test_array_primitive.cmj test/test_bool_equal.cmi test/test_bool_equal.cmj test/test_bs_this.cmi test/test_bs_this.cmj test/test_bug.cmi test/test_bug.cmj test/test_bytes.cmi test/test_bytes.cmj test/test_case_opt_collision.cmi test/test_case_opt_collision.cmj test/test_case_set.cmi test/test_case_set.cmj test/test_char.cmi test/test_char.cmj test/test_closure.cmi test/test_closure.cmj test/test_common.cmi test/test_common.cmj test/test_const_elim.cmi test/test_const_elim.cmj test/test_const_propogate.cmi test/test_const_propogate.cmj test/test_cpp.cmi test/test_cpp.cmj test/test_cps.cmi test/test_cps.cmj test/test_demo.cmi test/test_demo.cmj test/test_dup_param.cmi test/test_dup_param.cmj test/test_eq.cmi test/test_eq.cmj test/test_exception.cmi test/test_exception.cmj test/test_exception_escape.cmi test/test_exception_escape.cmj test/test_export2.cmi test/test_export2.cmj test/test_external.cmi test/test_external.cmj test/test_external_unit.cmi test/test_external_unit.cmj test/test_ffi.cmi test/test_ffi.cmj test/test_fib.cmi test/test_fib.cmj test/test_filename.cmi test/test_filename.cmj test/test_for_loop.cmi test/test_for_loop.cmj test/test_for_map.cmi test/test_for_map.cmj test/test_for_map2.cmi test/test_for_map2.cmj test/test_format.cmi test/test_format.cmj test/test_formatter.cmi test/test_formatter.cmj test/test_functor_dead_code.cmi test/test_functor_dead_code.cmj test/test_generative_module.cmi test/test_generative_module.cmj test/test_global_print.cmi test/test_global_print.cmj test/test_google_closure.cmi test/test_google_closure.cmj test/test_http_server.cmi test/test_http_server.cmj test/test_include.cmi test/test_include.cmj test/test_incomplete.cmi test/test_incomplete.cmj test/test_incr_ref.cmi test/test_incr_ref.cmj test/test_index.cmi test/test_index.cmj test/test_int_map_find.cmi test/test_int_map_find.cmj test/test_internalOO.cmi test/test_internalOO.cmj test/test_is_js.cmi test/test_is_js.cmj test/test_js_ffi.cmi test/test_js_ffi.cmj test/test_let.cmi test/test_let.cmj test/test_list.cmi test/test_list.cmj test/test_literal.cmi test/test_literal.cmj test/test_literals.cmi test/test_literals.cmj test/test_match_exception.cmi test/test_match_exception.cmj test/test_mutliple.cmi test/test_mutliple.cmj test/test_nat64.cmi test/test_nat64.cmj test/test_nested_let.cmi test/test_nested_let.cmj test/test_nested_print.cmi test/test_nested_print.cmj test/test_non_export.cmi test/test_non_export.cmj test/test_nullary.cmi test/test_nullary.cmj test/test_obj.cmi test/test_obj.cmj test/test_obj_simple_ffi.cmi test/test_obj_simple_ffi.cmj test/test_order.cmi test/test_order.cmj test/test_order_tailcall.cmi test/test_order_tailcall.cmj test/test_other_exn.cmi test/test_other_exn.cmj test/test_pack.cmi test/test_pack.cmj test/test_per.cmi test/test_per.cmj test/test_pervasive.cmi test/test_pervasive.cmj test/test_pervasives2.cmi test/test_pervasives2.cmj test/test_pervasives3.cmi test/test_pervasives3.cmj test/test_primitive.cmi test/test_primitive.cmj test/test_promise_bind.cmi test/test_promise_bind.cmj test/test_ramification.cmi test/test_ramification.cmj test/test_react.cmi test/test_react.cmj test/test_react_case.cmi test/test_react_case.cmj test/test_regex.cmi test/test_regex.cmj test/test_require.cmi test/test_require.cmj test/test_runtime_encoding.cmi test/test_runtime_encoding.cmj test/test_scope.cmi test/test_scope.cmj test/test_seq.cmi test/test_seq.cmj test/test_set.cmi test/test_set.cmj test/test_side_effect_functor.cmi test/test_side_effect_functor.cmj test/test_simple_include.cmi test/test_simple_include.cmj test/test_simple_pattern_match.cmi test/test_simple_pattern_match.cmj test/test_simple_ref.cmi test/test_simple_ref.cmj test/test_simple_tailcall.cmi test/test_simple_tailcall.cmj test/test_small.cmi test/test_small.cmj test/test_sprintf.cmi test/test_sprintf.cmj test/test_stack.cmi test/test_stack.cmj test/test_static_catch_ident.cmi test/test_static_catch_ident.cmj test/test_string.cmi test/test_string.cmj test/test_string_case.cmi test/test_string_case.cmj test/test_string_const.cmi test/test_string_const.cmj test/test_string_map.cmi test/test_string_map.cmj test/test_string_switch.cmi test/test_string_switch.cmj test/test_switch.cmi test/test_switch.cmj test/test_trywith.cmi test/test_trywith.cmj test/test_tuple.cmi test/test_tuple.cmj test/test_tuple_destructring.cmi test/test_tuple_destructring.cmj test/test_type_based_arity.cmi test/test_type_based_arity.cmj test/test_u.cmi test/test_u.cmj test/test_unsafe_cmp.cmi test/test_unsafe_cmp.cmj test/test_unsafe_obj_ffi.cmi test/test_unsafe_obj_ffi.cmj test/test_unsafe_obj_ffi_ppx.cmi test/test_unsafe_obj_ffi_ppx.cmj test/test_unsupported_primitive.cmi test/test_unsupported_primitive.cmj test/test_while_closure.cmi test/test_while_closure.cmj test/test_while_side_effect.cmi test/test_while_side_effect.cmj test/test_zero_nullable.cmi test/test_zero_nullable.cmj test/then_mangle_test.cmi test/then_mangle_test.cmj test/ticker.cmi test/ticker.cmj test/to_string_test.cmi test/to_string_test.cmj test/topsort_test.cmi test/topsort_test.cmj test/tramp_fib.cmi test/tramp_fib.cmj test/tuple_alloc.cmi test/tuple_alloc.cmj test/type_disambiguate.cmi test/type_disambiguate.cmj test/typeof_test.cmi test/typeof_test.cmj test/ui_defs.cmi test/unboxed_attribute_test.cmi test/unboxed_attribute_test.cmj test/unboxed_use_case.cmi test/unboxed_use_case.cmj test/uncurry_external_test.cmi test/uncurry_external_test.cmj test/uncurry_glob_test.cmi test/uncurry_glob_test.cmj test/uncurry_method.cmi test/uncurry_method.cmj test/uncurry_test.cmi test/uncurry_test.cmj test/undef_regression2_test.cmi test/undef_regression2_test.cmj test/undef_regression_test.cmi test/undef_regression_test.cmj test/unicode_type_error.cmi test/unicode_type_error.cmj test/unit_undefined_test.cmi test/unit_undefined_test.cmj test/unitest_string.cmi test/unitest_string.cmj test/unsafe_full_apply_primitive.cmi test/unsafe_full_apply_primitive.cmj test/unsafe_obj_external.cmi test/unsafe_obj_external.cmj test/unsafe_ppx_test.cmi test/unsafe_ppx_test.cmj test/unsafe_this.cmi test/unsafe_this.cmj test/update_record_test.cmi test/update_record_test.cmj test/utf8_decode_test.cmi test/utf8_decode_test.cmj test/variant.cmi test/variant.cmj test/watch_test.cmi test/watch_test.cmj test/webpack_config.cmi test/webpack_config.cmj

--- a/jscomp/test/gpr_4280_test.ml
+++ b/jscomp/test/gpr_4280_test.ml
@@ -1,4 +1,4 @@
-[@@@bs.config {flags = [|"-bs-diagnose"|]}]
+[@@@bs.config {flags = [|(* "-bs-diagnose" *)|]}]
 let suites :  Mt.pair_suites ref  = ref []
 let test_id = ref 0
 let eq loc x y = Mt.eq_suites ~test_id ~suites loc x y 

--- a/jscomp/test/hash_sugar_desugar.ml
+++ b/jscomp/test/hash_sugar_desugar.ml
@@ -1,8 +1,8 @@
 [@@@config{
   flags = [|
-  "-drawlambda";
-  "-dsource";
-  "-bs-diagnose"
+  (* "-drawlambda"; *)
+  (* "-dsource"; *)
+  (* "-bs-diagnose" *)
   |]
 }]
 

--- a/jscomp/test/hello_res.res
+++ b/jscomp/test/hello_res.res
@@ -1,5 +1,7 @@
 @@config({
-  flags: ["-dparsetree"],
+  flags: [
+    // "-dparsetree"
+    ],
 })
 
 let b = List.length(list{1, 2, 3})

--- a/jscomp/test/obj_magic_test.ml
+++ b/jscomp/test/obj_magic_test.ml
@@ -1,6 +1,6 @@
 [@@@bs.config {
   flags = [|
-    "-drawlambda"
+    (* "-drawlambda" *)
   |]
 }]
 

--- a/jscomp/test/option_encoding_test.ml
+++ b/jscomp/test/option_encoding_test.ml
@@ -2,10 +2,10 @@
   flags = [|
     "-w";
        "@A";
-    "-drawlambda";
-    "-dtypedtree";
-    "-bs-diagnose";
-    "-dparsetree";
+    (* "-drawlambda"; *)
+    (* "-dtypedtree"; *)
+    (* "-bs-diagnose"; *)
+    (* "-dparsetree"; *)
     (* "-dsource"; *)
   |]
 }]

--- a/jscomp/test/rec_module_opt.ml
+++ b/jscomp/test/rec_module_opt.ml
@@ -1,7 +1,7 @@
 
 [@@@bs.config {
   flags = [|
-  "-drawlambda";
+  (* "-drawlambda"; *)
   (* "-dlambda";  *)
   (* "-dtypedtree"; *)
   (* "-bs-diagnose" *)

--- a/jscomp/test/recursive_react_component.re
+++ b/jscomp/test/recursive_react_component.re
@@ -1,6 +1,6 @@
 
 [@bs.config {
-  flags : [|"-bs-jsx","3", "-dsource",
+  flags : [|"-bs-jsx","3", // "-dsource",
      // "-w","A", 
      // "-warn-error", "a"
     |]

--- a/jscomp/test/res_debug.res
+++ b/jscomp/test/res_debug.res
@@ -5,7 +5,7 @@
     /* "-drawlambda"; */
     /* "-dtypedtree"; */
     /* "-bs-diagnose"; */
-    "-dparsetree",
+    // "-dparsetree",
     /* "-dsource"; */
   ],
 })

--- a/jscomp/test/unit_undefined_test.ml
+++ b/jscomp/test/unit_undefined_test.ml
@@ -1,9 +1,9 @@
 
 [@@@bs.config{flags = 
 [|
-  "-bs-diagnose"
-  ; "-drawlambda"
-  ; "-dtypedtree"
+  (* "-bs-diagnose" *)
+  (* ; "-drawlambda" *)
+  (* ; "-dtypedtree" *)
 |]}]
 
 let suites :  Mt.pair_suites ref  = ref []

--- a/scripts/ninja.js
+++ b/scripts/ninja.js
@@ -1227,7 +1227,7 @@ ${mllList(ninjaCwd, [
   let depsMap = createDepsMapWithTargets(sources);
   await Promise.all(depModulesForBscAsync(sources, testDir, depsMap));
   var targets = collectTarget(sources);
-  var output = generateNinja(depsMap, targets, ninjaCwd, [stdlibTarget,compilerTarget]);
+  var output = generateNinja(depsMap, targets, ninjaCwd, [stdlibTarget,pseudoTarget("$bsc")]);
   output.push(phony(pseudoTarget('test'), fileTargets(scanFileTargets(targets,[])), ninjaCwd));
   writeFileAscii(
     path.join(testDir, ninjaOutput),
@@ -1374,7 +1374,7 @@ function updateDev() {
     `
 subninja compiler.ninja
 stdlib = stdlib-406
-${BSC_COMPILER}      
+${BSC_COMPILER}
 subninja runtime/build.ninja
 subninja others/build.ninja
 subninja $stdlib/build.ninja

--- a/scripts/ninja.js
+++ b/scripts/ninja.js
@@ -1227,7 +1227,8 @@ ${mllList(ninjaCwd, [
   let depsMap = createDepsMapWithTargets(sources);
   await Promise.all(depModulesForBscAsync(sources, testDir, depsMap));
   var targets = collectTarget(sources);
-  var output = generateNinja(depsMap, targets, ninjaCwd, [stdlibTarget]);
+  var output = generateNinja(depsMap, targets, ninjaCwd, [stdlibTarget,compilerTarget]);
+  output.push(phony(pseudoTarget('test'), fileTargets(scanFileTargets(targets,[])), ninjaCwd));
   writeFileAscii(
     path.join(testDir, ninjaOutput),
     templateTestRules + output.join("\n") + "\n"

--- a/scripts/ninja.js
+++ b/scripts/ninja.js
@@ -1512,7 +1512,7 @@ ${buildNapkinFiles}
 }
 
 var sourceDirs = [
-  "ml",  
+  "ml",
   "stubs",
   "ext",
   "common",
@@ -1541,7 +1541,7 @@ var bsc_libs = [
   "stubs",
   "ext",
   ...compiler_libs,
-  "js_parser",  
+  "js_parser",
   "napkin",
   "common",
   "frontend",
@@ -1554,7 +1554,7 @@ var bsc_libs = [
 var bspack_libs = [
   "stubs",
   "ext",
-  ...compiler_libs,  
+  ...compiler_libs,
   "common",
   "frontend",
   "depends",
@@ -1562,7 +1562,7 @@ var bspack_libs = [
 
 var bsb_helper_libs = ["stubs", "ext", "common", "bsb_helper"];
 
-var rescript_libs = ["stubs",  "ext", "common", "bsb"];
+var rescript_libs = ["stubs", "ext", "common", "bsb"];
 
 var cmjdumps_libs = [
   "stubs",
@@ -1577,7 +1577,7 @@ var cmjdumps_libs = [
 var cmij_libs = [
   "stubs",
   "ext",
-  ...compiler_libs,    
+  ...compiler_libs,
   "common",
   "frontend",
   "depends",
@@ -1607,7 +1607,7 @@ function nativeNinja() {
 
   var includes = sourceDirs.map((x) => `-I ${x}`).join(" ");
 
-  var flags = "-w A-4-9-40..42-30-48-50-44-45";  
+  var flags = "-w A-4-9-40..42-30-48-50-44-45";
   if (+getVersionString().split(".")[1] > 7) {
     flags += "-3-67 -error-style short";
   }


### PR DESCRIPTION
- format
- make build scripts more robust
- fix build scripts
- make the default output less noisy
- snapshot

It used to work since we run the default mode which contains all targets