### PR TITLE
Add better error message for arity mismatch

### DIFF
--- a/jscomp/ml/typetexp.ml
+++ b/jscomp/ml/typetexp.ml
@@ -872,9 +872,9 @@ let report_error env ppf = function
       fprintf ppf
         "@[The type %a is not generic so expects no arguments,@ \
           but is here applied to %i argument(s).@ \
-          You wrote `%a<>`. Have you tried removing the angular brackets@ \
-          and writing `%a` instead? @]"
-        longident lid provided longident lid longident lid
+          Have you tried removing the angular brackets `<` and `>` and the@ \
+          arguments within them and just writing `%a` instead? @]"
+        longident lid provided longident lid
     else 
       fprintf ppf
         "@[The type constructor %a@ expects %i argument(s),@ \

--- a/jscomp/ml/typetexp.ml
+++ b/jscomp/ml/typetexp.ml
@@ -868,10 +868,18 @@ let report_error env ppf = function
     fprintf ppf "The type constructor@ %a@ is not yet completely defined"
       path p
   | Type_arity_mismatch(lid, expected, provided) ->
-    fprintf ppf
-      "@[The type constructor %a@ expects %i argument(s),@ \
-        but is here applied to %i argument(s)@]"
-      longident lid expected provided
+    if expected==0 then
+      fprintf ppf
+        "@[The type %a is not generic so expects no arguments,@ \
+          but is here applied to %i argument(s).@ \
+          You wrote `%a<>`. Have you tried removing the angular brackets@ \
+          and writing `%a` instead? @]"
+        longident lid provided longident lid longident lid
+    else 
+      fprintf ppf
+        "@[The type constructor %a@ expects %i argument(s),@ \
+          but is here applied to %i argument(s)@]"
+        longident lid expected provided
   | Bound_type_variable name ->
     fprintf ppf "Already bound type parameter '%s" name
   | Recursive_type ->


### PR DESCRIPTION
@wokalski opened an issue #5201 for a simpler error message for type arity mismatch case. I spent a little time working on it as a good first issue. 

Taking a page out of Elm's book, I thought it would be nice to explicitly suggest a solution to the user here. Here's what it ends up looking like: 

```
// Sample file:
type t = int

let make = (~param: t<int>) => param + 1
```

which produces this error message: 
```
We've found a bug for you!
  ./test.res:3:21-26

  1 │ type t = int
  2 │ 
  3 │ let make = (~param: t<int>) => param + 1
  4 │ 

  The type t is not generic so expects no arguments,
  but is here applied to 1 argument(s).
  You wrote `t<>`. Have you tried removing the angular brackets
  and writing `t` instead? 
```

I don't quite understand what `stl` does, but I know it contains the actual arguments passed into the type constructor itself, so I tried to pass stl into `Type_arity_mismatch` and get an error message that includes the exact syntax the user typed, but I am unsure how to do that. Any assistance would be appreciated! 