### PR TITLE
remove trailing newlines, prepare return unit optimization

### DIFF
--- a/jscomp/core/js_dump.ml
+++ b/jscomp/core/js_dump.ml
@@ -1225,9 +1225,7 @@ and brace_block cxt f b =
 and statements top cxt f b =
   iter_lst cxt f b
     (fun cxt f s -> statement top cxt f s)
-    (if top then (fun f ->
-     P.newline f;
-     P.force_newline f)
+    (if top then P.at_least_two_lines
     else P.newline)
 
 let string_of_block (block : J.block) =

--- a/jscomp/core/js_dump.ml
+++ b/jscomp/core/js_dump.ml
@@ -1212,6 +1212,8 @@ and function_body (cxt : cxt) f (b : J.block) : unit =
               : cxt)
       | Return { expression_desc = Undefined } -> ()
       | _ -> ignore (statement false cxt f s : cxt))
+  | [ s; { statement_desc = Return { expression_desc = Undefined } } ] ->
+      ignore (statement false cxt f s : cxt)
   | s :: r ->
       let cxt = statement false cxt f s in
       P.newline f;
@@ -1225,8 +1227,7 @@ and brace_block cxt f b =
 and statements top cxt f b =
   iter_lst cxt f b
     (fun cxt f s -> statement top cxt f s)
-    (if top then P.at_least_two_lines
-    else P.newline)
+    (if top then P.at_least_two_lines else P.newline)
 
 let string_of_block (block : J.block) =
   let buffer = Buffer.create 50 in

--- a/jscomp/core/js_dump.mli
+++ b/jscomp/core/js_dump.mli
@@ -17,23 +17,15 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-*)
+ *)
 (* Authors: Jérôme Vouillon, Hongbo Zhang  *)
 
-
-
+val statements : bool -> Ext_pp_scope.t -> Ext_pp.t -> J.block -> Ext_pp_scope.t
 (** Print JS IR to vanilla Javascript code 
     Called by module {!Js_dump_program}
 *)
-val statement_list : 
-  bool ->
-  Ext_pp_scope.t -> 
-  Ext_pp.t -> 
-  J.block -> 
-  Ext_pp_scope.t
 
-
-(** 2 functions Only used for debugging *)
 val string_of_block : J.block -> string
+(** 2 functions Only used for debugging *)
 
 val string_of_expression : J.expression -> string

--- a/jscomp/core/js_dump_import_export.ml
+++ b/jscomp/core/js_dump_import_export.ml
@@ -24,132 +24,121 @@
 
 module P = Ext_pp
 module L = Js_dump_lit
+
 let default_export = "default"
-let esModule  = "__esModule", "true"
+
+let esModule = ("__esModule", "true")
 (* Exports printer *)
 
 (* Print exports in Google module format, CommonJS format *)
-let exports cxt f (idents : Ident.t list) = 
-  let outer_cxt, reversed_list = 
-    Ext_list.fold_left idents (cxt, []) (fun (cxt, acc) id -> 
-        let id_name = id.name in 
-        let s = Ext_ident.convert id_name in        
-        let str,cxt  = Ext_pp_scope.str_of_ident cxt id in         
-        cxt, ( 
-          if id_name = default_export then 
+let exports cxt f (idents : Ident.t list) =
+  let outer_cxt, reversed_list =
+    Ext_list.fold_left idents (cxt, []) (fun (cxt, acc) id ->
+        let id_name = id.name in
+        let s = Ext_ident.convert id_name in
+        let str, cxt = Ext_pp_scope.str_of_ident cxt id in
+        ( cxt,
+          if id_name = default_export then
             (* TODO check how it will affect AMDJS*)
-            esModule :: (default_export, str) :: (s,str)::acc 
-          else (s,str) :: acc ))
-  in    
-  P.newline f ;
-  Ext_list.rev_iter reversed_list (fun (s,export) -> 
-      P.group f 0 @@ (fun _ ->  
-          P.string f L.exports;
-          P.string f L.dot;
-          P.string f s; 
-          P.space f ;
-          P.string f L.eq;
-          P.space f;
-          P.string f export;          
-          P.string f L.semi;);
-      P.newline f;
-    ) ;
-  outer_cxt  
-
+            esModule :: (default_export, str) :: (s, str) :: acc
+          else (s, str) :: acc ))
+  in
+  P.newline f;
+  Ext_list.rev_iter reversed_list (fun (s, export) ->
+      ( P.group f 0 @@ fun _ ->
+        P.string f L.exports;
+        P.string f L.dot;
+        P.string f s;
+        P.space f;
+        P.string f L.eq;
+        P.space f;
+        P.string f export;
+        P.string f L.semi );
+      P.newline f);
+  outer_cxt
 
 (** Print module in ES6 format, it is ES6, trailing comma is valid ES6 code *)
-let es6_export cxt f (idents : Ident.t list) = 
-  let outer_cxt, reversed_list = 
-    Ext_list.fold_left idents (cxt, []) (fun (cxt, acc) id  -> 
-        let id_name = id.name in 
-        let s = Ext_ident.convert id_name in        
-        let str,cxt  = Ext_pp_scope.str_of_ident cxt id in         
-        cxt, ( 
-          if id_name = default_export then 
-            (default_export,str)::(s,str)::acc
-          else 
-            (s,str) :: acc ))
-  in    
-  P.newline f ;
-  P.string f L.export ; 
-  P.space f ; 
-  P.brace_vgroup f 1 begin fun _ -> 
-    Ext_list.rev_iter reversed_list (fun (s,export) -> 
-        P.group f 0 @@ (fun _ ->  
-            P.string f export;          
-            P.space f ;
-            if not @@ Ext_string.equal export s then begin 
-              P.string f L.as_ ;
+let es6_export cxt f (idents : Ident.t list) =
+  let outer_cxt, reversed_list =
+    Ext_list.fold_left idents (cxt, []) (fun (cxt, acc) id ->
+        let id_name = id.name in
+        let s = Ext_ident.convert id_name in
+        let str, cxt = Ext_pp_scope.str_of_ident cxt id in
+        ( cxt,
+          if id_name = default_export then
+            (default_export, str) :: (s, str) :: acc
+          else (s, str) :: acc ))
+  in
+  P.newline f;
+  P.string f L.export;
+  P.space f;
+  P.brace_vgroup f 1 (fun _ ->
+      Ext_list.rev_iter reversed_list (fun (s, export) ->
+          ( P.group f 0 @@ fun _ ->
+            P.string f export;
+            P.space f;
+            if not @@ Ext_string.equal export s then (
+              P.string f L.as_;
               P.space f;
-              P.string f s
-            end ;             
-            P.string f L.comma ;);
-        P.newline f;
-      ) ;
-  end;
-  outer_cxt  
-
+              P.string f s);
+            P.string f L.comma );
+          P.newline f));
+  outer_cxt
 
 (** Node or Google module style imports *)
-let requires require_lit cxt f (modules : (Ident.t * string * bool) list ) =
-  P.newline f ; 
-  (* the context used to print the following program *)  
-  let outer_cxt, reversed_list  =
-    Ext_list.fold_left modules (cxt, []) 
-      (fun (cxt, acc) (id,s,b)  ->
-         let str, cxt = Ext_pp_scope.str_of_ident cxt id  in
-         cxt, ((str,s,b) :: acc ))
+let requires require_lit cxt f (modules : (Ident.t * string * bool) list) =
+  P.newline f;
+  (* the context used to print the following program *)
+  let outer_cxt, reversed_list =
+    Ext_list.fold_left modules (cxt, []) (fun (cxt, acc) (id, s, b) ->
+        let str, cxt = Ext_pp_scope.str_of_ident cxt id in
+        (cxt, (str, s, b) :: acc))
   in
-  P.force_newline f ;    
-  Ext_list.rev_iter reversed_list (fun (s,file,default) ->
+  P.force_newline f;
+  Ext_list.rev_iter reversed_list (fun (s, file, default) ->
       P.string f L.var;
-      P.space f ;
-      P.string f s ;
-      P.space f ;
+      P.space f;
+      P.string f s;
+      P.space f;
       P.string f L.eq;
       P.space f;
       P.string f require_lit;
-      P.paren_group f 0  (fun _ ->
-          Js_dump_string.pp_string f file  );
-      (if default then P.string f ".default");
+      P.paren_group f 0 (fun _ -> Js_dump_string.pp_string f file);
+      if default then P.string f ".default";
       P.string f L.semi;
-      P.newline f ;
-    ) ;
-  outer_cxt  
+      P.newline f);
+  outer_cxt
 
 (** ES6 module style imports *)
-let imports  cxt f (modules : (Ident.t * string * bool) list ) =
-  P.newline f ; 
-  (* the context used to print the following program *)  
+let imports cxt f (modules : (Ident.t * string * bool) list) =
+  P.newline f;
+  (* the context used to print the following program *)
   let outer_cxt, reversed_list =
-    Ext_list.fold_left modules (cxt, []) 
-      (fun (cxt, acc) (id,s,b) ->
-         let str, cxt = Ext_pp_scope.str_of_ident cxt id  in
-         cxt, ((str,s,b) :: acc))
+    Ext_list.fold_left modules (cxt, []) (fun (cxt, acc) (id, s, b) ->
+        let str, cxt = Ext_pp_scope.str_of_ident cxt id in
+        (cxt, (str, s, b) :: acc))
   in
-  P.force_newline f ;    
-  Ext_list.rev_iter reversed_list (fun (s,file,default) ->    
+  P.force_newline f;
+  Ext_list.rev_iter reversed_list (fun (s, file, default) ->
       P.string f L.import;
-      P.space f ;
-      if default then begin
+      P.space f;
+      if default then (
         P.string f s;
-        P.space f ;
+        P.space f;
         P.string f L.from;
         P.space f;
-        Js_dump_string.pp_string f file 
-      end
-      else begin       
-        P.string f L.star ;
-        P.space f ; (* import * as xx from 'xx'*) 
-        P.string f L.as_ ; 
-        P.space f ; 
-        P.string f s ; 
-        P.space f ;
+        Js_dump_string.pp_string f file)
+      else (
+        P.string f L.star;
+        P.space f;
+        (* import * as xx from 'xx'*)
+        P.string f L.as_;
+        P.space f;
+        P.string f s;
+        P.space f;
         P.string f L.from;
         P.space f;
-        Js_dump_string.pp_string f file ;
-      end;
-      P.string f L.semi ;
-      P.newline f ;
-    ) ;
+        Js_dump_string.pp_string f file);
+      P.string f L.semi;
+      P.newline f);
   outer_cxt

--- a/jscomp/core/js_dump_program.ml
+++ b/jscomp/core/js_dump_program.ml
@@ -23,100 +23,76 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 module P = Ext_pp
-module L = Js_dump_lit 
+module L = Js_dump_lit
 
+let empty_explanation =
+  "/* This output is empty. Its source's type definitions, externals and/or \
+   unused code got optimized away. */\n"
 
+let program_is_empty (x : J.program) =
+  match x with
+  | { block = []; exports = []; export_set = _ } -> true
+  | _ -> false
 
+let deps_program_is_empty (x : J.deps_program) =
+  match x with
+  | { modules = []; program; side_effect = None } -> program_is_empty program
+  | _ -> false
 
-let empty_explanation = 
-  "/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */\n"
-
-let program_is_empty (x : J.program) = 
-  match x with 
+let rec extract_block_comments acc (x : J.block) =
+  match x with
   | {
-    block = [];
-    exports = [];
-    export_set = _
-  }  -> true 
-  | _  -> false  
+      statement_desc =
+        Exp
+          {
+            expression_desc =
+              Raw_js_code { code; code_info = Stmt Js_stmt_comment };
+          };
+    }
+    :: rest ->
+      extract_block_comments (code :: acc) rest
+  | _ -> (acc, x)
 
-let deps_program_is_empty (x : J.deps_program) = 
-  match x with 
-  | { modules = [];
-      program ;
-      side_effect = None
-    } -> program_is_empty program
-  | _ -> false 
+let extract_file_comments (x : J.deps_program) =
+  let comments, new_block = extract_block_comments [] x.program.block in
+  (comments, { x with program = { x.program with block = new_block } })
 
-let rec extract_block_comments acc (x : J.block) = 
-  match x with 
-  | {statement_desc = Exp {expression_desc = Raw_js_code {code ; code_info = Stmt (Js_stmt_comment)}} } :: rest
-    -> extract_block_comments (code :: acc) rest 
-  | _ -> (acc ,x)
-
-
-let extract_file_comments  (x : J.deps_program) = 
-  let comments, new_block = extract_block_comments [] x.program.block in 
-  comments , {x with program = {x.program with block = new_block}}
-
-
-
-
-
-let program f cxt   ( x : J.program ) = 
+let program f cxt (x : J.program) =
   P.force_newline f;
-  let cxt =  Js_dump.statement_list true cxt f x.block  in
+  let cxt = Js_dump.statement_list true cxt f x.block in
   P.force_newline f;
   Js_dump_import_export.exports cxt f x.exports
 
-let dump_program (x : J.program) oc = 
-  ignore (program (P.from_channel oc)  Ext_pp_scope.empty  x )
+let dump_program (x : J.program) oc =
+  ignore (program (P.from_channel oc) Ext_pp_scope.empty x)
 
-let [@inline] is_default (x : Js_op.kind) =  
-  match x with External {default} -> default | _ -> false
+let[@inline] is_default (x : Js_op.kind) =
+  match x with External { default } -> default | _ -> false
 
-let node_program ~output_dir f ( x : J.deps_program) = 
-  P.string f L.strict_directive; 
-  P.newline f ;
-  let cxt = 
-    Js_dump_import_export.requires 
-      L.require
-      Ext_pp_scope.empty
-      f
-      (Ext_list.map x.modules 
-         (fun x -> 
-            x.id,
-            Js_name_of_module_id.string_of_module_id 
-              x
-              ~output_dir
-              NodeJS,
-            is_default x.kind
-         ))
+let node_program ~output_dir f (x : J.deps_program) =
+  P.string f L.strict_directive;
+  P.newline f;
+  let cxt =
+    Js_dump_import_export.requires L.require Ext_pp_scope.empty f
+      (Ext_list.map x.modules (fun x ->
+           ( x.id,
+             Js_name_of_module_id.string_of_module_id x ~output_dir NodeJS,
+             is_default x.kind )))
   in
-  program f cxt x.program  
+  program f cxt x.program
 
-
-
-
-let es6_program  ~output_dir fmt f (  x : J.deps_program) = 
-  let cxt = 
-    Js_dump_import_export.imports
-      Ext_pp_scope.empty
-      f
-      (Ext_list.map x.modules
-         (fun x -> 
-            x.id,
-            Js_name_of_module_id.string_of_module_id x ~output_dir
-              fmt,
-            is_default x.kind
-         ))
+let es6_program ~output_dir fmt f (x : J.deps_program) =
+  let cxt =
+    Js_dump_import_export.imports Ext_pp_scope.empty f
+      (Ext_list.map x.modules (fun x ->
+           ( x.id,
+             Js_name_of_module_id.string_of_module_id x ~output_dir fmt,
+             is_default x.kind )))
   in
-  let () = P.force_newline f in 
-  let cxt = Js_dump.statement_list true cxt f x.program.block in 
-  let () = P.force_newline f in 
+  let () = P.force_newline f in
+  let cxt = Js_dump.statement_list true cxt f x.program.block in
+  let () = P.force_newline f in
   Js_dump_import_export.es6_export cxt f x.program.exports
-
-
 
 (** Make sure github linguist happy
     {[
@@ -125,43 +101,31 @@ let es6_program  ~output_dir fmt f (  x : J.deps_program) =
     ]}
 *)
 
-let pp_deps_program
-    ~(output_prefix : string)
-    (kind : Js_packages_info.module_system )
-    (program  : J.deps_program) (f : Ext_pp.t) = 
-  if not !Js_config.no_version_header then 
-    begin 
-      P.string f Bs_version.header;
-      P.newline f
-    end ; 
-  if deps_program_is_empty program then 
-    P.string f empty_explanation 
+let pp_deps_program ~(output_prefix : string)
+    (kind : Js_packages_info.module_system) (program : J.deps_program)
+    (f : Ext_pp.t) =
+  if not !Js_config.no_version_header then (
+    P.string f Bs_version.header;
+    P.newline f);
+  if deps_program_is_empty program then P.string f empty_explanation
     (* This is empty module, it won't be referred anywhere *)
-  else 
-    let comments, program = extract_file_comments program  in 
-    Ext_list.rev_iter comments (fun comment -> P.string f comment; P.newline f) ;
-    let output_dir = Filename.dirname output_prefix in   
-    begin 
-      ignore (match kind with 
-          | Es6 | Es6_global -> 
-            es6_program ~output_dir kind f program
-          | NodeJS -> 
-            node_program ~output_dir f program
-        ) ;
-      P.newline f ;
-      P.string f (
-        match program.side_effect with
-        | None -> "/* No side effect */"
-        | Some v -> Printf.sprintf "/* %s Not a pure module */" v );
-      P.newline f;
-      P.flush f ()
-    end
+  else
+    let comments, program = extract_file_comments program in
+    Ext_list.rev_iter comments (fun comment ->
+        P.string f comment;
+        P.newline f);
+    let output_dir = Filename.dirname output_prefix in
+    ignore
+      (match kind with
+      | Es6 | Es6_global -> es6_program ~output_dir kind f program
+      | NodeJS -> node_program ~output_dir f program);
+    P.newline f;
+    P.string f
+      (match program.side_effect with
+      | None -> "/* No side effect */"
+      | Some v -> Printf.sprintf "/* %s Not a pure module */" v);
+    P.newline f;
+    P.flush f ()
 
-
-
-let dump_deps_program
-    ~output_prefix
-    kind
-    x 
-    (oc : out_channel) = 
-  pp_deps_program ~output_prefix  kind x (P.from_channel oc)
+let dump_deps_program ~output_prefix kind x (oc : out_channel) =
+  pp_deps_program ~output_prefix kind x (P.from_channel oc)

--- a/jscomp/core/js_dump_program.ml
+++ b/jscomp/core/js_dump_program.ml
@@ -59,7 +59,7 @@ let extract_file_comments (x : J.deps_program) =
 
 let program f cxt (x : J.program) =
   P.force_newline f;
-  let cxt = Js_dump.statement_list true cxt f x.block in
+  let cxt = Js_dump.statements true cxt f x.block in
   P.force_newline f;
   Js_dump_import_export.exports cxt f x.exports
 
@@ -90,7 +90,7 @@ let es6_program ~output_dir fmt f (x : J.deps_program) =
              is_default x.kind )))
   in
   let () = P.force_newline f in
-  let cxt = Js_dump.statement_list true cxt f x.program.block in
+  let cxt = Js_dump.statements true cxt f x.program.block in
   let () = P.force_newline f in
   Js_dump_import_export.es6_export cxt f x.program.exports
 

--- a/jscomp/core/js_dump_program.ml
+++ b/jscomp/core/js_dump_program.ml
@@ -58,9 +58,8 @@ let extract_file_comments (x : J.deps_program) =
   (comments, { x with program = { x.program with block = new_block } })
 
 let program f cxt (x : J.program) =
-  P.force_newline f;
+  P.at_least_two_lines f;
   let cxt = Js_dump.statements true cxt f x.block in
-  P.force_newline f;
   Js_dump_import_export.exports cxt f x.exports
 
 let dump_program (x : J.program) oc =
@@ -89,9 +88,8 @@ let es6_program ~output_dir fmt f (x : J.deps_program) =
              Js_name_of_module_id.string_of_module_id x ~output_dir fmt,
              is_default x.kind )))
   in
-  let () = P.force_newline f in
+  let () = P.at_least_two_lines f in
   let cxt = Js_dump.statements true cxt f x.program.block in
-  let () = P.force_newline f in
   Js_dump_import_export.es6_export cxt f x.program.exports
 
 (** Make sure github linguist happy

--- a/jscomp/ext/ext_pp.ml
+++ b/jscomp/ext/ext_pp.ml
@@ -73,6 +73,14 @@ let newline t =
     done;
     t.last_new_line <- true)
 
+let at_least_two_lines t =
+  if not t.last_new_line then t.output_char '\n';
+  t.output_char '\n';
+  for _ = 0 to t.indent_level - 1 do
+    t.output_string L.indent_str
+  done;
+  t.last_new_line <- true
+
 let force_newline t =
   t.output_char '\n';
   for _ = 0 to t.indent_level - 1 do

--- a/jscomp/ext/ext_pp.ml
+++ b/jscomp/ext/ext_pp.ml
@@ -85,7 +85,8 @@ let force_newline t =
   t.output_char '\n';
   for _ = 0 to t.indent_level - 1 do
     t.output_string L.indent_str
-  done
+  done;
+  t.last_new_line <- true
 
 let space t = string t L.space
 

--- a/jscomp/ext/ext_pp.ml
+++ b/jscomp/ext/ext_pp.ml
@@ -22,15 +22,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-
-
-
-
-
-
-
 module L = struct
   let space = " "
+
   let indent_str = "  "
 end
 
@@ -42,63 +36,59 @@ type t = {
   flush : unit -> unit;
   mutable indent_level : int;
   mutable last_new_line : bool;
-  (* only when we print newline, we print the indent *)
+      (* only when we print newline, we print the indent *)
 }
 
-let from_channel chan = {
-  output_string = (fun  s -> output_string chan s);
-  output_char = (fun c -> output_char chan c);
-  flush = (fun _ -> flush chan);
-  indent_level = 0 ;
-  last_new_line = false;
-}
+let from_channel chan =
+  {
+    output_string = (fun s -> output_string chan s);
+    output_char = (fun c -> output_char chan c);
+    flush = (fun _ -> flush chan);
+    indent_level = 0;
+    last_new_line = false;
+  }
 
-
-let from_buffer buf = {
-  output_string = (fun s -> Buffer.add_string buf s);
-  output_char = (fun  c -> Buffer.add_char buf c);
-  flush = (fun _ -> ());
-  indent_level = 0;
-  last_new_line = false;
-}
+let from_buffer buf =
+  {
+    output_string = (fun s -> Buffer.add_string buf s);
+    output_char = (fun c -> Buffer.add_char buf c);
+    flush = (fun _ -> ());
+    indent_level = 0;
+    last_new_line = false;
+  }
 
 (* If we have [newline] in [s],
    all indentations will be broken
    in the future, we can detect this in [s]
 *)
 let string t s =
-  t.output_string  s ;
+  t.output_string s;
   t.last_new_line <- false
 
 let newline t =
-  if not t.last_new_line then
-    begin
-      t.output_char  '\n';
-      for _ = 0 to t.indent_level - 1 do
-        t.output_string  L.indent_str;
-      done;
-      t.last_new_line <- true
-    end
+  if not t.last_new_line then (
+    t.output_char '\n';
+    for _ = 0 to t.indent_level - 1 do
+      t.output_string L.indent_str
+    done;
+    t.last_new_line <- true)
 
 let force_newline t =
-  t.output_char  '\n';
+  t.output_char '\n';
   for _ = 0 to t.indent_level - 1 do
-    t.output_string  L.indent_str;
+    t.output_string L.indent_str
   done
 
-let space t  =
-  string t L.space
+let space t = string t L.space
 
-let nspace  t n  =
-  string  t (String.make n ' ')
+let nspace t n = string t (String.make n ' ')
 
 let group t i action =
   if i = 0 then action ()
   else
     let old = t.indent_level in
     t.indent_level <- t.indent_level + i;
-    Ext_pervasives.finally ~clean:(fun _ -> t.indent_level <- old)
-      ()  action
+    Ext_pervasives.finally ~clean:(fun _ -> t.indent_level <- old) () action
 
 let vgroup = group
 
@@ -123,52 +113,48 @@ let bracket fmt u =
 
 let brace_vgroup st n action =
   string st "{";
-  let v = vgroup st n (fun _ ->
-      newline st;
-      let v =  action () in
-      v
-    ) in
+  let v =
+    vgroup st n (fun _ ->
+        newline st;
+        let v = action () in
+        v)
+  in
   force_newline st;
   string st "}";
   v
 
 let bracket_vgroup st n action =
   string st "[";
-  let v = vgroup st n (fun _ ->
-      newline st;
-      let v =  action () in
-      v
-    ) in
+  let v =
+    vgroup st n (fun _ ->
+        newline st;
+        let v = action () in
+        v)
+  in
   force_newline st;
   string st "]";
   v
 
-let bracket_group st n action =
-  group st n (fun _ -> bracket st action)
+let bracket_group st n action = group st n (fun _ -> bracket st action)
 
 let paren_vgroup st n action =
   string st "(";
-  let v = group st n (fun _ ->
-      newline st;
-      let v = action () in
-      v
-    ) in
+  let v =
+    group st n (fun _ ->
+        newline st;
+        let v = action () in
+        v)
+  in
   newline st;
   string st ")";
   v
 
-let paren_group st n action = 
-  group st n (fun _ -> paren st action)
+let paren_group st n action = group st n (fun _ -> paren st action)
 
-let cond_paren_group st b n action =    
-  if b then 
-    paren_group st n action 
-  else 
-    action ()
+let cond_paren_group st b n action =
+  if b then paren_group st n action else action ()
 
-
-let brace_group st n action =
-  group st n (fun _ -> brace st action )
+let brace_group st n action = group st n (fun _ -> brace st action)
 
 (* let indent t n =
    t.indent_level <- t.indent_level + n *)

--- a/jscomp/ext/ext_pp.mli
+++ b/jscomp/ext/ext_pp.mli
@@ -22,13 +22,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-
-
-
-
-
-
-
+type t
 (** A simple pretty printer
 
     Advantage compared with [Format], 
@@ -40,15 +34,14 @@
     {- buffer the last line, so that  we can do a smart newline, when it's really safe to do so}
     }
 *)
-type t
 
-val indent_length : int 
+val indent_length : int
 
 val string : t -> string -> unit
 
-val space :  t -> unit
+val space : t -> unit
 
-val nspace : t -> int ->  unit
+val nspace : t -> int -> unit
 
 val group : t -> int -> (unit -> 'a) -> 'a
 (** [group] will record current indentation 
@@ -63,12 +56,7 @@ val brace : t -> (unit -> 'a) -> 'a
 
 val paren_group : t -> int -> (unit -> 'a) -> 'a
 
-val cond_paren_group :
-  t -> 
-  bool -> 
-  int -> 
-  (unit -> 'a) -> 
-  'a 
+val cond_paren_group : t -> bool -> int -> (unit -> 'a) -> 'a
 
 val paren_vgroup : t -> int -> (unit -> 'a) -> 'a
 

--- a/jscomp/ext/ext_pp.mli
+++ b/jscomp/ext/ext_pp.mli
@@ -73,6 +73,8 @@ val newline : t -> unit
 val force_newline : t -> unit
 (** [force_newline] Always print a newline *)
 
+val at_least_two_lines : t -> unit
+
 val from_channel : out_channel -> t
 
 val from_buffer : Buffer.t -> t

--- a/jscomp/ext/ext_pp.mli
+++ b/jscomp/ext/ext_pp.mli
@@ -70,9 +70,6 @@ val bracket_vgroup : t -> int -> (unit -> 'a) -> 'a
 
 val newline : t -> unit
 
-val force_newline : t -> unit
-(** [force_newline] Always print a newline *)
-
 val at_least_two_lines : t -> unit
 
 val from_channel : out_channel -> t

--- a/jscomp/test/a_filename_test.js
+++ b/jscomp/test/a_filename_test.js
@@ -27,7 +27,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function test(param, param$1) {

--- a/jscomp/test/arity.js
+++ b/jscomp/test/arity.js
@@ -5,13 +5,11 @@ var Curry = require("../../lib/js/curry.js");
 function u(f, a, b) {
   console.log(f(a, b));
   console.log(f(a, b));
-  
 }
 
 function u2(f, a, b) {
   console.log(Curry._2(f, a, b));
   console.log(Curry._2(f, a, b));
-  
 }
 
 function f(x, y) {

--- a/jscomp/test/arity_deopt.js
+++ b/jscomp/test/arity_deopt.js
@@ -26,7 +26,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function f0(x, y, z) {

--- a/jscomp/test/array_subtle_test.js
+++ b/jscomp/test/array_subtle_test.js
@@ -28,7 +28,6 @@ function eq(loc, param) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var v = [
@@ -87,7 +86,6 @@ function f(v) {
     console.log("hi2");
   }
   console.log((v.pop(), undefined));
-  
 }
 
 function fff(x) {

--- a/jscomp/test/ast_abstract_test.js
+++ b/jscomp/test/ast_abstract_test.js
@@ -26,7 +26,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function tToJs(param) {

--- a/jscomp/test/ast_js_mapper_poly_test.js
+++ b/jscomp/test/ast_js_mapper_poly_test.js
@@ -27,7 +27,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var _map = {"D":"D","C":"C","f":"x"};

--- a/jscomp/test/ast_mapper_defensive_test.js
+++ b/jscomp/test/ast_mapper_defensive_test.js
@@ -25,7 +25,6 @@ function $$throw(loc, x) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function aToJs(param) {
@@ -73,17 +72,14 @@ function cFromJs(param) {
 
 $$throw("File \"ast_mapper_defensive_test.ml\", line 28, characters 16-23", (function (param) {
         aFromJs(3);
-        
       }));
 
 $$throw("File \"ast_mapper_defensive_test.ml\", line 29, characters 15-22", (function (param) {
         bFromJs(2);
-        
       }));
 
 $$throw("File \"ast_mapper_defensive_test.ml\", line 30, characters 15-22", (function (param) {
         cFromJs(33);
-        
       }));
 
 Mt.from_pair_suites("Ast_mapper_defensive_test", suites.contents);

--- a/jscomp/test/attr_test.js
+++ b/jscomp/test/attr_test.js
@@ -16,9 +16,7 @@ var hh = max2(1, 2);
 function f(x) {
   des(x, (function () {
           console.log("hei");
-          
         }));
-  
 }
 
 exports.u = u;

--- a/jscomp/test/basic_module_test.js
+++ b/jscomp/test/basic_module_test.js
@@ -11,7 +11,6 @@ var count = {
 
 function test(set) {
   count.contents = Offset.$$Set.cardinal(set) + count.contents | 0;
-  
 }
 
 test(Curry._1(Offset.M.$$Set.singleton, "42"));

--- a/jscomp/test/bdd.js
+++ b/jscomp/test/bdd.js
@@ -85,7 +85,6 @@ function resize(newSize) {
   }
   htab.contents = newArr;
   sz_1.contents = newSz_1;
-  
 }
 
 function insert(idl, idh, v, ind, bucket, newNode) {
@@ -110,7 +109,6 @@ function resetUnique(param) {
   htab.contents = Caml_array.make(sz_1.contents + 1 | 0, /* [] */0);
   n_items.contents = 0;
   nodeC.contents = 1;
-  
 }
 
 function mkNode(low, v, high) {

--- a/jscomp/test/bench.js
+++ b/jscomp/test/bench.js
@@ -56,7 +56,6 @@ function f2(param) {
           return prim0 + prim1;
         }), 0, b);
   console.log(Pervasives.string_of_float(v));
-  
 }
 
 f2(undefined);

--- a/jscomp/test/bs_array_test.js
+++ b/jscomp/test/bs_array_test.js
@@ -45,12 +45,10 @@ function neq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function push(prim0, prim1) {
   prim0.push(prim1);
-  
 }
 
 console.log([
@@ -90,7 +88,6 @@ $$throw("File \"bs_array_test.ml\", line 31, characters 8-15", (function (param)
               0,
               1
             ], -1);
-        
       }));
 
 $$throw("File \"bs_array_test.ml\", line 32, characters 8-15", (function (param) {
@@ -98,7 +95,6 @@ $$throw("File \"bs_array_test.ml\", line 32, characters 8-15", (function (param)
               0,
               1
             ], 2);
-        
       }));
 
 var partial_arg = [
@@ -1188,7 +1184,6 @@ function sumUsingForEach(xs) {
   };
   Belt_Array.forEach(xs, (function (x) {
           v.contents = v.contents + x | 0;
-          
         }));
   return v.contents;
 }
@@ -1245,7 +1240,6 @@ b("File \"bs_array_test.ml\", line 278, characters 4-11", (Belt_Array.forEachWit
             1
           ], (function (i, v) {
               c$1.contents = (c$1.contents + i | 0) + v | 0;
-              
             })), c$1.contents === 6));
 
 function id$1(loc, x) {

--- a/jscomp/test/bs_auto_uncurry.js
+++ b/jscomp/test/bs_auto_uncurry.js
@@ -44,7 +44,6 @@ function f_0(param) {
 function f_01(param) {
   return hi(function () {
               console.log("x");
-              
             });
 }
 
@@ -52,7 +51,6 @@ function f_02(xs) {
   return hi(function () {
               xs.contents = undefined;
               console.log("x");
-              
             });
 }
 
@@ -129,7 +127,6 @@ function hh(xs) {
           xs,
           param
         ]);
-    
   };
 }
 

--- a/jscomp/test/bs_auto_uncurry_test.js
+++ b/jscomp/test/bs_auto_uncurry_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function hi (cb){
@@ -43,7 +42,6 @@ hi(function () {
         hd: undefined,
         tl: xs.contents
       };
-      
     });
 
 hi(function () {
@@ -51,7 +49,6 @@ hi(function () {
         hd: undefined,
         tl: xs.contents
       };
-      
     });
 
 eq("File \"bs_auto_uncurry_test.ml\", line 27, characters 7-14", xs.contents, {

--- a/jscomp/test/bs_float_test.js
+++ b/jscomp/test/bs_float_test.js
@@ -38,7 +38,6 @@ function neq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 eq("File \"bs_float_test.ml\", line 14, characters 5-12", 1, 1.0);

--- a/jscomp/test/bs_hashset_int_test.js
+++ b/jscomp/test/bs_hashset_int_test.js
@@ -34,7 +34,6 @@ function sum2(h) {
   };
   Belt_HashSetInt.forEach(h, (function (x) {
           v.contents = v.contents + x | 0;
-          
         }));
   return v.contents;
 }

--- a/jscomp/test/bs_ignore_effect.js
+++ b/jscomp/test/bs_ignore_effect.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function add(x,y){

--- a/jscomp/test/bs_int_test.js
+++ b/jscomp/test/bs_int_test.js
@@ -38,7 +38,6 @@ function neq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 eq("File \"bs_int_test.ml\", line 14, characters 5-12", 1, 1.0);

--- a/jscomp/test/bs_list_test.js
+++ b/jscomp/test/bs_list_test.js
@@ -32,7 +32,6 @@ function sum(xs) {
   };
   Belt_List.forEach(xs, (function (x) {
           v.contents = v.contents + x | 0;
-          
         }));
   return v.contents;
 }
@@ -43,7 +42,6 @@ function sum2(xs, ys) {
   };
   Belt_List.forEach2(xs, ys, (function (x, y) {
           v.contents = (v.contents + x | 0) + y | 0;
-          
         }));
   return v.contents;
 }
@@ -1558,7 +1556,6 @@ $$throw("File \"bs_list_test.ml\", line 220, characters 8-15", (function (param)
 
 $$throw("File \"bs_list_test.ml\", line 221, characters 8-15", (function (param) {
         Belt_List.tailExn(/* [] */0);
-        
       }));
 
 $$throw("File \"bs_list_test.ml\", line 222, characters 8-15", (function (param) {
@@ -1569,7 +1566,6 @@ $$throw("File \"bs_list_test.ml\", line 222, characters 8-15", (function (param)
                 tl: /* [] */0
               }
             }, -1);
-        
       }));
 
 $$throw("File \"bs_list_test.ml\", line 223, characters 8-15", (function (param) {
@@ -1580,7 +1576,6 @@ $$throw("File \"bs_list_test.ml\", line 223, characters 8-15", (function (param)
                 tl: /* [] */0
               }
             }, 2);
-        
       }));
 
 eq("File \"bs_list_test.ml\", line 224, characters 5-12", Belt_List.map({

--- a/jscomp/test/bs_map_test.js
+++ b/jscomp/test/bs_map_test.js
@@ -28,7 +28,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function b(loc, v) {
@@ -45,7 +44,6 @@ function b(loc, v) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var mapOfArray = Belt_MapInt.fromArray;

--- a/jscomp/test/bs_node_string_buffer_test.js
+++ b/jscomp/test/bs_node_string_buffer_test.js
@@ -15,7 +15,6 @@ function f(str) {
           match[1]
         ]);
   }
-  
 }
 
 f("xx");

--- a/jscomp/test/bs_poly_set_test.js
+++ b/jscomp/test/bs_poly_set_test.js
@@ -203,7 +203,6 @@ function testIterToList(xs) {
             hd: x,
             tl: v.contents
           };
-          
         }));
   return Belt_List.reverse(v.contents);
 }
@@ -217,7 +216,6 @@ function testIterToList2(xs) {
             hd: x,
             tl: v.contents
           };
-          
         }));
   return Belt_List.reverse(v.contents);
 }
@@ -304,12 +302,10 @@ eq("File \"bs_poly_set_test.ml\", line 132, characters 5-12", Belt_Set.getExn(a0
 
 t("File \"bs_poly_set_test.ml\", line 133, characters 4-11", (function (param) {
         Belt_Set.getExn(a0, 1002);
-        
       }));
 
 t("File \"bs_poly_set_test.ml\", line 134, characters 4-11", (function (param) {
         Belt_Set.getExn(a0, -1);
-        
       }));
 
 eq("File \"bs_poly_set_test.ml\", line 135, characters 5-12", Belt_SetDict.size(a0.data), 1001);

--- a/jscomp/test/bs_queue_test.js
+++ b/jscomp/test/bs_queue_test.js
@@ -734,7 +734,6 @@ Belt_MutableQueue.forEach(q$5, (function (j) {
               };
         }
         i$7.contents = i$7.contents + 1 | 0;
-        
       }));
 
 var q1$1 = {

--- a/jscomp/test/bs_splice_partial.js
+++ b/jscomp/test/bs_splice_partial.js
@@ -4,7 +4,6 @@ var Curry = require("../../lib/js/curry.js");
 
 function test(g) {
   g.xx(22, 3, "xxx", 1, 2, 3);
-  
 }
 
 function test_hi(x) {
@@ -34,7 +33,6 @@ function test_cb(x) {
 
 function f(x) {
   v(x);
-  
 }
 
 function testUndefined(param) {

--- a/jscomp/test/bs_stack_test.js
+++ b/jscomp/test/bs_stack_test.js
@@ -70,7 +70,6 @@ function inOrder3(v) {
             Belt_MutableStack.push(s, v);
             current = v.left;
           };
-          
         }));
   return Belt_MutableQueue.toArray(q);
 }
@@ -100,7 +99,6 @@ function inOrder2(v) {
       todo = false;
     }
   };
-  
 }
 
 function n(l, r, a) {
@@ -120,7 +118,6 @@ function pushAllLeft(st1, s1) {
     Belt_MutableStack.push(s1, v);
     current = v.left;
   };
-  
 }
 
 var test2 = n(Caml_option.some(n(Caml_option.some(n(Caml_option.some(n(Caml_option.some(n(undefined, undefined, 4)), undefined, 2)), undefined, 5)), undefined, 1)), undefined, 3);

--- a/jscomp/test/bs_string_test.js
+++ b/jscomp/test/bs_string_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 eq("File \"bs_string_test.ml\", line 11, characters 5-12", "ghso ghso g".split(" ").reduce((function (x, y) {

--- a/jscomp/test/bs_unwrap_test.js
+++ b/jscomp/test/bs_unwrap_test.js
@@ -52,7 +52,6 @@ console.log(7, Caml_option.option_unwrap((console.log("trace"), undefined)));
 
 function dyn_log3(prim0, prim1, prim2) {
   console.log(prim0.VAL, Caml_option.option_unwrap(prim1));
-  
 }
 
 dyn_log3({
@@ -71,7 +70,6 @@ console.log({
 
 function dyn_log4(prim) {
   console.log(prim.VAL);
-  
 }
 
 console.log({
@@ -80,17 +78,14 @@ console.log({
 
 function f(x) {
   console.log(x.VAL);
-  
 }
 
 function ff0(x, p) {
   console.log(Caml_option.option_unwrap(x), p);
-  
 }
 
 function ff1(x, p) {
   console.log(Caml_option.option_unwrap(Curry._1(x, undefined)), p);
-  
 }
 
 function test00(param) {

--- a/jscomp/test/bytes_split_gpr_743_test.js
+++ b/jscomp/test/bytes_split_gpr_743_test.js
@@ -29,7 +29,6 @@ function eq(loc, param) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var b = [

--- a/jscomp/test/caml_format_test.js
+++ b/jscomp/test/caml_format_test.js
@@ -173,7 +173,6 @@ var suites = Pervasives.$at(from_of_string(of_string), Pervasives.$at({
                                 TAG: /* ThrowAny */7,
                                 _0: (function (param) {
                                     Caml_format.float_of_string("");
-                                    
                                   })
                               };
                       })

--- a/jscomp/test/caml_sys_poly_fill_test.js
+++ b/jscomp/test/caml_sys_poly_fill_test.js
@@ -29,7 +29,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 Node_process.putEnvVar("Caml_sys_poly_fill_test", "X");

--- a/jscomp/test/chain_code_test.js
+++ b/jscomp/test/chain_code_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function f(h) {
@@ -49,7 +48,6 @@ function f4(h, x, y) {
     x,
     y
   ];
-  
 }
 
 eq("File \"chain_code_test.ml\", line 28, characters 5-12", 32, ({

--- a/jscomp/test/chn_test.js
+++ b/jscomp/test/chn_test.js
@@ -27,7 +27,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 console.log("你好，\n世界");

--- a/jscomp/test/class_setter_getter.js
+++ b/jscomp/test/class_setter_getter.js
@@ -3,7 +3,6 @@
 
 function fff(x) {
   x.height = 2;
-  
 }
 
 function ff(x, z) {

--- a/jscomp/test/class_type_ffi_test.js
+++ b/jscomp/test/class_type_ffi_test.js
@@ -28,7 +28,6 @@ function sum_poly(zero, add, arr) {
 
 function test_set(x) {
   x.length = 3;
-  
 }
 
 function f(x) {

--- a/jscomp/test/complex_while_loop.js
+++ b/jscomp/test/complex_while_loop.js
@@ -16,7 +16,6 @@ function f(param) {
     console.log(String(n));
     n = n + 1 | 0;
   };
-  
 }
 
 function ff(param) {
@@ -26,7 +25,6 @@ function ff(param) {
         })()) {
     
   };
-  
 }
 
 exports.f = f;

--- a/jscomp/test/condition_compilation_test.js
+++ b/jscomp/test/condition_compilation_test.js
@@ -33,7 +33,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 eq("File \"condition_compilation_test.ml\", line 100, characters 5-12", 3, 3);

--- a/jscomp/test/cps_test.js
+++ b/jscomp/test/cps_test.js
@@ -48,7 +48,6 @@ function test_closure(param) {
   }
   $$Array.iter((function (i) {
           v.contents = v.contents + Curry._1(i, 0) | 0;
-          
         }), arr);
   return v.contents;
 }
@@ -70,7 +69,6 @@ function test_closure2(param) {
   }
   $$Array.iter((function (i) {
           v.contents = v.contents + Curry._1(i, 0) | 0;
-          
         }), arr);
   return v.contents;
 }

--- a/jscomp/test/demo.js
+++ b/jscomp/test/demo.js
@@ -119,7 +119,6 @@ function ui_layout(compile, lookup, appContext) {
                           mk_titleRow(result.toFixed(2))
                         ];
                 }));
-          
         }), 100);
   return hw1;
 }

--- a/jscomp/test/demo_int_map.js
+++ b/jscomp/test/demo_int_map.js
@@ -151,7 +151,6 @@ function test(param) {
   for(var i$1 = 0; i$1 <= 1000000; ++i$1){
     find(i$1, m);
   }
-  
 }
 
 test(undefined);

--- a/jscomp/test/demo_pipe.js
+++ b/jscomp/test/demo_pipe.js
@@ -4,10 +4,8 @@
 function register(rl) {
   return rl.on("line", (function (x) {
                   console.log(x);
-                  
                 })).on("close", (function (param) {
                 console.log("finished");
-                
               }));
 }
 

--- a/jscomp/test/div_by_zero_test.js
+++ b/jscomp/test/div_by_zero_test.js
@@ -27,7 +27,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function add(suite) {
@@ -35,7 +34,6 @@ function add(suite) {
     hd: suite,
     tl: suites.contents
   };
-  
 }
 
 add([
@@ -45,7 +43,6 @@ add([
                   TAG: /* ThrowAny */7,
                   _0: (function (param) {
                       Caml_int32.div(3, 0);
-                      
                     })
                 };
         })
@@ -58,7 +55,6 @@ add([
                   TAG: /* ThrowAny */7,
                   _0: (function (param) {
                       Caml_int32.mod_(3, 0);
-                      
                     })
                 };
         })
@@ -71,7 +67,6 @@ add([
                   TAG: /* ThrowAny */7,
                   _0: (function (param) {
                       Caml_int32.div(3, 0);
-                      
                     })
                 };
         })
@@ -84,7 +79,6 @@ add([
                   TAG: /* ThrowAny */7,
                   _0: (function (param) {
                       Caml_int32.mod_(3, 0);
-                      
                     })
                 };
         })
@@ -100,7 +94,6 @@ add([
                             0,
                             3
                           ], Caml_int64.zero);
-                      
                     })
                 };
         })
@@ -116,7 +109,6 @@ add([
                             0,
                             3
                           ], Caml_int64.zero);
-                      
                     })
                 };
         })

--- a/jscomp/test/dollar_escape_test.js
+++ b/jscomp/test/dollar_escape_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function $$(x, y) {

--- a/jscomp/test/earger_curry_test.js
+++ b/jscomp/test/earger_curry_test.js
@@ -57,7 +57,6 @@ function f2(param) {
           return prim0 + prim1;
         }), 0, b);
   console.log(Pervasives.string_of_float(v));
-  
 }
 
 f2(undefined);
@@ -85,7 +84,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var v = {

--- a/jscomp/test/es6_export.mjs
+++ b/jscomp/test/es6_export.mjs
@@ -6,6 +6,5 @@ var $$default = 3;
 export {
   $$default ,
   $$default as default,
-  
 }
 /* No side effect */

--- a/jscomp/test/event_ffi.js
+++ b/jscomp/test/event_ffi.js
@@ -40,7 +40,6 @@ function ocaml_run(b, c) {
 
 function a0() {
   console.log("hi");
-  
 }
 
 function a1(param) {
@@ -60,7 +59,6 @@ function a3(x, y, z) {
 function xx(param) {
   return function (param) {
     console.log(3);
-    
   };
 }
 

--- a/jscomp/test/exception_rebound_err_test.js
+++ b/jscomp/test/exception_rebound_err_test.js
@@ -28,7 +28,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var A = /* @__PURE__ */Caml_exceptions.create("Exception_rebound_err_test.A");

--- a/jscomp/test/exception_repr_test.js
+++ b/jscomp/test/exception_repr_test.js
@@ -28,7 +28,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var Hi = /* @__PURE__ */Caml_exceptions.create("Exception_repr_test.Hi");

--- a/jscomp/test/ext_array_test.js
+++ b/jscomp/test/ext_array_test.js
@@ -15,7 +15,6 @@ function reverse_range(a, i, len) {
     a[i + k | 0] = a[((i + len | 0) - 1 | 0) - k | 0];
     a[((i + len | 0) - 1 | 0) - k | 0] = t;
   }
-  
 }
 
 function reverse_in_place(a) {

--- a/jscomp/test/ext_list_test.js
+++ b/jscomp/test/ext_list_test.js
@@ -812,7 +812,6 @@ function ref_push(x, refs) {
     hd: x,
     tl: refs.contents
   };
-  
 }
 
 function ref_pop(refs) {

--- a/jscomp/test/ffi_arity_test.js
+++ b/jscomp/test/ffi_arity_test.js
@@ -51,7 +51,6 @@ function fff(param) {
   console.log("x");
   console.log("x");
   vvv.contents = vvv.contents + 1 | 0;
-  
 }
 
 function g() {

--- a/jscomp/test/ffi_array_test.js
+++ b/jscomp/test/ffi_array_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 eq("File \"ffi_array_test.ml\", line 12, characters 5-12", [

--- a/jscomp/test/ffi_js_test.js
+++ b/jscomp/test/ffi_js_test.js
@@ -36,7 +36,6 @@ function eq(loc, param) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var int_config = {
@@ -84,7 +83,6 @@ var same_type = [
 var v_obj = {
   hi: (function () {
       console.log("hei");
-      
     })
 };
 
@@ -174,7 +172,6 @@ function ffff(x) {
     3,
     "x"
   ];
-  
 }
 
 Mt.from_pair_suites("Ffi_js_test", suites.contents);

--- a/jscomp/test/ffi_splice_test.js
+++ b/jscomp/test/ffi_splice_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function Make (){

--- a/jscomp/test/flattern_order_test.js
+++ b/jscomp/test/flattern_order_test.js
@@ -35,7 +35,6 @@ function obj_get(param) {
 
 function obj_set(i) {
   v.contents = i;
-  
 }
 
 var obj = {

--- a/jscomp/test/flow_parser_reg_test.js
+++ b/jscomp/test/flow_parser_reg_test.js
@@ -1756,7 +1756,6 @@ function yyback(n, lexbuf) {
     pos_bol: currp.pos_bol,
     pos_cnum: currp.pos_cnum - n | 0
   };
-  
 }
 
 function back(lb) {
@@ -1958,7 +1957,6 @@ function start(str) {
             hd: c,
             tl: todo.contents
           };
-          
         }), str);
   return {
           negative: false,
@@ -2220,7 +2218,6 @@ function unicode_fix_cols(lb) {
     pos_bol: new_bol,
     pos_cnum: init.pos_cnum
   };
-  
 }
 
 function oct_to_int(x) {
@@ -5449,7 +5446,6 @@ function grow(t, n) {
   };
   var new_arr = $$Array.init(new_size, filler);
   t.la_results = new_arr;
-  
 }
 
 function lex(t) {
@@ -5501,7 +5497,6 @@ function lex(t) {
         match$1[1]
       ]);
   t.la_num_lexed = t.la_num_lexed + 1 | 0;
-  
 }
 
 function lex_until(t, i) {
@@ -5509,7 +5504,6 @@ function lex_until(t, i) {
   while(t.la_num_lexed <= i) {
     lex(t);
   };
-  
 }
 
 var default_parse_options = {
@@ -5605,7 +5599,6 @@ function comment_list(env) {
                     hd: c,
                     tl: env.comments.contents
                   };
-                  
                 }), param);
   };
 }
@@ -5999,7 +5992,6 @@ function token$3(env) {
   }
   Caml_array.set(t.la_results, t.la_num_lexed - 1 | 0, undefined);
   t.la_num_lexed = t.la_num_lexed - 1 | 0;
-  
 }
 
 function push_lex_mode(env, mode) {
@@ -6008,7 +6000,6 @@ function push_lex_mode(env, mode) {
     tl: env.lex_mode_stack.contents
   };
   env.lookahead.contents = create$1(env.lex_env.contents, List.hd(env.lex_mode_stack.contents));
-  
 }
 
 function pop_lex_mode(env) {
@@ -6025,7 +6016,6 @@ function pop_lex_mode(env) {
   }
   env.lex_mode_stack.contents = new_stack;
   env.lookahead.contents = create$1(env.lex_env.contents, List.hd(env.lex_mode_stack.contents));
-  
 }
 
 function double_pop_lex_mode(env) {
@@ -6051,7 +6041,6 @@ function double_pop_lex_mode(env) {
   }
   env.lex_mode_stack.contents = new_stack;
   env.lookahead.contents = create$1(env.lex_env.contents, List.hd(env.lex_mode_stack.contents));
-  
 }
 
 function semicolon(env) {
@@ -7938,7 +7927,6 @@ function strict_post_check(env, strict, simple, id, params) {
         env$1,
         /* Empty */0
       ], params);
-  
 }
 
 function param$1(env) {
@@ -17664,7 +17652,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var f = typeof __dirname === "undefined" ? undefined : __dirname;

--- a/jscomp/test/for_loop_test.js
+++ b/jscomp/test/for_loop_test.js
@@ -17,7 +17,6 @@ function for_3(x) {
     Caml_array.set(arr, i, (function(j){
         return function (param) {
           v.contents = v.contents + j | 0;
-          
         }
         }(j)));
   }
@@ -40,7 +39,6 @@ function for_4(x) {
     Caml_array.set(arr, i, (function(k){
         return function (param) {
           v.contents = v.contents + k | 0;
-          
         }
         }(k)));
   }
@@ -62,7 +60,6 @@ function for_5(x, u) {
     Caml_array.set(arr, i, (function(k){
         return function (param) {
           v.contents = v.contents + k | 0;
-          
         }
         }(k)));
   }
@@ -100,7 +97,6 @@ function for_6(x, u) {
       Caml_array.set(arr, i, (function(k,h){
           return function (param) {
             v.contents = (((((v.contents + k | 0) + v2.contents | 0) + v4.contents | 0) + v5.contents | 0) + h | 0) + u | 0;
-            
           }
           }(k,h)));
     }
@@ -131,7 +127,6 @@ function for_7(param) {
       Caml_array.set(arr, Math.imul(i, 3) + j | 0, (function(j){
           return function (param) {
             v.contents = (v.contents + i | 0) + j | 0;
-            
           }
           }(j)));
     }
@@ -158,7 +153,6 @@ function for_8(param) {
       Caml_array.set(arr, Math.imul(i, 3) + j | 0, (function(j,h){
           return function (param) {
             v.contents = (((v.contents + i | 0) + j | 0) + h | 0) + k | 0;
-            
           }
           }(j,h)));
     }
@@ -179,7 +173,6 @@ function for_9(param) {
       hd: x,
       tl: v.contents
     };
-    
   };
   var vv = {
     contents: 0
@@ -204,14 +197,12 @@ function for_9(param) {
       collect(v$1.contents);
       Caml_array.set(arr, (i << 1) + j | 0, (function (param) {
               vv.contents = vv.contents + v$1.contents | 0;
-              
             }));
     }
     }(v$1));
     Caml_array.set(arr2, i, (function(v$1){
         return function (param) {
           vv2.contents = vv2.contents + v$1.contents | 0;
-          
         }
         }(v$1)));
   }

--- a/jscomp/test/for_side_effect_test.js
+++ b/jscomp/test/for_side_effect_test.js
@@ -6,7 +6,6 @@ function tst(param) {
   for(var i = (console.log("hi"), 0) ,i_finish = (console.log("hello"), 3); i <= i_finish; ++i){
     
   }
-  
 }
 
 function test2(param) {

--- a/jscomp/test/format_test.js
+++ b/jscomp/test/format_test.js
@@ -29,7 +29,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function eq3(loc, a, b, c) {

--- a/jscomp/test/fs_test.js
+++ b/jscomp/test/fs_test.js
@@ -29,7 +29,6 @@ function eq(loc, param) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var x = typeof __filename === "undefined" ? undefined : __filename;

--- a/jscomp/test/functor_app_test.js
+++ b/jscomp/test/functor_app_test.js
@@ -28,7 +28,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var Y0 = Functor_def.Make(Functor_inst);

--- a/jscomp/test/global_module_alias_test.js
+++ b/jscomp/test/global_module_alias_test.js
@@ -27,7 +27,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var v = {

--- a/jscomp/test/gpr496_test.js
+++ b/jscomp/test/gpr496_test.js
@@ -27,7 +27,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var expected = [

--- a/jscomp/test/gpr_1154_test.js
+++ b/jscomp/test/gpr_1154_test.js
@@ -27,7 +27,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function f(x) {

--- a/jscomp/test/gpr_1170.js
+++ b/jscomp/test/gpr_1170.js
@@ -4,7 +4,6 @@
 function f(resp) {
   resp.statusCode = 200;
   resp.hi = "hi";
-  
 }
 
 exports.f = f;

--- a/jscomp/test/gpr_1245_test.js
+++ b/jscomp/test/gpr_1245_test.js
@@ -20,7 +20,6 @@ function f(param) {
     contents: param[1]
   };
   console.log(a, b);
-  
 }
 
 function g(param) {

--- a/jscomp/test/gpr_1268.js
+++ b/jscomp/test/gpr_1268.js
@@ -16,12 +16,10 @@ function f1(a, b, x, y) {
 
 function f2(x) {
   console.log(x);
-  
 }
 
 function f3(x) {
   console.log(x);
-  
 }
 
 function f4(x, y) {

--- a/jscomp/test/gpr_1409_test.js
+++ b/jscomp/test/gpr_1409_test.js
@@ -29,7 +29,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var a = {};

--- a/jscomp/test/gpr_1423_app_test.js
+++ b/jscomp/test/gpr_1423_app_test.js
@@ -27,12 +27,10 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function foo(f) {
   console.log(Curry._2(f, "a1", undefined));
-  
 }
 
 foo(function (param) {

--- a/jscomp/test/gpr_1484.js
+++ b/jscomp/test/gpr_1484.js
@@ -3,7 +3,6 @@
 
 function test(x) {
   x.nodeValue = null;
-  
 }
 
 exports.test = test;

--- a/jscomp/test/gpr_1501_test.js
+++ b/jscomp/test/gpr_1501_test.js
@@ -27,7 +27,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var A = /* @__PURE__ */Caml_exceptions.create("Gpr_1501_test.A");

--- a/jscomp/test/gpr_1503_test.js
+++ b/jscomp/test/gpr_1503_test.js
@@ -28,7 +28,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function id(x) {

--- a/jscomp/test/gpr_1600_test.js
+++ b/jscomp/test/gpr_1600_test.js
@@ -4,7 +4,6 @@
 var obj = {
   hi: (function (x) {
       console.log(x);
-      
     })
 };
 
@@ -16,7 +15,6 @@ var eventObj = {
   push: (function (a) {
       var self = this ;
       self.events[0] = a;
-      
     }),
   needRebuild: (function () {
       var self = this ;

--- a/jscomp/test/gpr_1658_test.js
+++ b/jscomp/test/gpr_1658_test.js
@@ -26,7 +26,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 eq("File \"gpr_1658_test.ml\", line 11, characters 7-14", null, null);

--- a/jscomp/test/gpr_1667_test.js
+++ b/jscomp/test/gpr_1667_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 eq("File \"gpr_1667_test.ml\", line 18, characters 7-14", 0, 0);

--- a/jscomp/test/gpr_1716_test.js
+++ b/jscomp/test/gpr_1716_test.js
@@ -26,7 +26,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var a = {};

--- a/jscomp/test/gpr_1728_test.js
+++ b/jscomp/test/gpr_1728_test.js
@@ -26,7 +26,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function foo(x) {
@@ -36,7 +35,6 @@ function foo(x) {
 function badInlining(obj) {
   var x = obj.field;
   Caml_format.int_of_string(x) !== 3;
-  
 }
 
 eq("File \"gpr_1728_test.ml\", line 17, characters 6-13", badInlining({

--- a/jscomp/test/gpr_1749_test.js
+++ b/jscomp/test/gpr_1749_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 eq("File \"gpr_1749_test.ml\", line 18, characters 6-13", 0, 0);

--- a/jscomp/test/gpr_1760_test.js
+++ b/jscomp/test/gpr_1760_test.js
@@ -27,7 +27,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var a0;

--- a/jscomp/test/gpr_1762_test.js
+++ b/jscomp/test/gpr_1762_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var v = {

--- a/jscomp/test/gpr_1817_test.js
+++ b/jscomp/test/gpr_1817_test.js
@@ -26,7 +26,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function f(param) {

--- a/jscomp/test/gpr_1822_test.js
+++ b/jscomp/test/gpr_1822_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var myShape = {

--- a/jscomp/test/gpr_1891_test.js
+++ b/jscomp/test/gpr_1891_test.js
@@ -8,7 +8,6 @@ function foo(x) {
   } else {
     console.log("2");
   }
-  
 }
 
 function foo2(x) {
@@ -40,7 +39,6 @@ function foo5(x) {
   } else {
     console.log("x");
   }
-  
 }
 
 exports.foo = foo;

--- a/jscomp/test/gpr_1943_test.js
+++ b/jscomp/test/gpr_1943_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function f(x) {

--- a/jscomp/test/gpr_2316_test.js
+++ b/jscomp/test/gpr_2316_test.js
@@ -26,7 +26,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var y;

--- a/jscomp/test/gpr_2352_test.js
+++ b/jscomp/test/gpr_2352_test.js
@@ -3,7 +3,6 @@
 
 function f(x) {
   x.hey = 22;
-  
 }
 
 exports.f = f;

--- a/jscomp/test/gpr_2503_test.js
+++ b/jscomp/test/gpr_2503_test.js
@@ -25,14 +25,12 @@ function makeWrapper(foo, param) {
     tmp.foo = Caml_option.valFromOption(foo);
   }
   console.log(tmp);
-  
 }
 
 function makeWrapper2(foo, param) {
   console.log({
         foo: foo
       });
-  
 }
 
 makeWrapper2("a", undefined);

--- a/jscomp/test/gpr_2614_test.js
+++ b/jscomp/test/gpr_2614_test.js
@@ -15,7 +15,6 @@ var c = v.open;
 function ff(param) {
   v["Content-Type"] = 3;
   v.l = 2;
-  
 }
 
 var partial_arg = "x";

--- a/jscomp/test/gpr_2633_test.js
+++ b/jscomp/test/gpr_2633_test.js
@@ -4,12 +4,10 @@ var Curry = require("../../lib/js/curry.js");
 
 function on1(foo, $$event) {
   foo.on($$event.NAME, $$event.VAL);
-  
 }
 
 function on2(foo, h, $$event) {
   foo.on(Curry._1(h, $$event).NAME, Curry._1(h, $$event).VAL);
-  
 }
 
 exports.on1 = on1;

--- a/jscomp/test/gpr_2682_test.js
+++ b/jscomp/test/gpr_2682_test.js
@@ -21,7 +21,6 @@ var forIn = ((o,foo)=> {
 
 function log(x) {
   console.log(x);
-  
 }
 
 var N = {
@@ -32,7 +31,6 @@ forIn({
       x: 3
     }, (function (x) {
         console.log(x);
-        
       }));
 
 forIn({
@@ -40,7 +38,6 @@ forIn({
       y: 3
     }, (function (x) {
         console.log(x);
-        
       }));
 
 var f3 = (()=>true);

--- a/jscomp/test/gpr_3697_test.js
+++ b/jscomp/test/gpr_3697_test.js
@@ -26,7 +26,6 @@ function unfix(p) {
     var match = p.contents;
     p.contents = CamlinternalLazy.force(match._0);
   };
-  
 }
 
 exports.fix = fix;

--- a/jscomp/test/gpr_3875_test.js
+++ b/jscomp/test/gpr_3875_test.js
@@ -9,7 +9,6 @@ var result = {
 
 function log(x) {
   result.contents = x;
-  
 }
 
 var Xx = {
@@ -45,7 +44,6 @@ function compilerBug(a, b, c, f) {
   } else {
     result.contents = "Some x, f returns false";
   }
-  
 }
 
 var suites = {

--- a/jscomp/test/gpr_3931_test.js
+++ b/jscomp/test/gpr_3931_test.js
@@ -44,7 +44,6 @@ Caml_module.update_mod({
 
 function print$1(i) {
   console.log(String(i));
-  
 }
 
 Caml_module.update_mod({

--- a/jscomp/test/gpr_4025_test.js
+++ b/jscomp/test/gpr_4025_test.js
@@ -9,7 +9,6 @@ function f(x) {
   ({
       x: (console.log("hi"), x)
     }).x = x + 1 | 0;
-  
 }
 
 exports.f = f;

--- a/jscomp/test/gpr_4274_test.js
+++ b/jscomp/test/gpr_4274_test.js
@@ -9,7 +9,6 @@ function f(X, xs) {
   return X.forEach(xs, {
               i: (function (x) {
                   console.log(x.x);
-                  
                 })
             });
 }
@@ -21,7 +20,6 @@ Belt_List.forEachU({
       tl: /* [] */0
     }, (function (x) {
         console.log(x.x);
-        
       }));
 
 var Foo = {};

--- a/jscomp/test/gpr_4280_test.js
+++ b/jscomp/test/gpr_4280_test.js
@@ -23,7 +23,6 @@ function div(children, param) {
     u.contents = 300;
     console.log("nonline");
   }
-  
 }
 
 function string(s) {
@@ -31,7 +30,6 @@ function string(s) {
     u.contents = 200;
     console.log("no");
   }
-  
 }
 
 function fn(authState, route) {

--- a/jscomp/test/gpr_4491_test.js
+++ b/jscomp/test/gpr_4491_test.js
@@ -9,7 +9,6 @@ function f(xs) {
     
   }
   console.log("nothing to see here", xs);
-  
 }
 
 exports.f = f;

--- a/jscomp/test/gpr_459_test.js
+++ b/jscomp/test/gpr_459_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var uu = {

--- a/jscomp/test/gpr_5071_test.js
+++ b/jscomp/test/gpr_5071_test.js
@@ -14,7 +14,6 @@ function f(s, y) {
   }
   console.log(tmp);
   console.log(y);
-  
 }
 
 function make(s) {

--- a/jscomp/test/gpr_627_test.js
+++ b/jscomp/test/gpr_627_test.js
@@ -27,7 +27,6 @@ function eq(loc, param) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var u = {

--- a/jscomp/test/gpr_904_test.js
+++ b/jscomp/test/gpr_904_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function check_healty(check) {

--- a/jscomp/test/gpr_977_test.js
+++ b/jscomp/test/gpr_977_test.js
@@ -26,7 +26,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function f(x) {

--- a/jscomp/test/hash_sugar_desugar.js
+++ b/jscomp/test/hash_sugar_desugar.js
@@ -21,12 +21,10 @@ function h4(u) {
 
 function g5(u) {
   u.hi = 3;
-  
 }
 
 function h5(u) {
   u.hi = 3;
-  
 }
 
 function h6(u) {

--- a/jscomp/test/ignore_test.js
+++ b/jscomp/test/ignore_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function f(x) {
@@ -34,7 +33,6 @@ function f(x) {
 
 function ff(x) {
   console.log(x);
-  
 }
 
 eq("File \"ignore_test.ml\", line 16, characters 5-12", undefined, undefined);

--- a/jscomp/test/imm_map_bench.js
+++ b/jscomp/test/imm_map_bench.js
@@ -34,7 +34,6 @@ function test(param) {
   for(var j = 0; j <= 1000000; ++j){
     should(v.has(j));
   }
-  
 }
 
 function test2(param) {
@@ -42,7 +41,6 @@ function test2(param) {
   for(var j = 0; j <= 1000000; ++j){
     should(Belt_MapInt.has(v, j));
   }
-  
 }
 
 console.time("imm_map_bench.ml 44");

--- a/jscomp/test/inline_record_test.js
+++ b/jscomp/test/inline_record_test.js
@@ -85,7 +85,6 @@ function ff(x) {
   } else {
     x.z = x.z + 2 | 0;
   }
-  
 }
 
 var v4 = {

--- a/jscomp/test/installation_test.js
+++ b/jscomp/test/installation_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 Mt.from_pair_suites("Installation_test", suites.contents);

--- a/jscomp/test/io_test.js
+++ b/jscomp/test/io_test.js
@@ -6,7 +6,6 @@ function f(param) {
   console.log(undefined);
   console.log("hi");
   console.log(undefined);
-  
 }
 
 exports.f = f;

--- a/jscomp/test/js_array_test.js
+++ b/jscomp/test/js_array_test.js
@@ -940,7 +940,6 @@ var suites_1 = {
                                                                                                               3
                                                                                                             ].forEach(function (n) {
                                                                                                                 sum.contents = sum.contents + n | 0;
-                                                                                                                
                                                                                                               });
                                                                                                           return {
                                                                                                                   TAG: /* Eq */0,
@@ -962,7 +961,6 @@ var suites_1 = {
                                                                                                                 3
                                                                                                               ].forEach(function (param, i) {
                                                                                                                   sum.contents = sum.contents + i | 0;
-                                                                                                                  
                                                                                                                 });
                                                                                                             return {
                                                                                                                     TAG: /* Eq */0,

--- a/jscomp/test/js_cast_test.js
+++ b/jscomp/test/js_cast_test.js
@@ -20,7 +20,6 @@ function add_test(loc, test) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function eq(loc, x, y) {

--- a/jscomp/test/js_exception_catch_test.js
+++ b/jscomp/test/js_exception_catch_test.js
@@ -24,7 +24,6 @@ function add_test(loc, test) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function eq(loc, x, y) {

--- a/jscomp/test/js_float_test.js
+++ b/jscomp/test/js_float_test.js
@@ -143,7 +143,6 @@ var suites_1 = {
                                       TAG: /* ThrowAny */7,
                                       _0: (function (param) {
                                           (0).toExponential(101);
-                                          
                                         })
                                     };
                             })
@@ -156,7 +155,6 @@ var suites_1 = {
                                         TAG: /* ThrowAny */7,
                                         _0: (function (param) {
                                             (0).toExponential(-1);
-                                            
                                           })
                                       };
                               })
@@ -224,7 +222,6 @@ var suites_1 = {
                                                     TAG: /* ThrowAny */7,
                                                     _0: (function (param) {
                                                         (0).toFixed(101);
-                                                        
                                                       })
                                                   };
                                           })
@@ -237,7 +234,6 @@ var suites_1 = {
                                                       TAG: /* ThrowAny */7,
                                                       _0: (function (param) {
                                                           (0).toFixed(-1);
-                                                          
                                                         })
                                                     };
                                             })
@@ -305,7 +301,6 @@ var suites_1 = {
                                                                   TAG: /* ThrowAny */7,
                                                                   _0: (function (param) {
                                                                       (0).toPrecision(101);
-                                                                      
                                                                     })
                                                                 };
                                                         })
@@ -318,7 +313,6 @@ var suites_1 = {
                                                                     TAG: /* ThrowAny */7,
                                                                     _0: (function (param) {
                                                                         (0).toPrecision(-1);
-                                                                        
                                                                       })
                                                                   };
                                                           })
@@ -386,7 +380,6 @@ var suites_1 = {
                                                                                 TAG: /* ThrowAny */7,
                                                                                 _0: (function (param) {
                                                                                     (0).toString(37);
-                                                                                    
                                                                                   })
                                                                               };
                                                                       })
@@ -399,7 +392,6 @@ var suites_1 = {
                                                                                   TAG: /* ThrowAny */7,
                                                                                   _0: (function (param) {
                                                                                       (0).toString(1);
-                                                                                      
                                                                                     })
                                                                                 };
                                                                         })
@@ -412,7 +404,6 @@ var suites_1 = {
                                                                                     TAG: /* ThrowAny */7,
                                                                                     _0: (function (param) {
                                                                                         (0).toString(-1);
-                                                                                        
                                                                                       })
                                                                                   };
                                                                           })

--- a/jscomp/test/js_int_test.js
+++ b/jscomp/test/js_int_test.js
@@ -54,7 +54,6 @@ var suites_1 = {
                       TAG: /* ThrowAny */7,
                       _0: (function (param) {
                           (0).toExponential(101);
-                          
                         })
                     };
             })
@@ -67,7 +66,6 @@ var suites_1 = {
                         TAG: /* ThrowAny */7,
                         _0: (function (param) {
                             (0).toExponential(-1);
-                            
                           })
                       };
               })
@@ -124,7 +122,6 @@ var suites_1 = {
                                   TAG: /* ThrowAny */7,
                                   _0: (function (param) {
                                       (0).toPrecision(101);
-                                      
                                     })
                                 };
                         })
@@ -137,7 +134,6 @@ var suites_1 = {
                                     TAG: /* ThrowAny */7,
                                     _0: (function (param) {
                                         (0).toPrecision(-1);
-                                        
                                       })
                                   };
                           })
@@ -194,7 +190,6 @@ var suites_1 = {
                                               TAG: /* ThrowAny */7,
                                               _0: (function (param) {
                                                   (0).toString(37);
-                                                  
                                                 })
                                             };
                                     })
@@ -207,7 +202,6 @@ var suites_1 = {
                                                 TAG: /* ThrowAny */7,
                                                 _0: (function (param) {
                                                     (0).toString(1);
-                                                    
                                                   })
                                               };
                                       })
@@ -220,7 +214,6 @@ var suites_1 = {
                                                   TAG: /* ThrowAny */7,
                                                   _0: (function (param) {
                                                       (0).toString(-1);
-                                                      
                                                     })
                                                 };
                                         })

--- a/jscomp/test/js_json_test.js
+++ b/jscomp/test/js_json_test.js
@@ -27,7 +27,6 @@ function add_test(loc, test) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function eq(loc, x, y) {

--- a/jscomp/test/js_list_test.js
+++ b/jscomp/test/js_list_test.js
@@ -27,7 +27,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 eq("File \"js_list_test.ml\", line 11, characters 7-14", Js_list.flatten({

--- a/jscomp/test/js_null_test.js
+++ b/jscomp/test/js_null_test.js
@@ -94,7 +94,6 @@ var suites_1 = {
                     };
                     Js_null.iter(null, (function (param) {
                             hit.contents = true;
-                            
                           }));
                     return {
                             TAG: /* Eq */0,
@@ -112,7 +111,6 @@ var suites_1 = {
                       };
                       Js_null.iter(2, (function (v) {
                               hit.contents = v;
-                              
                             }));
                       return {
                               TAG: /* Eq */0,

--- a/jscomp/test/js_null_undefined_test.js
+++ b/jscomp/test/js_null_undefined_test.js
@@ -164,7 +164,6 @@ var suites_1 = {
                                 };
                                 Js_null_undefined.iter(null, (function (param) {
                                         hit.contents = true;
-                                        
                                       }));
                                 return {
                                         TAG: /* Eq */0,
@@ -182,7 +181,6 @@ var suites_1 = {
                                   };
                                   Js_null_undefined.iter(undefined, (function (param) {
                                           hit.contents = true;
-                                          
                                         }));
                                   return {
                                           TAG: /* Eq */0,
@@ -200,7 +198,6 @@ var suites_1 = {
                                     };
                                     Js_null_undefined.iter(undefined, (function (param) {
                                             hit.contents = true;
-                                            
                                           }));
                                     return {
                                             TAG: /* Eq */0,
@@ -218,7 +215,6 @@ var suites_1 = {
                                       };
                                       Js_null_undefined.iter(2, (function (v) {
                                               hit.contents = v;
-                                              
                                             }));
                                       return {
                                               TAG: /* Eq */0,

--- a/jscomp/test/js_nullable_test.js
+++ b/jscomp/test/js_nullable_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function test(dom) {

--- a/jscomp/test/js_promise_basic_test.js
+++ b/jscomp/test/js_promise_basic_test.js
@@ -29,7 +29,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function assert_bool(b) {

--- a/jscomp/test/js_typed_array_test.js
+++ b/jscomp/test/js_typed_array_test.js
@@ -823,7 +823,6 @@ var suites_1 = {
                                                                                             };
                                                                                             Js_typed_array.$$Int8Array.forEach((function (n) {
                                                                                                     sum.contents = sum.contents + n | 0;
-                                                                                                    
                                                                                                   }), new Int8Array([
                                                                                                       1,
                                                                                                       2,
@@ -845,7 +844,6 @@ var suites_1 = {
                                                                                               };
                                                                                               Js_typed_array.$$Int8Array.forEachi((function (param, i) {
                                                                                                       sum.contents = sum.contents + i | 0;
-                                                                                                      
                                                                                                     }), new Int8Array([
                                                                                                         1,
                                                                                                         2,

--- a/jscomp/test/js_undefined_test.js
+++ b/jscomp/test/js_undefined_test.js
@@ -94,7 +94,6 @@ var suites_1 = {
                     };
                     Js_undefined.iter(undefined, (function (param) {
                             hit.contents = true;
-                            
                           }));
                     return {
                             TAG: /* Eq */0,
@@ -112,7 +111,6 @@ var suites_1 = {
                       };
                       Js_undefined.iter(2, (function (v) {
                               hit.contents = v;
-                              
                             }));
                       return {
                               TAG: /* Eq */0,

--- a/jscomp/test/jsoo_400_test.js
+++ b/jscomp/test/jsoo_400_test.js
@@ -22,7 +22,6 @@ Mt.from_pair_suites("Jsoo_400_test", {
                     TAG: /* ThrowAny */7,
                     _0: (function (param) {
                         u(undefined);
-                        
                       })
                   };
           })

--- a/jscomp/test/jsoo_485_test.js
+++ b/jscomp/test/jsoo_485_test.js
@@ -3,7 +3,6 @@
 
 function f(param) {
   3;
-  
 }
 
 exports.f = f;

--- a/jscomp/test/key_word_property_plus_test.js
+++ b/jscomp/test/key_word_property_plus_test.js
@@ -26,7 +26,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 eq("File \"key_word_property_plus_test.ml\", line 10, characters 5-12", [

--- a/jscomp/test/label_uncurry.js
+++ b/jscomp/test/label_uncurry.js
@@ -13,7 +13,6 @@ function u(x, y) {
 function u1(f) {
   console.log(f(2, "x"));
   console.log(f(2, "x"));
-  
 }
 
 function h(unit) {

--- a/jscomp/test/lazy_test.js
+++ b/jscomp/test/lazy_test.js
@@ -13,7 +13,6 @@ var v = {
   LAZY_DONE: false,
   VAL: (function () {
       u.contents = 32;
-      
     })
 };
 
@@ -57,7 +56,6 @@ var set_true = {
   LAZY_DONE: false,
   VAL: (function () {
       s.contents = 1;
-      
     })
 };
 
@@ -65,7 +63,6 @@ var set_false = {
   LAZY_DONE: false,
   VAL: (function () {
       s.contents = undefined;
-      
     })
 };
 
@@ -95,7 +92,6 @@ var u$1 = {
   LAZY_DONE: false,
   VAL: (function () {
       u_v.contents = 2;
-      
     })
 };
 

--- a/jscomp/test/lexer_test.js
+++ b/jscomp/test/lexer_test.js
@@ -117,7 +117,6 @@ var lexer_suites_1 = {
               hd: t,
               tl: v.contents
             };
-            
           };
           Number_lexer.token(add, Lexing.from_string("32 + 32 ( ) * / "));
           return {

--- a/jscomp/test/libarg_test.js
+++ b/jscomp/test/libarg_test.js
@@ -18,7 +18,6 @@ function record(fmt) {
     hd: fmt,
     tl: accum.contents
   };
-  
 }
 
 function f_unit(param) {
@@ -299,7 +298,6 @@ var args2 = [
 
 function error(s) {
   console.log("error (%s)");
-  
 }
 
 function check(r, v, msg) {
@@ -369,7 +367,6 @@ function test(argv) {
   if (Caml_obj.notequal(result, reference)) {
     var f = function (x, y) {
       console.log(x, y);
-      
     };
     List.iter2(f, result, reference);
   }

--- a/jscomp/test/libqueue_test.js
+++ b/jscomp/test/libqueue_test.js
@@ -830,7 +830,6 @@ Queue.iter((function (j) {
               };
         }
         i$7.contents = i$7.contents + 1 | 0;
-        
       }), q$5);
 
 var q1$1 = {

--- a/jscomp/test/limits_test.js
+++ b/jscomp/test/limits_test.js
@@ -27,7 +27,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 eq("File \"limits_test.ml\", line 10, characters 5-12", Pervasives.max_int, 2147483647);

--- a/jscomp/test/local_class_type.js
+++ b/jscomp/test/local_class_type.js
@@ -3,7 +3,6 @@
 
 function f(x) {
   x.height = 3;
-  
 }
 
 function h(x) {

--- a/jscomp/test/mario_game.js
+++ b/jscomp/test/mario_game.js
@@ -663,7 +663,6 @@ function transform_enemy(enemy_typ, spr, dir) {
   img.src = params.img_src;
   spr.params = params;
   spr.img = img;
-  
 }
 
 function update_animation(spr) {
@@ -767,7 +766,6 @@ function make_score(score, pos, ctx) {
 function update_vel(part) {
   part.vel.x = part.vel.x + part.acc.x;
   part.vel.y = part.vel.y + part.acc.y;
-  
 }
 
 function $$process(part) {
@@ -778,7 +776,6 @@ function $$process(part) {
   update_vel(part);
   part.pos.x = part.vel.x + part.pos.x;
   part.pos.y = part.vel.y + part.pos.y;
-  
 }
 
 var Particle = {
@@ -808,7 +805,6 @@ function set_vel_to_speed(obj) {
   } else {
     obj.vel.x = -speed;
   }
-  
 }
 
 function make_type$2(t) {
@@ -948,7 +944,6 @@ function normalize_pos(pos, p1, p2) {
   var match$3 = p2.bbox_size;
   pos.x = pos.x - (match$3[0] + match$1[0]) + (match$2[0] + match[0]);
   pos.y = pos.y - (match$3[1] + match$1[1]) + (match$2[1] + match[1]);
-  
 }
 
 function update_player(player, keys, context) {
@@ -1088,7 +1083,6 @@ function normalize_origin(pos, spr) {
   var match$1 = p.bbox_size;
   pos.x = pos.x - match[0];
   pos.y = pos.y - (match[1] + match$1[1]);
-  
 }
 
 function collide_block(check_xOpt, dir, obj) {
@@ -1116,7 +1110,6 @@ function collide_block(check_xOpt, dir, obj) {
 function reverse_left_right(obj) {
   obj.vel.x = -obj.vel.x;
   obj.dir = obj.dir ? /* Left */0 : /* Right */1;
-  
 }
 
 function evolve_enemy(player_dir, typ, spr, obj, context) {
@@ -1169,7 +1162,6 @@ function evolve_enemy(player_dir, typ, spr, obj, context) {
   } else {
     set_vel_to_speed(obj);
   }
-  
 }
 
 function rev_dir(o, t, s) {
@@ -1462,7 +1454,6 @@ function clear_canvas(canvas) {
   var cwidth = canvas.width;
   var cheight = canvas.height;
   context.clearRect(0, 0, cwidth, cheight);
-  
 }
 
 function hud(canvas, score, coins) {
@@ -1472,14 +1463,12 @@ function hud(canvas, score, coins) {
   context.font = "10px 'Press Start 2P'";
   context.fillText("Score: " + score_string, canvas.width - 140, 18);
   context.fillText("Coins: " + coin_string, 120, 18);
-  
 }
 
 function fps(canvas, fps_val) {
   var fps_str = String(fps_val | 0);
   var context = canvas.getContext("2d");
   context.fillText(fps_str, 10, 18);
-  
 }
 
 function game_win(ctx) {
@@ -1619,7 +1608,6 @@ function calc_fps(t0, t1) {
 
 function update_score(state, i) {
   state.score = state.score + i | 0;
-  
 }
 
 function process_collision(dir, c1, c2, state) {
@@ -2216,7 +2204,6 @@ function update_loop(canvas, param, map_dim) {
     };
     List.iter((function (obj) {
             run_update_collid(state$1, obj, objs);
-            
           }), objs);
     List.iter((function (part) {
             $$process(part);
@@ -2240,7 +2227,6 @@ function update_loop(canvas, param, map_dim) {
     requestAnimationFrame(function (t) {
           return update_helper(t, state$1, player$1, collid_objs.contents, particles.contents);
         });
-    
   };
   return update_helper(0, state, player, param[1], /* [] */0);
 }
@@ -3232,7 +3218,6 @@ function load(param) {
         256
       ]);
   console.log("asd");
-  
 }
 
 function inc_counter(param) {
@@ -3252,7 +3237,6 @@ function preload(param) {
                         inc_counter(undefined);
                         return true;
                       }), true);
-                
               }), {
               hd: "blocks.png",
               tl: {

--- a/jscomp/test/method_name_test.js
+++ b/jscomp/test/method_name_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function f(x, i, file, v) {

--- a/jscomp/test/method_string_name.js
+++ b/jscomp/test/method_string_name.js
@@ -12,7 +12,6 @@ function ff(x) {
   console.log(({
           "Content-Type": "hello"
         })["Content-Type"]);
-  
 }
 
 exports.f = f;

--- a/jscomp/test/module_alias_test.js
+++ b/jscomp/test/module_alias_test.js
@@ -27,7 +27,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function f(x) {

--- a/jscomp/test/module_splice_test.js
+++ b/jscomp/test/module_splice_test.js
@@ -29,7 +29,6 @@ function eq(loc, param) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function joinClasses(prim) {

--- a/jscomp/test/mpr_6033_test.js
+++ b/jscomp/test/mpr_6033_test.js
@@ -26,7 +26,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function f(x) {

--- a/jscomp/test/mt.js
+++ b/jscomp/test/mt.js
@@ -9,7 +9,6 @@ var Process = require("process");
 
 function assert_fail(msg) {
   Assert.fail(undefined, undefined, msg, "");
-  
 }
 
 function is_mocha(param) {
@@ -38,7 +37,6 @@ function from_suites(name, suite) {
                           it(param[0], (function () {
                                   return Curry._1(partial_arg, undefined);
                                 }));
-                          
                         }), suite);
           }));
     return ;
@@ -107,7 +105,6 @@ function from_pair_suites(name, suites) {
                             it(param[0], (function () {
                                     return handleCode(Curry._1(code, undefined));
                                   }));
-                            
                           }), suites);
             }));
       return ;
@@ -210,7 +207,6 @@ function from_promise_suites(name, suites) {
                                     };
                                     return code.then(arg1);
                                   }));
-                            
                           }), suites);
             }));
     } else {
@@ -236,7 +232,6 @@ function eq_suites(test_id, suites, loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function bool_suites(test_id, suites, loc, x) {
@@ -253,7 +248,6 @@ function bool_suites(test_id, suites, loc, x) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function throw_suites(test_id, suites, loc, x) {
@@ -270,7 +264,6 @@ function throw_suites(test_id, suites, loc, x) {
     ],
     tl: suites.contents
   };
-  
 }
 
 exports.from_suites = from_suites;

--- a/jscomp/test/mt_global.js
+++ b/jscomp/test/mt_global.js
@@ -16,7 +16,6 @@ function collect_eq(test_id, suites, loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function collect_neq(test_id, suites, loc, x, y) {
@@ -34,7 +33,6 @@ function collect_neq(test_id, suites, loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function collect_approx(test_id, suites, loc, x, y) {
@@ -52,7 +50,6 @@ function collect_approx(test_id, suites, loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 exports.collect_eq = collect_eq;

--- a/jscomp/test/mutable_obj_test.js
+++ b/jscomp/test/mutable_obj_test.js
@@ -8,7 +8,6 @@ function f(x) {
               y: x
             };
     });
-  
 }
 
 exports.f = f;

--- a/jscomp/test/name_mangle_test.js
+++ b/jscomp/test/name_mangle_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function f0(x) {

--- a/jscomp/test/number_lexer.js
+++ b/jscomp/test/number_lexer.js
@@ -5,7 +5,6 @@ var Lexing = require("../../lib/js/lexing.js");
 
 function l(prim) {
   console.log(prim);
-  
 }
 
 var __ocaml_lex_tables = {

--- a/jscomp/test/ocaml_re_test.js
+++ b/jscomp/test/ocaml_re_test.js
@@ -41,7 +41,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function union(_l, _l$p) {

--- a/jscomp/test/optional_ffi_test.js
+++ b/jscomp/test/optional_ffi_test.js
@@ -28,7 +28,6 @@ function eq(loc, param) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function hey(x, y) {

--- a/jscomp/test/pipe_send_readline.js
+++ b/jscomp/test/pipe_send_readline.js
@@ -4,10 +4,8 @@
 function u(rl) {
   return rl.on("line", (function (x) {
                   console.log(x);
-                  
                 })).on("close", (function () {
                 console.log("finished");
-                
               }));
 }
 

--- a/jscomp/test/poly_variant_test.js
+++ b/jscomp/test/poly_variant_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function hey_string (option){

--- a/jscomp/test/polymorphic_raw_test.js
+++ b/jscomp/test/polymorphic_raw_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var f = ((a) => typeof a);

--- a/jscomp/test/ppx_apply_test.js
+++ b/jscomp/test/ppx_apply_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var u = 3;

--- a/jscomp/test/ppx_this_obj_field.js
+++ b/jscomp/test/ppx_this_obj_field.js
@@ -27,7 +27,6 @@ function eq(loc, param) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var v5 = {
@@ -51,7 +50,6 @@ var v5 = {
     }),
   bark: (function () {
       console.log("bark");
-      
     }),
   xz: (function () {
       return 3;
@@ -64,12 +62,10 @@ var v = {
   reset: (function () {
       var self = this ;
       self.y = 0;
-      
     }),
   incr: (function () {
       var self = this ;
       self.y = self.y + 1 | 0;
-      
     }),
   getY: (function () {
       var self = this ;
@@ -84,7 +80,6 @@ var v = {
 var u = {
   incr: (function () {
       console.log("hey");
-      
     }),
   getY: (function () {
       return 3;
@@ -111,7 +106,6 @@ var z = {
   setX: (function (x) {
       var self = this ;
       self.x.contents = x;
-      
     }),
   getX: (function () {
       var self = this ;
@@ -125,13 +119,11 @@ var eventObj = {
       var self = this ;
       var a = self.events;
       a.splice(0);
-      
     }),
   push: (function (a) {
       var self = this ;
       var xs = self.events;
       xs.push(a);
-      
     }),
   needRebuild: (function () {
       var self = this ;
@@ -148,7 +140,6 @@ var zz = {
   setX: (function (x) {
       var self = this ;
       self.x = x;
-      
     }),
   getX: (function () {
       var self = this ;
@@ -218,7 +209,6 @@ var f = {
   hei: (function () {
       var y = this ;
       y.x = y.x + 3 | 0;
-      
     })
 };
 

--- a/jscomp/test/ppx_this_obj_test.js
+++ b/jscomp/test/ppx_this_obj_test.js
@@ -27,7 +27,6 @@ function eq(loc, param) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var v = {

--- a/jscomp/test/prepend_data_ffi.js
+++ b/jscomp/test/prepend_data_ffi.js
@@ -43,20 +43,16 @@ function f(x) {
   x.xx(116, 3, "xxx", 1, 2, 3);
   x.xx(117, 3, "xxx", 0, "b", 1, 2, 3, 4, 5);
   x.xx(118, 3, true, false, "你好", ["你好",1,2,3], [{ "arr" : ["你好",1,2,3], "encoding" : "utf8"}], [{ "arr" : ["你好",1,2,3], "encoding" : "utf8"}], "xxx", 0, "yyy", "b", 1, 2, 3, 4, 5);
-  
 }
 
 process.on("exit", (function (exit_code) {
         console.log("error code: " + String(exit_code));
-        
       }));
 
 function register(p) {
   p.on("exit", (function (i) {
           console.log(i);
-          
         }));
-  
 }
 
 var config = {

--- a/jscomp/test/promise_catch_test.js
+++ b/jscomp/test/promise_catch_test.js
@@ -29,7 +29,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function handler(e) {

--- a/jscomp/test/queue_402.js
+++ b/jscomp/test/queue_402.js
@@ -16,7 +16,6 @@ function create(param) {
 function clear(q) {
   q.length = 0;
   q.tail = undefined;
-  
 }
 
 function add(x, q) {
@@ -37,7 +36,6 @@ function add(x, q) {
   q.length = q.length + 1 | 0;
   tail.next = cell$1;
   q.tail = cell$1;
-  
 }
 
 function peek(q) {
@@ -166,7 +164,6 @@ function transfer(q1, q2) {
   }
   q2.length = q2.length + length1 | 0;
   q2.tail = tail1;
-  
 }
 
 var push = add;

--- a/jscomp/test/raw_hash_tbl_bench.js
+++ b/jscomp/test/raw_hash_tbl_bench.js
@@ -24,7 +24,6 @@ function bench(param) {
   for(var i$2 = 0; i$2 <= 1000000; ++i$2){
     Hashtbl.remove(table, i$2);
   }
-  
 }
 
 bench(undefined);

--- a/jscomp/test/reactDOMRe.js
+++ b/jscomp/test/reactDOMRe.js
@@ -10,7 +10,6 @@ function renderToElementWithClassName(reactElement, className) {
   } else {
     console.error("ReactDOMRe.renderToElementWithClassName: no element of class " + (className + " found in the HTML."));
   }
-  
 }
 
 function renderToElementWithId(reactElement, id) {
@@ -20,7 +19,6 @@ function renderToElementWithId(reactElement, id) {
   } else {
     ReactDom.render(reactElement, element);
   }
-  
 }
 
 function createRootWithClassName(className) {
@@ -65,7 +63,6 @@ function hydrateToElementWithClassName(reactElement, className) {
   } else {
     console.error("ReactDOMRe.hydrateToElementWithClassName: no element of class " + (className + " found in the HTML."));
   }
-  
 }
 
 function hydrateToElementWithId(reactElement, id) {
@@ -78,7 +75,6 @@ function hydrateToElementWithId(reactElement, id) {
         };
   }
   ReactDom.hydrate(reactElement, element);
-  
 }
 
 var Ref = {};

--- a/jscomp/test/reactTestUtils.js
+++ b/jscomp/test/reactTestUtils.js
@@ -9,10 +9,8 @@ var TestUtils = require("react-dom/test-utils");
 function act(func) {
   var reactFunc = function () {
     Curry._1(func, undefined);
-    
   };
   TestUtils.act(reactFunc);
-  
 }
 
 function actAsync(func) {
@@ -28,7 +26,6 @@ function changeWithValue(element, value) {
     }
   };
   TestUtils.Simulate.change(element, $$event);
-  
 }
 
 function changeWithChecked(element, value) {
@@ -38,7 +35,6 @@ function changeWithChecked(element, value) {
     }
   };
   TestUtils.Simulate.change(element, $$event);
-  
 }
 
 var Simulate = {
@@ -79,16 +75,13 @@ function prepareContainer(container, param) {
           return body.appendChild(containerElement);
         }));
   container.contents = Caml_option.some(containerElement);
-  
 }
 
 function cleanupContainer(container, param) {
   Belt_Option.map(container.contents, (function (prim) {
           prim.remove();
-          
         }));
   container.contents = undefined;
-  
 }
 
 function getContainer(container) {

--- a/jscomp/test/reasonReact.js
+++ b/jscomp/test/reasonReact.js
@@ -228,7 +228,6 @@ function createClass(debugName) {
                   } else {
                     $$this.subscriptions = [subscription];
                   }
-                  
                 }),
               handleMethod: (function (callback) {
                   var $$this = this ;

--- a/jscomp/test/rec_fun_test.js
+++ b/jscomp/test/rec_fun_test.js
@@ -27,7 +27,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var called = {
@@ -47,7 +46,6 @@ function g(param) {
         contents: next
       });
   console.log(String(next(0, true)));
-  
 }
 
 g(undefined);

--- a/jscomp/test/rec_value_test.js
+++ b/jscomp/test/rec_value_test.js
@@ -167,7 +167,6 @@ var lazy_v = {
   LAZY_DONE: true,
   VAL: (function (param) {
       CamlinternalLazy.force(lazy_v);
-      
     })
 };
 

--- a/jscomp/test/recursive_module_test.js
+++ b/jscomp/test/recursive_module_test.js
@@ -27,7 +27,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function add(suite) {
@@ -35,7 +34,6 @@ function add(suite) {
     hd: suite,
     tl: suites.contents
   };
-  
 }
 
 var Int3 = Caml_module.init_mod([
@@ -86,7 +84,6 @@ add([
                   TAG: /* ThrowAny */7,
                   _0: (function (param) {
                       Curry._1(Int3.u, 3);
-                      
                     })
                 };
         })

--- a/jscomp/test/return_check.js
+++ b/jscomp/test/return_check.js
@@ -51,7 +51,6 @@ function f_escaped_1(xs, i) {
 
 function f_escaped_2(xs, i) {
   console.log(Caml_option.undefined_to_opt(xs[i]));
-  
 }
 
 function f_null(xs, i) {

--- a/jscomp/test/set_gen.js
+++ b/jscomp/test/set_gen.js
@@ -222,7 +222,6 @@ function check_height_and_diff(param) {
 
 function check(tree) {
   check_height_and_diff(tree);
-  
 }
 
 function create(l, v, r) {

--- a/jscomp/test/sexpm_test.js
+++ b/jscomp/test/sexpm_test.js
@@ -28,7 +28,6 @@ function eq(loc, param) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function print_or_error(x) {

--- a/jscomp/test/stack_comp_test.js
+++ b/jscomp/test/stack_comp_test.js
@@ -36,7 +36,6 @@ function to_list(s) {
             hd: x,
             tl: l.contents
           };
-          
         }), s.c);
   return l.contents;
 }
@@ -361,7 +360,6 @@ var i$7 = {
 List.iter((function (j) {
         assert_("File \"stack_comp_test.ml\", line 112, characters 27-34", i$7.contents === j);
         i$7.contents = i$7.contents + 1 | 0;
-        
       }), s$5.c);
 
 var s1$1 = {

--- a/jscomp/test/stream_parser_test.js
+++ b/jscomp/test/stream_parser_test.js
@@ -280,7 +280,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var match = parse(token(Stream.of_string("1 + 2 + (3  - 2) * 3 * 3  - 2 a")));

--- a/jscomp/test/string_interp_test.js
+++ b/jscomp/test/string_interp_test.js
@@ -32,7 +32,6 @@ function ffff(a_1, a_2) {
 function f(x, y) {
   var sum = x + y | 0;
   console.log(" " + x + " + " + y + " = " + sum + " ");
-  
 }
 
 var world = "世界";

--- a/jscomp/test/string_set_test.js
+++ b/jscomp/test/string_set_test.js
@@ -26,7 +26,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var s = String_set.empty;

--- a/jscomp/test/string_unicode_test.js
+++ b/jscomp/test/string_unicode_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 console.log("\xe4\xbd\xa0\xe5\xa5\xbd");

--- a/jscomp/test/switch_case_test.js
+++ b/jscomp/test/switch_case_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function f(x) {

--- a/jscomp/test/test_bs_this.js
+++ b/jscomp/test/test_bs_this.js
@@ -37,12 +37,10 @@ function f(x) {
   x.onload = (function () {
       var o = this ;
       console.log(o);
-      
     });
   return x.addEventListener("onload", (function () {
                 var o = this ;
                 console.log(o.response);
-                
               }));
 }
 

--- a/jscomp/test/test_case_set.js
+++ b/jscomp/test/test_case_set.js
@@ -3,7 +3,6 @@
 
 function f(x) {
   x.case = 3;
-  
 }
 
 function g(x) {

--- a/jscomp/test/test_closure.js
+++ b/jscomp/test/test_closure.js
@@ -16,7 +16,6 @@ function f(param) {
     Caml_array.set(arr, i, (function(i){
         return function (param) {
           v.contents = v.contents + i | 0;
-          
         }
         }(i)));
   }

--- a/jscomp/test/test_for_loop.js
+++ b/jscomp/test/test_for_loop.js
@@ -8,14 +8,12 @@ function for_(x) {
   for(var i = 0 ,i_finish = (console.log("hi"), x.length); i <= i_finish; ++i){
     console.log(Caml_array.get(x, i));
   }
-  
 }
 
 function for_2(x) {
   for(var i = 0 ,i_finish = x.length; i <= i_finish; ++i){
     console.log(Caml_array.get(x, i));
   }
-  
 }
 
 function for_3(x) {
@@ -30,7 +28,6 @@ function for_3(x) {
     Caml_array.set(arr, i, (function(j){
         return function (param) {
           v.contents = v.contents + j | 0;
-          
         }
         }(j)));
   }
@@ -53,7 +50,6 @@ function for_4(x) {
     Caml_array.set(arr, i, (function(k){
         return function (param) {
           v.contents = v.contents + k | 0;
-          
         }
         }(k)));
   }
@@ -75,7 +71,6 @@ function for_5(x, u) {
     Caml_array.set(arr, i, (function(k){
         return function (param) {
           v.contents = v.contents + k | 0;
-          
         }
         }(k)));
   }
@@ -112,7 +107,6 @@ function for_6(x, u) {
       Caml_array.set(arr, i, (function(k,h){
           return function (param) {
             v.contents = (((((v.contents + k | 0) + v2.contents | 0) + u | 0) + v4.contents | 0) + v5.contents | 0) + h | 0;
-            
           }
           }(k,h)));
     }

--- a/jscomp/test/test_for_map.js
+++ b/jscomp/test/test_for_map.js
@@ -980,7 +980,6 @@ function assertion_test(param) {
   for(var i$1 = 0; i$1 <= 1000000; ++i$1){
     find(i$1, m);
   }
-  
 }
 
 exports.IntMap = IntMap;

--- a/jscomp/test/test_http_server.js
+++ b/jscomp/test/test_http_server.js
@@ -12,7 +12,6 @@ function create_server(http) {
       });
   return server.listen(3000, hostname, (function () {
                 console.log("Server running at http://" + (hostname + (":" + (String(3000) + "/"))));
-                
               }));
 }
 

--- a/jscomp/test/test_js_ffi.js
+++ b/jscomp/test/test_js_ffi.js
@@ -6,7 +6,6 @@ function v(u) {
   t({
         compare: $$String.compare
       });
-  
 }
 
 function u(v) {

--- a/jscomp/test/test_nullary.js
+++ b/jscomp/test/test_nullary.js
@@ -3,7 +3,6 @@
 
 function f(param) {
   console.log("hey");
-  
 }
 
 exports.f = f;

--- a/jscomp/test/test_per.js
+++ b/jscomp/test/test_per.js
@@ -435,7 +435,6 @@ function at_exit(f) {
       Curry._1(f, undefined);
       return Curry._1(g, undefined);
     });
-  
 }
 
 function do_at_exit(param) {

--- a/jscomp/test/test_primitive.js
+++ b/jscomp/test/test_primitive.js
@@ -65,7 +65,6 @@ var unboxed_x = {
 
 function gg(x) {
   x.u = 0;
-  
 }
 
 function f(x) {

--- a/jscomp/test/test_react.js
+++ b/jscomp/test/test_react.js
@@ -31,7 +31,6 @@ function f(param) {
   C$1.y();
   C.x();
   C.y();
-  
 }
 
 var v;

--- a/jscomp/test/test_runtime_encoding.js
+++ b/jscomp/test/test_runtime_encoding.js
@@ -43,7 +43,6 @@ function f(x) {
   for(var i = 0; i <= 10; ++i){
     Caml_array.set(x, i, i);
   }
-  
 }
 
 exports.g = g;

--- a/jscomp/test/test_static_catch_ident.js
+++ b/jscomp/test/test_static_catch_ident.js
@@ -15,7 +15,6 @@ function scanf_bad_input(ib, x) {
     console.log(s);
     console.log("don't inlinie");
   }
-  
 }
 
 exports.Scan_failure = Scan_failure;

--- a/jscomp/test/test_string_map.js
+++ b/jscomp/test/test_string_map.js
@@ -149,7 +149,6 @@ function timing(label, f) {
   console.time(label);
   Curry._1(f, undefined);
   console.timeEnd(label);
-  
 }
 
 function assertion_test(param) {
@@ -160,13 +159,11 @@ function assertion_test(param) {
           for(var i = 0; i <= 1000000; ++i){
             m.contents = add(String(i), String(i), m.contents);
           }
-          
         }));
   return timing("querying", (function (param) {
                 for(var i = 0; i <= 1000000; ++i){
                   find(String(i), m.contents);
                 }
-                
               }));
 }
 

--- a/jscomp/test/test_type_based_arity.js
+++ b/jscomp/test/test_type_based_arity.js
@@ -18,7 +18,6 @@ function f2(g, x) {
 
 function f3(g, x) {
   Curry._1(g, x);
-  
 }
 
 function f4(g, x) {

--- a/jscomp/test/test_unsafe_obj_ffi.js
+++ b/jscomp/test/test_unsafe_obj_ffi.js
@@ -13,7 +13,6 @@ function g(x) {
 function h(x) {
   x.height = 3;
   x.width = 3;
-  
 }
 
 exports.f = f;

--- a/jscomp/test/test_unsafe_obj_ffi_ppx.js
+++ b/jscomp/test/test_unsafe_obj_ffi_ppx.js
@@ -8,7 +8,6 @@ function f(x) {
 function h(x) {
   x.height = 3;
   x.width = 3;
-  
 }
 
 function chain(x) {

--- a/jscomp/test/test_while_closure.js
+++ b/jscomp/test/test_while_closure.js
@@ -19,12 +19,10 @@ function f(param) {
     Caml_array.set(arr, j, (function(j){
         return function (param) {
           v.contents = v.contents + j | 0;
-          
         }
         }(j)));
     n = n + 1 | 0;
   };
-  
 }
 
 f(undefined);

--- a/jscomp/test/test_zero_nullable.js
+++ b/jscomp/test/test_zero_nullable.js
@@ -27,7 +27,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function f1(x) {

--- a/jscomp/test/topsort_test.js
+++ b/jscomp/test/topsort_test.js
@@ -413,7 +413,6 @@ function unsafe_topsort(graph) {
       hd: node,
       tl: visited.contents
     };
-    
   };
   List.iter((function (param) {
           return sort_node(param[0]);

--- a/jscomp/test/tuple_alloc.js
+++ b/jscomp/test/tuple_alloc.js
@@ -8,12 +8,10 @@ var v = {
 
 function reset(param) {
   v.contents = 0;
-  
 }
 
 function incr(param) {
   v.contents = v.contents + 1 | 0;
-  
 }
 
 var vv = {
@@ -22,12 +20,10 @@ var vv = {
 
 function reset2(param) {
   vv.contents = 0;
-  
 }
 
 function incr2(param) {
   v.contents = v.contents + 1 | 0;
-  
 }
 
 function f(a, b, d, e) {

--- a/jscomp/test/uncurry_external_test.js
+++ b/jscomp/test/uncurry_external_test.js
@@ -25,7 +25,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function sum(a,b){

--- a/jscomp/test/uncurry_method.js
+++ b/jscomp/test/uncurry_method.js
@@ -32,7 +32,6 @@ function f1(u) {
 var obj3 = {
   hi: (function (name, age) {
       console.log(name);
-      
     }),
   hh: (function () {
       var self = this ;

--- a/jscomp/test/undef_regression2_test.js
+++ b/jscomp/test/undef_regression2_test.js
@@ -26,7 +26,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function ok(loc, x) {
@@ -43,7 +42,6 @@ function ok(loc, x) {
     ],
     tl: suites.contents
   };
-  
 }
 
 var match = typeof ___undefined_value === "undefined" ? undefined : ___undefined_value;
@@ -57,7 +55,6 @@ function test(param) {
   } else {
     console.log("producton mode");
   }
-  
 }
 
 function test2(param) {
@@ -67,7 +64,6 @@ function test2(param) {
   } else {
     console.log("non node environment");
   }
-  
 }
 
 function test3(param) {

--- a/jscomp/test/unit_undefined_test.js
+++ b/jscomp/test/unit_undefined_test.js
@@ -18,7 +18,6 @@ function eq(loc, x, y) {
 function f_01(param) {
   return hi(function () {
               console.log("x");
-              
             });
 }
 

--- a/jscomp/test/unsafe_ppx_test.js
+++ b/jscomp/test/unsafe_ppx_test.js
@@ -29,7 +29,6 @@ function g(a) {
   regression4(3, (function (x) {
           return x;
         }));
-  
 }
 
 var max2 = Math.max;

--- a/jscomp/test/unsafe_this.js
+++ b/jscomp/test/unsafe_this.js
@@ -10,7 +10,6 @@ var u = {
             $$this.x,
             $$this.y
           ]);
-      
     }),
   length: 32
 };

--- a/jscomp/test/update_record_test.js
+++ b/jscomp/test/update_record_test.js
@@ -30,7 +30,6 @@ function eq(loc, x, y) {
     ],
     tl: suites.contents
   };
-  
 }
 
 function f(x) {

--- a/jscomp/test/utf8_decode_test.js
+++ b/jscomp/test/utf8_decode_test.js
@@ -119,7 +119,6 @@ function to_list(xs) {
             hd: x,
             tl: v.contents
           };
-          
         }), xs);
   return List.rev(v.contents);
 }
@@ -239,7 +238,6 @@ function eq(loc, param) {
     ],
     tl: suites.contents
   };
-  
 }
 
 List.iter((function (param) {

--- a/jscomp/test/watch_test.js
+++ b/jscomp/test/watch_test.js
@@ -10,9 +10,7 @@ function test(path) {
                   $$event,
                   string_buffer
                 ]);
-            
           })).close();
-  
 }
 
 exports.test = test;

--- a/jscomp/test/webpack_config.js
+++ b/jscomp/test/webpack_config.js
@@ -40,19 +40,15 @@ function f(param) {
   return [
           (function (prim) {
               List$3.ff();
-              
             }),
           (function (prim) {
               List$3.ff2();
-              
             }),
           (function (prim) {
               List$2.ff();
-              
             }),
           (function (prim) {
               List$2.ff2();
-              
             })
         ];
 }

--- a/lib/es6/arg.js
+++ b/lib/es6/arg.js
@@ -144,7 +144,6 @@ function usage_string(speclist, errmsg) {
 
 function usage(speclist, errmsg) {
   console.log(usage_string(speclist, errmsg));
-  
 }
 
 var current = {
@@ -506,7 +505,6 @@ function parse_and_expand_argv_dynamic_aux(allow_expand, current, argv, speclist
     }
     current.contents = current.contents + 1 | 0;
   };
-  
 }
 
 function parse_and_expand_argv_dynamic(current, argv, speclist, anonfun, errmsg) {
@@ -715,6 +713,5 @@ export {
   usage_string ,
   align ,
   current ,
-  
 }
 /* No side effect */

--- a/lib/es6/array.js
+++ b/lib/es6/array.js
@@ -78,7 +78,6 @@ function fill(a, ofs, len, v) {
   for(var i = ofs ,i_finish = ofs + len | 0; i < i_finish; ++i){
     a[i] = v;
   }
-  
 }
 
 function blit(a1, ofs1, a2, ofs2, len) {
@@ -96,7 +95,6 @@ function iter(f, a) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     Curry._1(f, a[i]);
   }
-  
 }
 
 function iter2(f, a, b) {
@@ -110,7 +108,6 @@ function iter2(f, a, b) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     Curry._2(f, a[i], b[i]);
   }
-  
 }
 
 function map(f, a) {
@@ -149,7 +146,6 @@ function iteri(f, a) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     Curry._2(f, i, a[i]);
   }
-  
 }
 
 function mapi(f, a) {
@@ -453,7 +449,6 @@ function stable_sort(cmp, a) {
       };
       Caml_array.set(dst, j + 1 | 0, e);
     }
-    
   };
   var sortto = function (srcofs, dst, dstofs, len) {
     if (len <= 5) {
@@ -512,6 +507,5 @@ export {
   stable_sort ,
   fast_sort ,
   Floatarray ,
-  
 }
 /* No side effect */

--- a/lib/es6/arrayLabels.js
+++ b/lib/es6/arrayLabels.js
@@ -78,7 +78,6 @@ function fill(a, ofs, len, v) {
   for(var i = ofs ,i_finish = ofs + len | 0; i < i_finish; ++i){
     a[i] = v;
   }
-  
 }
 
 function blit(a1, ofs1, a2, ofs2, len) {
@@ -96,7 +95,6 @@ function iter(f, a) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     Curry._1(f, a[i]);
   }
-  
 }
 
 function iter2(f, a, b) {
@@ -110,7 +108,6 @@ function iter2(f, a, b) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     Curry._2(f, a[i], b[i]);
   }
-  
 }
 
 function map(f, a) {
@@ -149,7 +146,6 @@ function iteri(f, a) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     Curry._2(f, i, a[i]);
   }
-  
 }
 
 function mapi(f, a) {
@@ -453,7 +449,6 @@ function stable_sort(cmp, a) {
       };
       Caml_array.set(dst, j + 1 | 0, e);
     }
-    
   };
   var sortto = function (srcofs, dst, dstofs, len) {
     if (len <= 5) {
@@ -512,6 +507,5 @@ export {
   stable_sort ,
   fast_sort ,
   Floatarray ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt.js
+++ b/lib/es6/belt.js
@@ -53,6 +53,5 @@ export {
   Result ,
   Int ,
   Float ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_Array.js
+++ b/lib/es6/belt_Array.js
@@ -49,14 +49,12 @@ function setExn(arr, i, v) {
         };
   }
   arr[i] = v;
-  
 }
 
 function swapUnsafe(xs, i, j) {
   var tmp = xs[i];
   xs[i] = xs[j];
   xs[j] = tmp;
-  
 }
 
 function shuffleInPlace(xs) {
@@ -64,7 +62,6 @@ function shuffleInPlace(xs) {
   for(var i = 0; i < len; ++i){
     swapUnsafe(xs, i, Js_math.random_int(i, len));
   }
-  
 }
 
 function shuffle(xs) {
@@ -79,7 +76,6 @@ function reverseInPlace(xs) {
   for(var i = 0 ,i_finish = len / 2 | 0; i < i_finish; ++i){
     swapUnsafe(xs, ofs + i | 0, ((ofs + len | 0) - i | 0) - 1 | 0);
   }
-  
 }
 
 function reverse(xs) {
@@ -257,7 +253,6 @@ function fill(a, offset, len, v) {
   for(var i = ofs ,i_finish = ofs + fillLength | 0; i < i_finish; ++i){
     a[i] = v;
   }
-  
 }
 
 function blitUnsafe(a1, srcofs1, a2, srcofs2, blitLength) {
@@ -270,7 +265,6 @@ function blitUnsafe(a1, srcofs1, a2, srcofs2, blitLength) {
   for(var j$1 = blitLength - 1 | 0; j$1 >= 0; --j$1){
     a2[j$1 + srcofs2 | 0] = a1[j$1 + srcofs1 | 0];
   }
-  
 }
 
 function blit(a1, ofs1, a2, ofs2, len) {
@@ -288,14 +282,12 @@ function blit(a1, ofs1, a2, ofs2, len) {
   for(var j$1 = blitLength - 1 | 0; j$1 >= 0; --j$1){
     a2[j$1 + srcofs2 | 0] = a1[j$1 + srcofs1 | 0];
   }
-  
 }
 
 function forEachU(a, f) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     f(a[i]);
   }
-  
 }
 
 function forEach(a, f) {
@@ -424,7 +416,6 @@ function forEachWithIndexU(a, f) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     f(i, a[i]);
   }
-  
 }
 
 function forEachWithIndex(a, f) {
@@ -769,6 +760,5 @@ export {
   eq ,
   initU ,
   init ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_Float.js
+++ b/lib/es6/belt_Float.js
@@ -12,6 +12,5 @@ function fromString(i) {
 
 export {
   fromString ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_HashMap.js
+++ b/lib/es6/belt_HashMap.js
@@ -217,7 +217,6 @@ function mergeMany(h, arr) {
     var match = arr[i];
     set0(h, match[0], match[1], eq, hash);
   }
-  
 }
 
 var Int;
@@ -277,6 +276,5 @@ export {
   mergeMany ,
   getBucketHistogram ,
   logStats ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_HashMapInt.js
+++ b/lib/es6/belt_HashMapInt.js
@@ -207,7 +207,6 @@ function mergeMany(h, arr) {
     var match = arr[i];
     set(h, match[0], match[1]);
   }
-  
 }
 
 var clear = Belt_internalBucketsType.clear;
@@ -261,6 +260,5 @@ export {
   mergeMany ,
   getBucketHistogram ,
   logStats ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_HashMapString.js
+++ b/lib/es6/belt_HashMapString.js
@@ -207,7 +207,6 @@ function mergeMany(h, arr) {
     var match = arr[i];
     set(h, match[0], match[1]);
   }
-  
 }
 
 var clear = Belt_internalBucketsType.clear;
@@ -261,6 +260,5 @@ export {
   mergeMany ,
   getBucketHistogram ,
   logStats ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_HashSet.js
+++ b/lib/es6/belt_HashSet.js
@@ -172,7 +172,6 @@ function mergeMany(h, arr) {
   for(var i = 0; i < len; ++i){
     add0(h, arr[i], hash, eq);
   }
-  
 }
 
 var Int;
@@ -219,6 +218,5 @@ export {
   fromArray ,
   mergeMany ,
   getBucketHistogram ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_HashSetInt.js
+++ b/lib/es6/belt_HashSetInt.js
@@ -163,7 +163,6 @@ function mergeMany(h, arr) {
   for(var i = 0; i < len; ++i){
     add(h, arr[i]);
   }
-  
 }
 
 var clear = Belt_internalBucketsType.clear;
@@ -204,6 +203,5 @@ export {
   fromArray ,
   mergeMany ,
   getBucketHistogram ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_HashSetString.js
+++ b/lib/es6/belt_HashSetString.js
@@ -163,7 +163,6 @@ function mergeMany(h, arr) {
   for(var i = 0; i < len; ++i){
     add(h, arr[i]);
   }
-  
 }
 
 var clear = Belt_internalBucketsType.clear;
@@ -204,6 +203,5 @@ export {
   fromArray ,
   mergeMany ,
   getBucketHistogram ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_Id.js
+++ b/lib/es6/belt_Id.js
@@ -67,6 +67,5 @@ export {
   MakeHashable ,
   hashableU ,
   hashable ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_Int.js
+++ b/lib/es6/belt_Int.js
@@ -12,6 +12,5 @@ function fromString(i) {
 
 export {
   fromString ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_List.js
+++ b/lib/es6/belt_List.js
@@ -1508,6 +1508,5 @@ export {
   setAssoc ,
   sortU ,
   sort ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_Map.js
+++ b/lib/es6/belt_Map.js
@@ -372,6 +372,5 @@ export {
   getId ,
   packIdData ,
   checkInvariantInternal ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_MapDict.js
+++ b/lib/es6/belt_MapDict.js
@@ -413,6 +413,5 @@ export {
   map ,
   mapWithKeyU ,
   mapWithKey ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_MapInt.js
+++ b/lib/es6/belt_MapInt.js
@@ -303,6 +303,5 @@ export {
   map ,
   mapWithKeyU ,
   mapWithKey ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_MapString.js
+++ b/lib/es6/belt_MapString.js
@@ -303,6 +303,5 @@ export {
   map ,
   mapWithKeyU ,
   mapWithKey ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_MutableMap.js
+++ b/lib/es6/belt_MutableMap.js
@@ -149,7 +149,6 @@ function make(id) {
 
 function clear(m) {
   m.data = undefined;
-  
 }
 
 function isEmpty(d) {
@@ -392,6 +391,5 @@ export {
   map ,
   mapWithKeyU ,
   mapWithKey ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_MutableMapInt.js
+++ b/lib/es6/belt_MutableMapInt.js
@@ -18,7 +18,6 @@ function isEmpty(m) {
 
 function clear(m) {
   m.data = undefined;
-  
 }
 
 function minKeyUndefined(m) {
@@ -359,6 +358,5 @@ export {
   map ,
   mapWithKeyU ,
   mapWithKey ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_MutableMapString.js
+++ b/lib/es6/belt_MutableMapString.js
@@ -18,7 +18,6 @@ function isEmpty(m) {
 
 function clear(m) {
   m.data = undefined;
-  
 }
 
 function minKeyUndefined(m) {
@@ -359,6 +358,5 @@ export {
   map ,
   mapWithKeyU ,
   mapWithKey ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_MutableQueue.js
+++ b/lib/es6/belt_MutableQueue.js
@@ -15,7 +15,6 @@ function clear(q) {
   q.length = 0;
   q.first = undefined;
   q.last = undefined;
-  
 }
 
 function add(q, x) {
@@ -33,7 +32,6 @@ function add(q, x) {
     q.first = cell;
     q.last = cell;
   }
-  
 }
 
 function peek(q) {
@@ -297,6 +295,5 @@ export {
   reduce ,
   transfer ,
   toArray ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_MutableSet.js
+++ b/lib/es6/belt_MutableSet.js
@@ -77,7 +77,6 @@ function removeMany(d, xs) {
   }
   var len = xs.length;
   d.data = removeMany0(oldRoot, xs, 0, len, d.cmp);
-  
 }
 
 function removeCheck0(nt, x, removed, cmp) {
@@ -184,7 +183,6 @@ function addArrayMutate(t, xs, cmp) {
 
 function mergeMany(d, xs) {
   d.data = addArrayMutate(d.data, xs, d.cmp);
-  
 }
 
 function make(id) {
@@ -536,6 +534,5 @@ export {
   getExn ,
   split ,
   checkInvariantInternal ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_MutableSetInt.js
+++ b/lib/es6/belt_MutableSetInt.js
@@ -77,7 +77,6 @@ function removeMany(d, xs) {
   }
   var len = xs.length;
   d.data = removeMany0(oldRoot, xs, 0, len);
-  
 }
 
 function removeCheck0(nt, x, removed) {
@@ -182,7 +181,6 @@ function addArrayMutate(t, xs) {
 
 function mergeMany(d, arr) {
   d.data = addArrayMutate(d.data, arr);
-  
 }
 
 function make(param) {
@@ -499,6 +497,5 @@ export {
   getExn ,
   split ,
   checkInvariantInternal ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_MutableSetString.js
+++ b/lib/es6/belt_MutableSetString.js
@@ -77,7 +77,6 @@ function removeMany(d, xs) {
   }
   var len = xs.length;
   d.data = removeMany0(oldRoot, xs, 0, len);
-  
 }
 
 function removeCheck0(nt, x, removed) {
@@ -182,7 +181,6 @@ function addArrayMutate(t, xs) {
 
 function mergeMany(d, arr) {
   d.data = addArrayMutate(d.data, arr);
-  
 }
 
 function make(param) {
@@ -499,6 +497,5 @@ export {
   getExn ,
   split ,
   checkInvariantInternal ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_MutableStack.js
+++ b/lib/es6/belt_MutableStack.js
@@ -11,7 +11,6 @@ function make(param) {
 
 function clear(s) {
   s.root = undefined;
-  
 }
 
 function copy(s) {
@@ -25,7 +24,6 @@ function push(s, x) {
     head: x,
     tail: s.root
   };
-  
 }
 
 function topUndefined(s) {
@@ -135,6 +133,5 @@ export {
   forEach ,
   dynamicPopIterU ,
   dynamicPopIter ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_Option.js
+++ b/lib/es6/belt_Option.js
@@ -138,6 +138,5 @@ export {
   eq ,
   cmpU ,
   cmp ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_Range.js
+++ b/lib/es6/belt_Range.js
@@ -6,7 +6,6 @@ function forEachU(s, f, action) {
   for(var i = s; i <= f; ++i){
     action(i);
   }
-  
 }
 
 function forEach(s, f, action) {
@@ -106,6 +105,5 @@ export {
   some ,
   someByU ,
   someBy ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_Result.js
+++ b/lib/es6/belt_Result.js
@@ -132,6 +132,5 @@ export {
   eq ,
   cmpU ,
   cmp ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_Set.js
+++ b/lib/es6/belt_Set.js
@@ -310,6 +310,5 @@ export {
   getData ,
   getId ,
   packIdData ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_SetDict.js
+++ b/lib/es6/belt_SetDict.js
@@ -358,6 +358,5 @@ export {
   getExn ,
   split ,
   checkInvariantInternal ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_SetInt.js
+++ b/lib/es6/belt_SetInt.js
@@ -355,6 +355,5 @@ export {
   getExn ,
   split ,
   checkInvariantInternal ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_SetString.js
+++ b/lib/es6/belt_SetString.js
@@ -355,6 +355,5 @@ export {
   getExn ,
   split ,
   checkInvariantInternal ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_SortArray.js
+++ b/lib/es6/belt_SortArray.js
@@ -306,7 +306,6 @@ function insertionSort(src, srcofs, dst, dstofs, len, cmp) {
     };
     dst[j + 1 | 0] = e;
   }
-  
 }
 
 function sortTo(src, srcofs, dst, dstofs, len, cmp) {
@@ -424,6 +423,5 @@ export {
   intersect ,
   diffU ,
   diff ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_SortArrayInt.js
+++ b/lib/es6/belt_SortArrayInt.js
@@ -282,7 +282,6 @@ function insertionSort(src, srcofs, dst, dstofs, len) {
     };
     dst[j + 1 | 0] = e;
   }
-  
 }
 
 function sortTo(src, srcofs, dst, dstofs, len) {
@@ -371,6 +370,5 @@ export {
   union ,
   intersect ,
   diff ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_SortArrayString.js
+++ b/lib/es6/belt_SortArrayString.js
@@ -282,7 +282,6 @@ function insertionSort(src, srcofs, dst, dstofs, len) {
     };
     dst[j + 1 | 0] = e;
   }
-  
 }
 
 function sortTo(src, srcofs, dst, dstofs, len) {
@@ -371,6 +370,5 @@ export {
   union ,
   intersect ,
   diff ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_internalAVLset.js
+++ b/lib/es6/belt_internalAVLset.js
@@ -936,6 +936,5 @@ export {
   addMutate ,
   balMutate ,
   removeMinAuxWithRootMutate ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_internalAVLtree.js
+++ b/lib/es6/belt_internalAVLtree.js
@@ -1142,6 +1142,5 @@ export {
   updateMutate ,
   balMutate ,
   removeMinAuxWithRootMutate ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_internalBuckets.js
+++ b/lib/es6/belt_internalBuckets.js
@@ -84,7 +84,6 @@ function forEachU(h, f) {
   for(var i = 0 ,i_finish = d.length; i < i_finish; ++i){
     do_bucket_iter(f, d[i]);
   }
-  
 }
 
 function forEach(h, f) {
@@ -136,7 +135,6 @@ function getBucketHistogram(h) {
   Belt_Array.forEachU(h.buckets, (function (b) {
           var l = bucketLength(0, b);
           histo[l] = histo[l] + 1 | 0;
-          
         }));
   return histo;
 }
@@ -148,7 +146,6 @@ function logStats(h) {
         buckets: h.buckets.length,
         histogram: histogram
       });
-  
 }
 
 function filterMapInplaceBucket(f, h, i, _prec, _cell) {
@@ -195,7 +192,6 @@ function keepMapInPlaceU(h, f) {
     }
     
   }
-  
 }
 
 function keepMapInPlace(h, f) {
@@ -287,6 +283,5 @@ export {
   valuesToArray ,
   toArray ,
   getBucketHistogram ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_internalBucketsType.js
+++ b/lib/es6/belt_internalBucketsType.js
@@ -32,7 +32,6 @@ function clear(h) {
   for(var i = 0; i < len; ++i){
     h_buckets[i] = undefined;
   }
-  
 }
 
 function isEmpty(h) {
@@ -46,6 +45,5 @@ export {
   make ,
   clear ,
   isEmpty ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_internalMapInt.js
+++ b/lib/es6/belt_internalMapInt.js
@@ -361,6 +361,5 @@ export {
   eq ,
   addMutate ,
   fromArray ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_internalMapString.js
+++ b/lib/es6/belt_internalMapString.js
@@ -361,6 +361,5 @@ export {
   eq ,
   addMutate ,
   fromArray ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_internalSetBuckets.js
+++ b/lib/es6/belt_internalSetBuckets.js
@@ -81,7 +81,6 @@ function forEachU(h, f) {
   for(var i = 0 ,i_finish = d.length; i < i_finish; ++i){
     doBucketIter(f, d[i]);
   }
-  
 }
 
 function forEach(h, f) {
@@ -162,7 +161,6 @@ function getBucketHistogram(h) {
   Belt_Array.forEachU(h.buckets, (function (b) {
           var l = bucketLength(0, b);
           histo[l] = histo[l] + 1 | 0;
-          
         }));
   return histo;
 }
@@ -174,7 +172,6 @@ function logStats(h) {
         buckets: h.buckets.length,
         histogram: histogram
       });
-  
 }
 
 var C;
@@ -190,6 +187,5 @@ export {
   reduce ,
   logStats ,
   getBucketHistogram ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_internalSetInt.js
+++ b/lib/es6/belt_internalSetInt.js
@@ -205,6 +205,5 @@ export {
   getExn ,
   addMutate ,
   fromArray ,
-  
 }
 /* No side effect */

--- a/lib/es6/belt_internalSetString.js
+++ b/lib/es6/belt_internalSetString.js
@@ -205,6 +205,5 @@ export {
   getExn ,
   addMutate ,
   fromArray ,
-  
 }
 /* No side effect */

--- a/lib/es6/buffer.js
+++ b/lib/es6/buffer.js
@@ -64,14 +64,12 @@ function length(b) {
 
 function clear(b) {
   b.position = 0;
-  
 }
 
 function reset(b) {
   b.position = 0;
   b.buffer = b.initial_buffer;
   b.length = b.buffer.length;
-  
 }
 
 function resize(b, more) {
@@ -84,7 +82,6 @@ function resize(b, more) {
   Bytes.blit(b.buffer, 0, new_buffer, 0, b.position);
   b.buffer = new_buffer;
   b.length = new_len;
-  
 }
 
 function add_char(b, c) {
@@ -94,7 +91,6 @@ function add_char(b, c) {
   }
   b.buffer[pos] = c;
   b.position = pos + 1 | 0;
-  
 }
 
 function add_utf_8_uchar(b, u) {
@@ -269,7 +265,6 @@ function add_substring(b, s, offset, len) {
   }
   Bytes.blit_string(s, offset, b.buffer, b.position, len);
   b.position = new_position;
-  
 }
 
 function add_subbytes(b, s, offset, len) {
@@ -284,7 +279,6 @@ function add_string(b, s) {
   }
   Bytes.blit_string(s, 0, b.buffer, b.position, len);
   b.position = new_position;
-  
 }
 
 function add_bytes(b, s) {
@@ -456,7 +450,6 @@ function truncate(b, len) {
         };
   }
   b.position = len;
-  
 }
 
 export {
@@ -480,6 +473,5 @@ export {
   add_substitute ,
   add_buffer ,
   truncate ,
-  
 }
 /* No side effect */

--- a/lib/es6/bytes.js
+++ b/lib/es6/bytes.js
@@ -13,7 +13,6 @@ function unsafe_fill(s, i, l, c) {
   for(var k = i ,k_finish = l + i | 0; k < k_finish; ++k){
     s[k] = c;
   }
-  
 }
 
 function unsafe_blit(s1, i1, s2, i2, len) {
@@ -54,7 +53,6 @@ function unsafe_blit(s1, i1, s2, i2, len) {
   for(var i$2 = off1; i$2 < len; ++i$2){
     s2[i2 + i$2 | 0] = /* '\000' */0;
   }
-  
 }
 
 function make(n, c) {
@@ -224,21 +222,18 @@ function blit_string(s1, ofs1, s2, ofs2, len) {
   for(var i$2 = off1; i$2 < len; ++i$2){
     s2[ofs2 + i$2 | 0] = /* '\000' */0;
   }
-  
 }
 
 function iter(f, a) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     Curry._1(f, a[i]);
   }
-  
 }
 
 function iteri(f, a) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     Curry._2(f, i, a[i]);
   }
-  
 }
 
 function ensure_ge(x, y) {
@@ -705,6 +700,5 @@ export {
   equal ,
   unsafe_to_string ,
   unsafe_of_string ,
-  
 }
 /* No side effect */

--- a/lib/es6/bytesLabels.js
+++ b/lib/es6/bytesLabels.js
@@ -13,7 +13,6 @@ function unsafe_fill(s, i, l, c) {
   for(var k = i ,k_finish = l + i | 0; k < k_finish; ++k){
     s[k] = c;
   }
-  
 }
 
 function unsafe_blit(s1, i1, s2, i2, len) {
@@ -54,7 +53,6 @@ function unsafe_blit(s1, i1, s2, i2, len) {
   for(var i$2 = off1; i$2 < len; ++i$2){
     s2[i2 + i$2 | 0] = /* '\000' */0;
   }
-  
 }
 
 function make(n, c) {
@@ -224,21 +222,18 @@ function blit_string(s1, ofs1, s2, ofs2, len) {
   for(var i$2 = off1; i$2 < len; ++i$2){
     s2[ofs2 + i$2 | 0] = /* '\000' */0;
   }
-  
 }
 
 function iter(f, a) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     Curry._1(f, a[i]);
   }
-  
 }
 
 function iteri(f, a) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     Curry._2(f, i, a[i]);
   }
-  
 }
 
 function ensure_ge(x, y) {
@@ -705,6 +700,5 @@ export {
   equal ,
   unsafe_to_string ,
   unsafe_of_string ,
-  
 }
 /* No side effect */

--- a/lib/es6/callback.js
+++ b/lib/es6/callback.js
@@ -12,6 +12,5 @@ function register_exception(param, param$1) {
 export {
   register ,
   register_exception ,
-  
 }
 /* No side effect */

--- a/lib/es6/caml.js
+++ b/lib/es6/caml.js
@@ -192,6 +192,5 @@ export {
   i64_ge ,
   i64_min ,
   i64_max ,
-  
 }
 /* No side effect */

--- a/lib/es6/caml_array.js
+++ b/lib/es6/caml_array.js
@@ -64,7 +64,6 @@ function set(xs, index, newval) {
         };
   }
   xs[index] = newval;
-  
 }
 
 function get(xs, index) {
@@ -104,7 +103,6 @@ function blit(a1, i1, a2, i2, len) {
   for(var j$1 = len - 1 | 0; j$1 >= 0; --j$1){
     a2[j$1 + i2 | 0] = a1[j$1 + i1 | 0];
   }
-  
 }
 
 function dup(prim) {
@@ -120,6 +118,5 @@ export {
   blit ,
   get ,
   set ,
-  
 }
 /* No side effect */

--- a/lib/es6/caml_bytes.js
+++ b/lib/es6/caml_bytes.js
@@ -10,7 +10,6 @@ function set(s, i, ch) {
         };
   }
   s[i] = ch;
-  
 }
 
 function get(s, i) {
@@ -119,6 +118,5 @@ export {
   bytes_lessthan ,
   bytes_lessequal ,
   bytes_equal ,
-  
 }
 /* No side effect */

--- a/lib/es6/caml_exceptions.js
+++ b/lib/es6/caml_exceptions.js
@@ -27,6 +27,5 @@ export {
   create ,
   is_extension ,
   exn_slot_name ,
-  
 }
 /* No side effect */

--- a/lib/es6/caml_external_polyfill.js
+++ b/lib/es6/caml_external_polyfill.js
@@ -28,6 +28,5 @@ export {
   getGlobalThis ,
   resolve ,
   register ,
-  
 }
 /* No side effect */

--- a/lib/es6/caml_float.js
+++ b/lib/es6/caml_float.js
@@ -125,6 +125,5 @@ export {
   copysign_float ,
   expm1_float ,
   hypot_float ,
-  
 }
 /* No side effect */

--- a/lib/es6/caml_format.js
+++ b/lib/es6/caml_format.js
@@ -814,6 +814,5 @@ export {
   int64_format ,
   int_of_string ,
   int64_of_string ,
-  
 }
 /* No side effect */

--- a/lib/es6/caml_hash.js
+++ b/lib/es6/caml_hash.js
@@ -17,7 +17,6 @@ function push_back(q, v) {
     q.first = cell;
     q.last = cell;
   }
-  
 }
 
 function unsafe_pop(q) {
@@ -98,6 +97,5 @@ function hash(count, _limit, seed, obj) {
 
 export {
   hash ,
-  
 }
 /* No side effect */

--- a/lib/es6/caml_hash_primitive.js
+++ b/lib/es6/caml_hash_primitive.js
@@ -47,6 +47,5 @@ export {
   hash_mix_int ,
   hash_mix_string ,
   hash_final_mix ,
-  
 }
 /* No side effect */

--- a/lib/es6/caml_int32.js
+++ b/lib/es6/caml_int32.js
@@ -24,6 +24,5 @@ function mod_(x, y) {
 export {
   div ,
   mod_ ,
-  
 }
 /* No side effect */

--- a/lib/es6/caml_int64.js
+++ b/lib/es6/caml_int64.js
@@ -602,6 +602,5 @@ export {
   to_hex ,
   discard_sign ,
   to_string ,
-  
 }
 /* No side effect */

--- a/lib/es6/caml_js_exceptions.js
+++ b/lib/es6/caml_js_exceptions.js
@@ -27,6 +27,5 @@ export {
   $$Error ,
   internalToOCamlException ,
   as_js_exn ,
-  
 }
 /* No side effect */

--- a/lib/es6/caml_lexer.js
+++ b/lib/es6/caml_lexer.js
@@ -254,6 +254,5 @@ function new_lex_engine(tbl, i, buf) {
 export {
   lex_engine ,
   new_lex_engine ,
-  
 }
 /*  Not a pure module */

--- a/lib/es6/caml_md5.js
+++ b/lib/es6/caml_md5.js
@@ -95,7 +95,6 @@ function cycle(x, k) {
   x[1] = b + x[1] | 0;
   x[2] = c + x[2] | 0;
   x[3] = d + x[3] | 0;
-  
 }
 
 var state = [
@@ -165,6 +164,5 @@ function md5_string(s, start, len) {
 
 export {
   md5_string ,
-  
 }
 /* No side effect */

--- a/lib/es6/caml_module.js
+++ b/lib/es6/caml_module.js
@@ -113,6 +113,5 @@ function update_mod(shape, o, n) {
 export {
   init_mod ,
   update_mod ,
-  
 }
 /* No side effect */

--- a/lib/es6/caml_obj.js
+++ b/lib/es6/caml_obj.js
@@ -409,6 +409,5 @@ export {
   lessequal ,
   min ,
   max ,
-  
 }
 /* No side effect */

--- a/lib/es6/caml_option.js
+++ b/lib/es6/caml_option.js
@@ -82,6 +82,5 @@ export {
   isNested ,
   option_get ,
   option_unwrap ,
-  
 }
 /* No side effect */

--- a/lib/es6/caml_parser.js
+++ b/lib/es6/caml_parser.js
@@ -299,6 +299,5 @@ var set_parser_trace = (function (v) {
 export {
   parse_engine ,
   set_parser_trace ,
-  
 }
 /*  Not a pure module */

--- a/lib/es6/caml_splice_call.js
+++ b/lib/es6/caml_splice_call.js
@@ -32,6 +32,5 @@ var spliceObjApply = (function(obj,name,args){
 export {
   spliceApply ,
   spliceObjApply ,
-  
 }
 /* No side effect */

--- a/lib/es6/caml_string.js
+++ b/lib/es6/caml_string.js
@@ -19,6 +19,5 @@ function make(n, ch) {
 export {
   get ,
   make ,
-  
 }
 /* No side effect */

--- a/lib/es6/caml_sys.js
+++ b/lib/es6/caml_sys.js
@@ -95,6 +95,5 @@ export {
   sys_exit ,
   sys_is_directory ,
   sys_file_exists ,
-  
 }
 /* No side effect */

--- a/lib/es6/camlinternalLazy.js
+++ b/lib/es6/camlinternalLazy.js
@@ -55,6 +55,5 @@ export {
   force ,
   force_val ,
   is_val ,
-  
 }
 /* No side effect */

--- a/lib/es6/char.js
+++ b/lib/es6/char.js
@@ -122,6 +122,5 @@ export {
   uppercase_ascii ,
   compare ,
   equal ,
-  
 }
 /* No side effect */

--- a/lib/es6/complex.js
+++ b/lib/es6/complex.js
@@ -172,6 +172,5 @@ export {
   exp ,
   log ,
   pow ,
-  
 }
 /* No side effect */

--- a/lib/es6/curry.js
+++ b/lib/es6/curry.js
@@ -522,6 +522,5 @@ export {
   __7 ,
   _8 ,
   __8 ,
-  
 }
 /* No side effect */

--- a/lib/es6/digest.js
+++ b/lib/es6/digest.js
@@ -114,6 +114,5 @@ export {
   subbytes ,
   to_hex ,
   from_hex ,
-  
 }
 /* No side effect */

--- a/lib/es6/dom.js
+++ b/lib/es6/dom.js
@@ -8,6 +8,5 @@ var Storage2;
 export {
   $$Storage ,
   Storage2 ,
-  
 }
 /* No side effect */

--- a/lib/es6/dom_storage.js
+++ b/lib/es6/dom_storage.js
@@ -8,12 +8,10 @@ function getItem(s, obj) {
 
 function setItem(k, v, obj) {
   obj.setItem(k, v);
-  
 }
 
 function removeItem(s, obj) {
   obj.removeItem(s);
-  
 }
 
 function key(i, obj) {
@@ -25,6 +23,5 @@ export {
   setItem ,
   removeItem ,
   key ,
-  
 }
 /* No side effect */

--- a/lib/es6/filename.js
+++ b/lib/es6/filename.js
@@ -259,7 +259,6 @@ function quote$1(s) {
     for(var _j = 1; _j <= n; ++_j){
       $$Buffer.add_char(b, /* '\\' */92);
     }
-    
   };
   loop(0);
   return $$Buffer.contents(b);
@@ -453,7 +452,6 @@ var current_temp_dir_name = {
 
 function set_temp_dir_name(s) {
   current_temp_dir_name.contents = s;
-  
 }
 
 function get_temp_dir_name(param) {
@@ -494,6 +492,5 @@ export {
   set_temp_dir_name ,
   temp_dir_name$2 as temp_dir_name,
   quote$2 as quote,
-  
 }
 /* temp_dir_name Not a pure module */

--- a/lib/es6/genlex.js
+++ b/lib/es6/genlex.js
@@ -23,7 +23,6 @@ var bufpos = {
 function reset_buffer(param) {
   buffer.contents = initial_buffer;
   bufpos.contents = 0;
-  
 }
 
 function store(c) {
@@ -34,7 +33,6 @@ function store(c) {
   }
   Caml_bytes.set(buffer.contents, bufpos.contents, c);
   bufpos.contents = bufpos.contents + 1 | 0;
-  
 }
 
 function get_string(param) {
@@ -664,6 +662,5 @@ function make_lexer(keywords) {
 
 export {
   make_lexer ,
-  
 }
 /* No side effect */

--- a/lib/es6/hashtbl.js
+++ b/lib/es6/hashtbl.js
@@ -25,7 +25,6 @@ function seeded_hash(seed, x) {
 
 function flip_ongoing_traversal(h) {
   h.initial_size = -h.initial_size | 0;
-  
 }
 
 var randomized = {
@@ -34,7 +33,6 @@ var randomized = {
 
 function randomize(param) {
   randomized.contents = true;
-  
 }
 
 function is_randomized(param) {
@@ -80,7 +78,6 @@ function clear(h) {
   for(var i = 0; i < len; ++i){
     Caml_array.set(h.data, i, /* Empty */0);
   }
-  
 }
 
 function reset(h) {
@@ -206,7 +203,6 @@ function resize(indexfun, h) {
     }
     
   }
-  
 }
 
 function key_index(h, key) {
@@ -1115,6 +1111,5 @@ export {
   seeded_hash ,
   hash_param ,
   seeded_hash_param ,
-  
 }
 /* No side effect */

--- a/lib/es6/hashtblLabels.js
+++ b/lib/es6/hashtblLabels.js
@@ -166,6 +166,5 @@ export {
   fold ,
   MakeSeeded ,
   Make ,
-  
 }
 /* No side effect */

--- a/lib/es6/int32.js
+++ b/lib/es6/int32.js
@@ -71,6 +71,5 @@ export {
   to_string ,
   compare ,
   equal ,
-  
 }
 /* No side effect */

--- a/lib/es6/int64.js
+++ b/lib/es6/int64.js
@@ -66,6 +66,5 @@ export {
   to_string ,
   compare ,
   equal ,
-  
 }
 /* No side effect */

--- a/lib/es6/js.js
+++ b/lib/es6/js.js
@@ -92,6 +92,5 @@ export {
   List ,
   Vector ,
   Console ,
-  
 }
 /* No side effect */

--- a/lib/es6/js_OO.js
+++ b/lib/es6/js_OO.js
@@ -11,6 +11,5 @@ export {
   Callback ,
   Meth ,
   Internal ,
-  
 }
 /* No side effect */

--- a/lib/es6/js_array.js
+++ b/lib/es6/js_array.js
@@ -138,12 +138,10 @@ function findIndexi(arg1, obj) {
 
 function forEach(arg1, obj) {
   obj.forEach(Curry.__1(arg1));
-  
 }
 
 function forEachi(arg1, obj) {
   obj.forEach(Curry.__2(arg1));
-  
 }
 
 function map(arg1, obj) {
@@ -221,6 +219,5 @@ export {
   reduceRighti ,
   some ,
   somei ,
-  
 }
 /* No side effect */

--- a/lib/es6/js_dict.js
+++ b/lib/es6/js_dict.js
@@ -81,6 +81,5 @@ export {
   fromList ,
   fromArray ,
   map ,
-  
 }
 /* No side effect */

--- a/lib/es6/js_exn.js
+++ b/lib/es6/js_exn.js
@@ -44,6 +44,5 @@ export {
   raiseSyntaxError ,
   raiseTypeError ,
   raiseUriError ,
-  
 }
 /* No side effect */

--- a/lib/es6/js_int.js
+++ b/lib/es6/js_int.js
@@ -13,6 +13,5 @@ export {
   equal ,
   max ,
   min ,
-  
 }
 /* No side effect */

--- a/lib/es6/js_json.js
+++ b/lib/es6/js_json.js
@@ -168,6 +168,5 @@ export {
   decodeNull ,
   deserializeUnsafe ,
   serializeExn ,
-  
 }
 /* No side effect */

--- a/lib/es6/js_list.js
+++ b/lib/es6/js_list.js
@@ -329,6 +329,5 @@ export {
   init ,
   toVector ,
   equal ,
-  
 }
 /* No side effect */

--- a/lib/es6/js_mapperRt.js
+++ b/lib/es6/js_mapperRt.js
@@ -50,6 +50,5 @@ export {
   raiseWhenNotFound ,
   fromInt ,
   fromIntAssert ,
-  
 }
 /* No side effect */

--- a/lib/es6/js_math.js
+++ b/lib/es6/js_math.js
@@ -46,6 +46,5 @@ export {
   floor_int ,
   floor ,
   random_int ,
-  
 }
 /* No side effect */

--- a/lib/es6/js_null.js
+++ b/lib/es6/js_null.js
@@ -45,6 +45,5 @@ export {
   iter ,
   fromOption ,
   from_opt ,
-  
 }
 /* No side effect */

--- a/lib/es6/js_null_undefined.js
+++ b/lib/es6/js_null_undefined.js
@@ -31,6 +31,5 @@ export {
   iter ,
   fromOption ,
   from_opt ,
-  
 }
 /* No side effect */

--- a/lib/es6/js_option.js
+++ b/lib/es6/js_option.js
@@ -100,6 +100,5 @@ export {
   $$default as default,
   filter ,
   firstSome ,
-  
 }
 /* No side effect */

--- a/lib/es6/js_promise.js
+++ b/lib/es6/js_promise.js
@@ -13,6 +13,5 @@ function $$catch(arg1, obj) {
 export {
   then_ ,
   $$catch ,
-  
 }
 /* No side effect */

--- a/lib/es6/js_string.js
+++ b/lib/es6/js_string.js
@@ -195,6 +195,5 @@ export {
   substringToEnd ,
   anchor ,
   link ,
-  
 }
 /* No side effect */

--- a/lib/es6/js_typed_array.js
+++ b/lib/es6/js_typed_array.js
@@ -16,12 +16,10 @@ var $$ArrayBuffer = {
 
 function setArray(arg1, obj) {
   obj.set(arg1);
-  
 }
 
 function setArrayOffset(arg1, arg2, obj) {
   obj.set(arg1, arg2);
-  
 }
 
 function copyWithin(to_, obj) {
@@ -126,12 +124,10 @@ function findIndexi(arg1, obj) {
 
 function forEach(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function forEachi(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function map(arg1, obj) {
@@ -208,12 +204,10 @@ var $$Int8Array = {
 
 function setArray$1(arg1, obj) {
   obj.set(arg1);
-  
 }
 
 function setArrayOffset$1(arg1, arg2, obj) {
   obj.set(arg1, arg2);
-  
 }
 
 function copyWithin$1(to_, obj) {
@@ -318,12 +312,10 @@ function findIndexi$1(arg1, obj) {
 
 function forEach$1(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function forEachi$1(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function map$1(arg1, obj) {
@@ -400,12 +392,10 @@ var $$Uint8Array = {
 
 function setArray$2(arg1, obj) {
   obj.set(arg1);
-  
 }
 
 function setArrayOffset$2(arg1, arg2, obj) {
   obj.set(arg1, arg2);
-  
 }
 
 function copyWithin$2(to_, obj) {
@@ -510,12 +500,10 @@ function findIndexi$2(arg1, obj) {
 
 function forEach$2(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function forEachi$2(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function map$2(arg1, obj) {
@@ -592,12 +580,10 @@ var $$Uint8ClampedArray = {
 
 function setArray$3(arg1, obj) {
   obj.set(arg1);
-  
 }
 
 function setArrayOffset$3(arg1, arg2, obj) {
   obj.set(arg1, arg2);
-  
 }
 
 function copyWithin$3(to_, obj) {
@@ -702,12 +688,10 @@ function findIndexi$3(arg1, obj) {
 
 function forEach$3(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function forEachi$3(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function map$3(arg1, obj) {
@@ -784,12 +768,10 @@ var $$Int16Array = {
 
 function setArray$4(arg1, obj) {
   obj.set(arg1);
-  
 }
 
 function setArrayOffset$4(arg1, arg2, obj) {
   obj.set(arg1, arg2);
-  
 }
 
 function copyWithin$4(to_, obj) {
@@ -894,12 +876,10 @@ function findIndexi$4(arg1, obj) {
 
 function forEach$4(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function forEachi$4(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function map$4(arg1, obj) {
@@ -976,12 +956,10 @@ var $$Uint16Array = {
 
 function setArray$5(arg1, obj) {
   obj.set(arg1);
-  
 }
 
 function setArrayOffset$5(arg1, arg2, obj) {
   obj.set(arg1, arg2);
-  
 }
 
 function copyWithin$5(to_, obj) {
@@ -1086,12 +1064,10 @@ function findIndexi$5(arg1, obj) {
 
 function forEach$5(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function forEachi$5(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function map$5(arg1, obj) {
@@ -1168,12 +1144,10 @@ var $$Int32Array = {
 
 function setArray$6(arg1, obj) {
   obj.set(arg1);
-  
 }
 
 function setArrayOffset$6(arg1, arg2, obj) {
   obj.set(arg1, arg2);
-  
 }
 
 function copyWithin$6(to_, obj) {
@@ -1278,12 +1252,10 @@ function findIndexi$6(arg1, obj) {
 
 function forEach$6(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function forEachi$6(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function map$6(arg1, obj) {
@@ -1360,12 +1332,10 @@ var $$Uint32Array = {
 
 function setArray$7(arg1, obj) {
   obj.set(arg1);
-  
 }
 
 function setArrayOffset$7(arg1, arg2, obj) {
   obj.set(arg1, arg2);
-  
 }
 
 function copyWithin$7(to_, obj) {
@@ -1470,12 +1440,10 @@ function findIndexi$7(arg1, obj) {
 
 function forEach$7(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function forEachi$7(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function map$7(arg1, obj) {
@@ -1552,12 +1520,10 @@ var $$Float32Array = {
 
 function setArray$8(arg1, obj) {
   obj.set(arg1);
-  
 }
 
 function setArrayOffset$8(arg1, arg2, obj) {
   obj.set(arg1, arg2);
-  
 }
 
 function copyWithin$8(to_, obj) {
@@ -1662,12 +1628,10 @@ function findIndexi$8(arg1, obj) {
 
 function forEach$8(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function forEachi$8(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function map$8(arg1, obj) {
@@ -1765,6 +1729,5 @@ export {
   $$Float64Array ,
   Float64_array ,
   $$DataView ,
-  
 }
 /* No side effect */

--- a/lib/es6/js_typed_array2.js
+++ b/lib/es6/js_typed_array2.js
@@ -35,6 +35,5 @@ export {
   $$Float32Array ,
   $$Float64Array ,
   $$DataView ,
-  
 }
 /* No side effect */

--- a/lib/es6/js_types.js
+++ b/lib/es6/js_types.js
@@ -66,6 +66,5 @@ function test(x, v) {
 export {
   test ,
   classify ,
-  
 }
 /* No side effect */

--- a/lib/es6/js_undefined.js
+++ b/lib/es6/js_undefined.js
@@ -48,6 +48,5 @@ export {
   iter ,
   fromOption ,
   from_opt ,
-  
 }
 /* No side effect */

--- a/lib/es6/js_vector.js
+++ b/lib/es6/js_vector.js
@@ -13,17 +13,14 @@ function filterInPlace(p, a) {
     i = i + 1 | 0;
   };
   a.splice(j);
-  
 }
 
 function empty(a) {
   a.splice(0);
-  
 }
 
 function pushBack(x, xs) {
   xs.push(x);
-  
 }
 
 function memByRef(x, xs) {
@@ -34,14 +31,12 @@ function iter(f, xs) {
   for(var i = 0 ,i_finish = xs.length; i < i_finish; ++i){
     f(xs[i]);
   }
-  
 }
 
 function iteri(f, a) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     f(i, a[i]);
   }
-  
 }
 
 function toList(a) {
@@ -135,6 +130,5 @@ export {
   foldRight ,
   init ,
   append ,
-  
 }
 /* No side effect */

--- a/lib/es6/lazy.js
+++ b/lib/es6/lazy.js
@@ -40,6 +40,5 @@ export {
   lazy_from_fun ,
   lazy_from_val ,
   lazy_is_val ,
-  
 }
 /* No side effect */

--- a/lib/es6/lexing.js
+++ b/lib/es6/lexing.js
@@ -82,7 +82,6 @@ function from_function(f) {
               }
               Bytes.blit(partial_arg, 0, param.lex_buffer, param.lex_buffer_len, n);
               param.lex_buffer_len = param.lex_buffer_len + n | 0;
-              
             }),
           lex_buffer: Caml_bytes.create(1024),
           lex_buffer_len: 0,
@@ -102,7 +101,6 @@ function from_string(s) {
   return {
           refill_buff: (function (lexbuf) {
               lexbuf.lex_eof_reached = true;
-              
             }),
           lex_buffer: Bytes.of_string(s),
           lex_buffer_len: s.length,
@@ -175,7 +173,6 @@ function new_line(lexbuf) {
     pos_bol: lcp.pos_cnum,
     pos_cnum: lcp.pos_cnum
   };
-  
 }
 
 function flush_input(lb) {
@@ -189,7 +186,6 @@ function flush_input(lb) {
     pos_cnum: 0
   };
   lb.lex_buffer_len = 0;
-  
 }
 
 var dummy_pos = {
@@ -217,6 +213,5 @@ export {
   sub_lexeme_char_opt ,
   engine ,
   new_engine ,
-  
 }
 /* No side effect */

--- a/lib/es6/list.js
+++ b/lib/es6/list.js
@@ -1709,6 +1709,5 @@ export {
   fast_sort ,
   sort_uniq ,
   merge ,
-  
 }
 /* No side effect */

--- a/lib/es6/listLabels.js
+++ b/lib/es6/listLabels.js
@@ -1709,6 +1709,5 @@ export {
   fast_sort ,
   sort_uniq ,
   merge ,
-  
 }
 /* No side effect */

--- a/lib/es6/map.js
+++ b/lib/es6/map.js
@@ -932,6 +932,5 @@ function Make(funarg) {
 
 export {
   Make ,
-  
 }
 /* No side effect */

--- a/lib/es6/mapLabels.js
+++ b/lib/es6/mapLabels.js
@@ -947,6 +947,5 @@ function Make(Ord) {
 
 export {
   Make ,
-  
 }
 /* No side effect */

--- a/lib/es6/moreLabels.js
+++ b/lib/es6/moreLabels.js
@@ -1927,6 +1927,5 @@ export {
   Hashtbl ,
   $$Map ,
   $$Set ,
-  
 }
 /* No side effect */

--- a/lib/es6/node.js
+++ b/lib/es6/node.js
@@ -35,6 +35,5 @@ export {
   $$Buffer ,
   Child_process ,
   test ,
-  
 }
 /* No side effect */

--- a/lib/es6/node_fs.js
+++ b/lib/es6/node_fs.js
@@ -5,6 +5,5 @@ var Watch = {};
 
 export {
   Watch ,
-  
 }
 /* No side effect */

--- a/lib/es6/node_process.js
+++ b/lib/es6/node_process.js
@@ -5,7 +5,6 @@ import * as Process from "process";
 
 function putEnvVar(key, $$var) {
   Process.env[key] = $$var;
-  
 }
 
 function deleteEnvVar(s) {
@@ -15,6 +14,5 @@ function deleteEnvVar(s) {
 export {
   putEnvVar ,
   deleteEnvVar ,
-  
 }
 /* process Not a pure module */

--- a/lib/es6/obj.js
+++ b/lib/es6/obj.js
@@ -7,6 +7,5 @@ function is_block(a) {
 
 export {
   is_block ,
-  
 }
 /* No side effect */

--- a/lib/es6/parsing.js
+++ b/lib/es6/parsing.js
@@ -48,13 +48,11 @@ function grow_stacks(param) {
   $$Array.blit(env.symb_end_stack, 0, new_end, 0, oldsize);
   env.symb_end_stack = new_end;
   env.stacksize = newsize;
-  
 }
 
 function clear_parser(param) {
   $$Array.fill(env.v_stack, 0, env.stacksize, undefined);
   env.lval = undefined;
-  
 }
 
 var current_lookahead_fun = {
@@ -235,6 +233,5 @@ export {
   peek_val ,
   is_current_lookahead ,
   parse_error ,
-  
 }
 /* No side effect */

--- a/lib/es6/pervasives.js
+++ b/lib/es6/pervasives.js
@@ -167,27 +167,22 @@ function $at(l1, l2) {
 
 function print_newline(param) {
   console.log("");
-  
 }
 
 function prerr_newline(param) {
   console.error("");
-  
 }
 
 function print_int(i) {
   console.log(String(i));
-  
 }
 
 function print_float(i) {
   console.log(valid_float_lexem(Caml_format.format_float("%.12g", i)));
-  
 }
 
 function print_string(prim) {
   console.log(prim);
-  
 }
 
 var exit_function = {
@@ -202,7 +197,6 @@ function at_exit(f) {
       Curry._1(f, undefined);
       return Curry._1(g, undefined);
     });
-  
 }
 
 function exit(retcode) {
@@ -252,6 +246,5 @@ export {
   exit ,
   at_exit ,
   valid_float_lexem ,
-  
 }
 /* No side effect */

--- a/lib/es6/printexc.js
+++ b/lib/es6/printexc.js
@@ -97,7 +97,6 @@ function register_printer(fn) {
     hd: fn,
     tl: printers.contents
   };
-  
 }
 
 export {
@@ -105,6 +104,5 @@ export {
   print ,
   $$catch ,
   register_printer ,
-  
 }
 /* No side effect */

--- a/lib/es6/queue.js
+++ b/lib/es6/queue.js
@@ -17,7 +17,6 @@ function clear(q) {
   q.length = 0;
   q.first = /* Nil */0;
   q.last = /* Nil */0;
-  
 }
 
 function add(x, q) {
@@ -35,7 +34,6 @@ function add(x, q) {
     q.first = cell;
     q.last = cell;
   }
-  
 }
 
 function peek(q) {
@@ -179,6 +177,5 @@ export {
   iter ,
   fold ,
   transfer ,
-  
 }
 /* No side effect */

--- a/lib/es6/random.js
+++ b/lib/es6/random.js
@@ -16,7 +16,6 @@ function random_seed(param) {
 function assign(st1, st2) {
   $$Array.blit(st2.st, 0, st1.st, 0, 55);
   st1.idx = st2.idx;
-  
 }
 
 function full_init(s, seed) {
@@ -41,7 +40,6 @@ function full_init(s, seed) {
     Caml_array.set(s.st, j, (Caml_array.get(s.st, j) ^ extract(accu)) & 1073741823);
   }
   s.idx = 0;
-  
 }
 
 function make(seed) {
@@ -278,6 +276,5 @@ export {
   State ,
   get_state ,
   set_state ,
-  
 }
 /* No side effect */

--- a/lib/es6/set.js
+++ b/lib/es6/set.js
@@ -951,6 +951,5 @@ function Make(funarg) {
 
 export {
   Make ,
-  
 }
 /* No side effect */

--- a/lib/es6/setLabels.js
+++ b/lib/es6/setLabels.js
@@ -984,6 +984,5 @@ function Make(Ord) {
 
 export {
   Make ,
-  
 }
 /* No side effect */

--- a/lib/es6/sort.js
+++ b/lib/es6/sort.js
@@ -90,7 +90,6 @@ function swap(arr, i, j) {
   var tmp = arr[i];
   arr[i] = arr[j];
   arr[j] = tmp;
-  
 }
 
 function array(cmp, arr) {
@@ -159,13 +158,11 @@ function array(cmp, arr) {
     }
     
   }
-  
 }
 
 export {
   list ,
   array ,
   merge ,
-  
 }
 /* No side effect */

--- a/lib/es6/stack.js
+++ b/lib/es6/stack.js
@@ -15,7 +15,6 @@ function create(param) {
 function clear(s) {
   s.c = /* [] */0;
   s.len = 0;
-  
 }
 
 function copy(s) {
@@ -31,7 +30,6 @@ function push(x, s) {
     tl: s.c
   };
   s.len = s.len + 1 | 0;
-  
 }
 
 function pop(s) {
@@ -86,6 +84,5 @@ export {
   length ,
   iter ,
   fold ,
-  
 }
 /* No side effect */

--- a/lib/es6/stdLabels.js
+++ b/lib/es6/stdLabels.js
@@ -14,6 +14,5 @@ export {
   Bytes ,
   List ,
   $$String ,
-  
 }
 /* No side effect */

--- a/lib/es6/stream.js
+++ b/lib/es6/stream.js
@@ -465,7 +465,6 @@ function dump(f, s) {
   dump_data(f, data(s));
   console.log("}");
   console.log("");
-  
 }
 
 var sempty;
@@ -493,6 +492,5 @@ export {
   sempty ,
   slazy ,
   dump ,
-  
 }
 /* No side effect */

--- a/lib/es6/string.js
+++ b/lib/es6/string.js
@@ -23,14 +23,12 @@ function iter(f, s) {
   for(var i = 0 ,i_finish = s.length; i < i_finish; ++i){
     Curry._1(f, s.codePointAt(i));
   }
-  
 }
 
 function iteri(f, s) {
   for(var i = 0 ,i_finish = s.length; i < i_finish; ++i){
     Curry._2(f, i, s.codePointAt(i));
   }
-  
 }
 
 function map(f, s) {
@@ -335,6 +333,5 @@ export {
   compare ,
   equal ,
   split_on_char ,
-  
 }
 /* No side effect */

--- a/lib/es6/stringLabels.js
+++ b/lib/es6/stringLabels.js
@@ -25,14 +25,12 @@ function iter(f, s) {
   for(var i = 0 ,i_finish = s.length; i < i_finish; ++i){
     Curry._1(f, s.codePointAt(i));
   }
-  
 }
 
 function iteri(f, s) {
   for(var i = 0 ,i_finish = s.length; i < i_finish; ++i){
     Curry._2(f, i, s.codePointAt(i));
   }
-  
 }
 
 function map(f, s) {
@@ -335,6 +333,5 @@ export {
   compare ,
   equal ,
   split_on_char ,
-  
 }
 /* No side effect */

--- a/lib/es6/sys.js
+++ b/lib/es6/sys.js
@@ -178,6 +178,5 @@ export {
   ocaml_version ,
   enable_runtime_warnings ,
   runtime_warnings_enabled ,
-  
 }
 /* No side effect */

--- a/lib/es6/uchar.js
+++ b/lib/es6/uchar.js
@@ -129,6 +129,5 @@ export {
   equal ,
   compare ,
   hash ,
-  
 }
 /* No side effect */

--- a/lib/js/arg.js
+++ b/lib/js/arg.js
@@ -144,7 +144,6 @@ function usage_string(speclist, errmsg) {
 
 function usage(speclist, errmsg) {
   console.log(usage_string(speclist, errmsg));
-  
 }
 
 var current = {
@@ -506,7 +505,6 @@ function parse_and_expand_argv_dynamic_aux(allow_expand, current, argv, speclist
     }
     current.contents = current.contents + 1 | 0;
   };
-  
 }
 
 function parse_and_expand_argv_dynamic(current, argv, speclist, anonfun, errmsg) {

--- a/lib/js/array.js
+++ b/lib/js/array.js
@@ -78,7 +78,6 @@ function fill(a, ofs, len, v) {
   for(var i = ofs ,i_finish = ofs + len | 0; i < i_finish; ++i){
     a[i] = v;
   }
-  
 }
 
 function blit(a1, ofs1, a2, ofs2, len) {
@@ -96,7 +95,6 @@ function iter(f, a) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     Curry._1(f, a[i]);
   }
-  
 }
 
 function iter2(f, a, b) {
@@ -110,7 +108,6 @@ function iter2(f, a, b) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     Curry._2(f, a[i], b[i]);
   }
-  
 }
 
 function map(f, a) {
@@ -149,7 +146,6 @@ function iteri(f, a) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     Curry._2(f, i, a[i]);
   }
-  
 }
 
 function mapi(f, a) {
@@ -453,7 +449,6 @@ function stable_sort(cmp, a) {
       };
       Caml_array.set(dst, j + 1 | 0, e);
     }
-    
   };
   var sortto = function (srcofs, dst, dstofs, len) {
     if (len <= 5) {

--- a/lib/js/arrayLabels.js
+++ b/lib/js/arrayLabels.js
@@ -78,7 +78,6 @@ function fill(a, ofs, len, v) {
   for(var i = ofs ,i_finish = ofs + len | 0; i < i_finish; ++i){
     a[i] = v;
   }
-  
 }
 
 function blit(a1, ofs1, a2, ofs2, len) {
@@ -96,7 +95,6 @@ function iter(f, a) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     Curry._1(f, a[i]);
   }
-  
 }
 
 function iter2(f, a, b) {
@@ -110,7 +108,6 @@ function iter2(f, a, b) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     Curry._2(f, a[i], b[i]);
   }
-  
 }
 
 function map(f, a) {
@@ -149,7 +146,6 @@ function iteri(f, a) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     Curry._2(f, i, a[i]);
   }
-  
 }
 
 function mapi(f, a) {
@@ -453,7 +449,6 @@ function stable_sort(cmp, a) {
       };
       Caml_array.set(dst, j + 1 | 0, e);
     }
-    
   };
   var sortto = function (srcofs, dst, dstofs, len) {
     if (len <= 5) {

--- a/lib/js/belt_Array.js
+++ b/lib/js/belt_Array.js
@@ -49,14 +49,12 @@ function setExn(arr, i, v) {
         };
   }
   arr[i] = v;
-  
 }
 
 function swapUnsafe(xs, i, j) {
   var tmp = xs[i];
   xs[i] = xs[j];
   xs[j] = tmp;
-  
 }
 
 function shuffleInPlace(xs) {
@@ -64,7 +62,6 @@ function shuffleInPlace(xs) {
   for(var i = 0; i < len; ++i){
     swapUnsafe(xs, i, Js_math.random_int(i, len));
   }
-  
 }
 
 function shuffle(xs) {
@@ -79,7 +76,6 @@ function reverseInPlace(xs) {
   for(var i = 0 ,i_finish = len / 2 | 0; i < i_finish; ++i){
     swapUnsafe(xs, ofs + i | 0, ((ofs + len | 0) - i | 0) - 1 | 0);
   }
-  
 }
 
 function reverse(xs) {
@@ -257,7 +253,6 @@ function fill(a, offset, len, v) {
   for(var i = ofs ,i_finish = ofs + fillLength | 0; i < i_finish; ++i){
     a[i] = v;
   }
-  
 }
 
 function blitUnsafe(a1, srcofs1, a2, srcofs2, blitLength) {
@@ -270,7 +265,6 @@ function blitUnsafe(a1, srcofs1, a2, srcofs2, blitLength) {
   for(var j$1 = blitLength - 1 | 0; j$1 >= 0; --j$1){
     a2[j$1 + srcofs2 | 0] = a1[j$1 + srcofs1 | 0];
   }
-  
 }
 
 function blit(a1, ofs1, a2, ofs2, len) {
@@ -288,14 +282,12 @@ function blit(a1, ofs1, a2, ofs2, len) {
   for(var j$1 = blitLength - 1 | 0; j$1 >= 0; --j$1){
     a2[j$1 + srcofs2 | 0] = a1[j$1 + srcofs1 | 0];
   }
-  
 }
 
 function forEachU(a, f) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     f(a[i]);
   }
-  
 }
 
 function forEach(a, f) {
@@ -424,7 +416,6 @@ function forEachWithIndexU(a, f) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     f(i, a[i]);
   }
-  
 }
 
 function forEachWithIndex(a, f) {

--- a/lib/js/belt_HashMap.js
+++ b/lib/js/belt_HashMap.js
@@ -217,7 +217,6 @@ function mergeMany(h, arr) {
     var match = arr[i];
     set0(h, match[0], match[1], eq, hash);
   }
-  
 }
 
 var Int;

--- a/lib/js/belt_HashMapInt.js
+++ b/lib/js/belt_HashMapInt.js
@@ -207,7 +207,6 @@ function mergeMany(h, arr) {
     var match = arr[i];
     set(h, match[0], match[1]);
   }
-  
 }
 
 var clear = Belt_internalBucketsType.clear;

--- a/lib/js/belt_HashMapString.js
+++ b/lib/js/belt_HashMapString.js
@@ -207,7 +207,6 @@ function mergeMany(h, arr) {
     var match = arr[i];
     set(h, match[0], match[1]);
   }
-  
 }
 
 var clear = Belt_internalBucketsType.clear;

--- a/lib/js/belt_HashSet.js
+++ b/lib/js/belt_HashSet.js
@@ -172,7 +172,6 @@ function mergeMany(h, arr) {
   for(var i = 0; i < len; ++i){
     add0(h, arr[i], hash, eq);
   }
-  
 }
 
 var Int;

--- a/lib/js/belt_HashSetInt.js
+++ b/lib/js/belt_HashSetInt.js
@@ -163,7 +163,6 @@ function mergeMany(h, arr) {
   for(var i = 0; i < len; ++i){
     add(h, arr[i]);
   }
-  
 }
 
 var clear = Belt_internalBucketsType.clear;

--- a/lib/js/belt_HashSetString.js
+++ b/lib/js/belt_HashSetString.js
@@ -163,7 +163,6 @@ function mergeMany(h, arr) {
   for(var i = 0; i < len; ++i){
     add(h, arr[i]);
   }
-  
 }
 
 var clear = Belt_internalBucketsType.clear;

--- a/lib/js/belt_MutableMap.js
+++ b/lib/js/belt_MutableMap.js
@@ -149,7 +149,6 @@ function make(id) {
 
 function clear(m) {
   m.data = undefined;
-  
 }
 
 function isEmpty(d) {

--- a/lib/js/belt_MutableMapInt.js
+++ b/lib/js/belt_MutableMapInt.js
@@ -18,7 +18,6 @@ function isEmpty(m) {
 
 function clear(m) {
   m.data = undefined;
-  
 }
 
 function minKeyUndefined(m) {

--- a/lib/js/belt_MutableMapString.js
+++ b/lib/js/belt_MutableMapString.js
@@ -18,7 +18,6 @@ function isEmpty(m) {
 
 function clear(m) {
   m.data = undefined;
-  
 }
 
 function minKeyUndefined(m) {

--- a/lib/js/belt_MutableQueue.js
+++ b/lib/js/belt_MutableQueue.js
@@ -15,7 +15,6 @@ function clear(q) {
   q.length = 0;
   q.first = undefined;
   q.last = undefined;
-  
 }
 
 function add(q, x) {
@@ -33,7 +32,6 @@ function add(q, x) {
     q.first = cell;
     q.last = cell;
   }
-  
 }
 
 function peek(q) {

--- a/lib/js/belt_MutableSet.js
+++ b/lib/js/belt_MutableSet.js
@@ -77,7 +77,6 @@ function removeMany(d, xs) {
   }
   var len = xs.length;
   d.data = removeMany0(oldRoot, xs, 0, len, d.cmp);
-  
 }
 
 function removeCheck0(nt, x, removed, cmp) {
@@ -184,7 +183,6 @@ function addArrayMutate(t, xs, cmp) {
 
 function mergeMany(d, xs) {
   d.data = addArrayMutate(d.data, xs, d.cmp);
-  
 }
 
 function make(id) {

--- a/lib/js/belt_MutableSetInt.js
+++ b/lib/js/belt_MutableSetInt.js
@@ -77,7 +77,6 @@ function removeMany(d, xs) {
   }
   var len = xs.length;
   d.data = removeMany0(oldRoot, xs, 0, len);
-  
 }
 
 function removeCheck0(nt, x, removed) {
@@ -182,7 +181,6 @@ function addArrayMutate(t, xs) {
 
 function mergeMany(d, arr) {
   d.data = addArrayMutate(d.data, arr);
-  
 }
 
 function make(param) {

--- a/lib/js/belt_MutableSetString.js
+++ b/lib/js/belt_MutableSetString.js
@@ -77,7 +77,6 @@ function removeMany(d, xs) {
   }
   var len = xs.length;
   d.data = removeMany0(oldRoot, xs, 0, len);
-  
 }
 
 function removeCheck0(nt, x, removed) {
@@ -182,7 +181,6 @@ function addArrayMutate(t, xs) {
 
 function mergeMany(d, arr) {
   d.data = addArrayMutate(d.data, arr);
-  
 }
 
 function make(param) {

--- a/lib/js/belt_MutableStack.js
+++ b/lib/js/belt_MutableStack.js
@@ -11,7 +11,6 @@ function make(param) {
 
 function clear(s) {
   s.root = undefined;
-  
 }
 
 function copy(s) {
@@ -25,7 +24,6 @@ function push(s, x) {
     head: x,
     tail: s.root
   };
-  
 }
 
 function topUndefined(s) {

--- a/lib/js/belt_Range.js
+++ b/lib/js/belt_Range.js
@@ -6,7 +6,6 @@ function forEachU(s, f, action) {
   for(var i = s; i <= f; ++i){
     action(i);
   }
-  
 }
 
 function forEach(s, f, action) {

--- a/lib/js/belt_SortArray.js
+++ b/lib/js/belt_SortArray.js
@@ -306,7 +306,6 @@ function insertionSort(src, srcofs, dst, dstofs, len, cmp) {
     };
     dst[j + 1 | 0] = e;
   }
-  
 }
 
 function sortTo(src, srcofs, dst, dstofs, len, cmp) {

--- a/lib/js/belt_SortArrayInt.js
+++ b/lib/js/belt_SortArrayInt.js
@@ -282,7 +282,6 @@ function insertionSort(src, srcofs, dst, dstofs, len) {
     };
     dst[j + 1 | 0] = e;
   }
-  
 }
 
 function sortTo(src, srcofs, dst, dstofs, len) {

--- a/lib/js/belt_SortArrayString.js
+++ b/lib/js/belt_SortArrayString.js
@@ -282,7 +282,6 @@ function insertionSort(src, srcofs, dst, dstofs, len) {
     };
     dst[j + 1 | 0] = e;
   }
-  
 }
 
 function sortTo(src, srcofs, dst, dstofs, len) {

--- a/lib/js/belt_internalBuckets.js
+++ b/lib/js/belt_internalBuckets.js
@@ -84,7 +84,6 @@ function forEachU(h, f) {
   for(var i = 0 ,i_finish = d.length; i < i_finish; ++i){
     do_bucket_iter(f, d[i]);
   }
-  
 }
 
 function forEach(h, f) {
@@ -136,7 +135,6 @@ function getBucketHistogram(h) {
   Belt_Array.forEachU(h.buckets, (function (b) {
           var l = bucketLength(0, b);
           histo[l] = histo[l] + 1 | 0;
-          
         }));
   return histo;
 }
@@ -148,7 +146,6 @@ function logStats(h) {
         buckets: h.buckets.length,
         histogram: histogram
       });
-  
 }
 
 function filterMapInplaceBucket(f, h, i, _prec, _cell) {
@@ -195,7 +192,6 @@ function keepMapInPlaceU(h, f) {
     }
     
   }
-  
 }
 
 function keepMapInPlace(h, f) {

--- a/lib/js/belt_internalBucketsType.js
+++ b/lib/js/belt_internalBucketsType.js
@@ -32,7 +32,6 @@ function clear(h) {
   for(var i = 0; i < len; ++i){
     h_buckets[i] = undefined;
   }
-  
 }
 
 function isEmpty(h) {

--- a/lib/js/belt_internalSetBuckets.js
+++ b/lib/js/belt_internalSetBuckets.js
@@ -81,7 +81,6 @@ function forEachU(h, f) {
   for(var i = 0 ,i_finish = d.length; i < i_finish; ++i){
     doBucketIter(f, d[i]);
   }
-  
 }
 
 function forEach(h, f) {
@@ -162,7 +161,6 @@ function getBucketHistogram(h) {
   Belt_Array.forEachU(h.buckets, (function (b) {
           var l = bucketLength(0, b);
           histo[l] = histo[l] + 1 | 0;
-          
         }));
   return histo;
 }
@@ -174,7 +172,6 @@ function logStats(h) {
         buckets: h.buckets.length,
         histogram: histogram
       });
-  
 }
 
 var C;

--- a/lib/js/buffer.js
+++ b/lib/js/buffer.js
@@ -64,14 +64,12 @@ function length(b) {
 
 function clear(b) {
   b.position = 0;
-  
 }
 
 function reset(b) {
   b.position = 0;
   b.buffer = b.initial_buffer;
   b.length = b.buffer.length;
-  
 }
 
 function resize(b, more) {
@@ -84,7 +82,6 @@ function resize(b, more) {
   Bytes.blit(b.buffer, 0, new_buffer, 0, b.position);
   b.buffer = new_buffer;
   b.length = new_len;
-  
 }
 
 function add_char(b, c) {
@@ -94,7 +91,6 @@ function add_char(b, c) {
   }
   b.buffer[pos] = c;
   b.position = pos + 1 | 0;
-  
 }
 
 function add_utf_8_uchar(b, u) {
@@ -269,7 +265,6 @@ function add_substring(b, s, offset, len) {
   }
   Bytes.blit_string(s, offset, b.buffer, b.position, len);
   b.position = new_position;
-  
 }
 
 function add_subbytes(b, s, offset, len) {
@@ -284,7 +279,6 @@ function add_string(b, s) {
   }
   Bytes.blit_string(s, 0, b.buffer, b.position, len);
   b.position = new_position;
-  
 }
 
 function add_bytes(b, s) {
@@ -456,7 +450,6 @@ function truncate(b, len) {
         };
   }
   b.position = len;
-  
 }
 
 exports.create = create;

--- a/lib/js/bytes.js
+++ b/lib/js/bytes.js
@@ -13,7 +13,6 @@ function unsafe_fill(s, i, l, c) {
   for(var k = i ,k_finish = l + i | 0; k < k_finish; ++k){
     s[k] = c;
   }
-  
 }
 
 function unsafe_blit(s1, i1, s2, i2, len) {
@@ -54,7 +53,6 @@ function unsafe_blit(s1, i1, s2, i2, len) {
   for(var i$2 = off1; i$2 < len; ++i$2){
     s2[i2 + i$2 | 0] = /* '\000' */0;
   }
-  
 }
 
 function make(n, c) {
@@ -224,21 +222,18 @@ function blit_string(s1, ofs1, s2, ofs2, len) {
   for(var i$2 = off1; i$2 < len; ++i$2){
     s2[ofs2 + i$2 | 0] = /* '\000' */0;
   }
-  
 }
 
 function iter(f, a) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     Curry._1(f, a[i]);
   }
-  
 }
 
 function iteri(f, a) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     Curry._2(f, i, a[i]);
   }
-  
 }
 
 function ensure_ge(x, y) {

--- a/lib/js/bytesLabels.js
+++ b/lib/js/bytesLabels.js
@@ -13,7 +13,6 @@ function unsafe_fill(s, i, l, c) {
   for(var k = i ,k_finish = l + i | 0; k < k_finish; ++k){
     s[k] = c;
   }
-  
 }
 
 function unsafe_blit(s1, i1, s2, i2, len) {
@@ -54,7 +53,6 @@ function unsafe_blit(s1, i1, s2, i2, len) {
   for(var i$2 = off1; i$2 < len; ++i$2){
     s2[i2 + i$2 | 0] = /* '\000' */0;
   }
-  
 }
 
 function make(n, c) {
@@ -224,21 +222,18 @@ function blit_string(s1, ofs1, s2, ofs2, len) {
   for(var i$2 = off1; i$2 < len; ++i$2){
     s2[ofs2 + i$2 | 0] = /* '\000' */0;
   }
-  
 }
 
 function iter(f, a) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     Curry._1(f, a[i]);
   }
-  
 }
 
 function iteri(f, a) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     Curry._2(f, i, a[i]);
   }
-  
 }
 
 function ensure_ge(x, y) {

--- a/lib/js/caml_array.js
+++ b/lib/js/caml_array.js
@@ -64,7 +64,6 @@ function set(xs, index, newval) {
         };
   }
   xs[index] = newval;
-  
 }
 
 function get(xs, index) {
@@ -104,7 +103,6 @@ function blit(a1, i1, a2, i2, len) {
   for(var j$1 = len - 1 | 0; j$1 >= 0; --j$1){
     a2[j$1 + i2 | 0] = a1[j$1 + i1 | 0];
   }
-  
 }
 
 function dup(prim) {

--- a/lib/js/caml_bytes.js
+++ b/lib/js/caml_bytes.js
@@ -10,7 +10,6 @@ function set(s, i, ch) {
         };
   }
   s[i] = ch;
-  
 }
 
 function get(s, i) {

--- a/lib/js/caml_hash.js
+++ b/lib/js/caml_hash.js
@@ -17,7 +17,6 @@ function push_back(q, v) {
     q.first = cell;
     q.last = cell;
   }
-  
 }
 
 function unsafe_pop(q) {

--- a/lib/js/caml_md5.js
+++ b/lib/js/caml_md5.js
@@ -95,7 +95,6 @@ function cycle(x, k) {
   x[1] = b + x[1] | 0;
   x[2] = c + x[2] | 0;
   x[3] = d + x[3] | 0;
-  
 }
 
 var state = [

--- a/lib/js/dom_storage.js
+++ b/lib/js/dom_storage.js
@@ -8,12 +8,10 @@ function getItem(s, obj) {
 
 function setItem(k, v, obj) {
   obj.setItem(k, v);
-  
 }
 
 function removeItem(s, obj) {
   obj.removeItem(s);
-  
 }
 
 function key(i, obj) {

--- a/lib/js/filename.js
+++ b/lib/js/filename.js
@@ -259,7 +259,6 @@ function quote$1(s) {
     for(var _j = 1; _j <= n; ++_j){
       $$Buffer.add_char(b, /* '\\' */92);
     }
-    
   };
   loop(0);
   return $$Buffer.contents(b);
@@ -453,7 +452,6 @@ var current_temp_dir_name = {
 
 function set_temp_dir_name(s) {
   current_temp_dir_name.contents = s;
-  
 }
 
 function get_temp_dir_name(param) {

--- a/lib/js/genlex.js
+++ b/lib/js/genlex.js
@@ -23,7 +23,6 @@ var bufpos = {
 function reset_buffer(param) {
   buffer.contents = initial_buffer;
   bufpos.contents = 0;
-  
 }
 
 function store(c) {
@@ -34,7 +33,6 @@ function store(c) {
   }
   Caml_bytes.set(buffer.contents, bufpos.contents, c);
   bufpos.contents = bufpos.contents + 1 | 0;
-  
 }
 
 function get_string(param) {

--- a/lib/js/hashtbl.js
+++ b/lib/js/hashtbl.js
@@ -25,7 +25,6 @@ function seeded_hash(seed, x) {
 
 function flip_ongoing_traversal(h) {
   h.initial_size = -h.initial_size | 0;
-  
 }
 
 var randomized = {
@@ -34,7 +33,6 @@ var randomized = {
 
 function randomize(param) {
   randomized.contents = true;
-  
 }
 
 function is_randomized(param) {
@@ -80,7 +78,6 @@ function clear(h) {
   for(var i = 0; i < len; ++i){
     Caml_array.set(h.data, i, /* Empty */0);
   }
-  
 }
 
 function reset(h) {
@@ -206,7 +203,6 @@ function resize(indexfun, h) {
     }
     
   }
-  
 }
 
 function key_index(h, key) {

--- a/lib/js/js_array.js
+++ b/lib/js/js_array.js
@@ -138,12 +138,10 @@ function findIndexi(arg1, obj) {
 
 function forEach(arg1, obj) {
   obj.forEach(Curry.__1(arg1));
-  
 }
 
 function forEachi(arg1, obj) {
   obj.forEach(Curry.__2(arg1));
-  
 }
 
 function map(arg1, obj) {

--- a/lib/js/js_typed_array.js
+++ b/lib/js/js_typed_array.js
@@ -16,12 +16,10 @@ var $$ArrayBuffer = {
 
 function setArray(arg1, obj) {
   obj.set(arg1);
-  
 }
 
 function setArrayOffset(arg1, arg2, obj) {
   obj.set(arg1, arg2);
-  
 }
 
 function copyWithin(to_, obj) {
@@ -126,12 +124,10 @@ function findIndexi(arg1, obj) {
 
 function forEach(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function forEachi(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function map(arg1, obj) {
@@ -208,12 +204,10 @@ var $$Int8Array = {
 
 function setArray$1(arg1, obj) {
   obj.set(arg1);
-  
 }
 
 function setArrayOffset$1(arg1, arg2, obj) {
   obj.set(arg1, arg2);
-  
 }
 
 function copyWithin$1(to_, obj) {
@@ -318,12 +312,10 @@ function findIndexi$1(arg1, obj) {
 
 function forEach$1(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function forEachi$1(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function map$1(arg1, obj) {
@@ -400,12 +392,10 @@ var $$Uint8Array = {
 
 function setArray$2(arg1, obj) {
   obj.set(arg1);
-  
 }
 
 function setArrayOffset$2(arg1, arg2, obj) {
   obj.set(arg1, arg2);
-  
 }
 
 function copyWithin$2(to_, obj) {
@@ -510,12 +500,10 @@ function findIndexi$2(arg1, obj) {
 
 function forEach$2(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function forEachi$2(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function map$2(arg1, obj) {
@@ -592,12 +580,10 @@ var $$Uint8ClampedArray = {
 
 function setArray$3(arg1, obj) {
   obj.set(arg1);
-  
 }
 
 function setArrayOffset$3(arg1, arg2, obj) {
   obj.set(arg1, arg2);
-  
 }
 
 function copyWithin$3(to_, obj) {
@@ -702,12 +688,10 @@ function findIndexi$3(arg1, obj) {
 
 function forEach$3(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function forEachi$3(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function map$3(arg1, obj) {
@@ -784,12 +768,10 @@ var $$Int16Array = {
 
 function setArray$4(arg1, obj) {
   obj.set(arg1);
-  
 }
 
 function setArrayOffset$4(arg1, arg2, obj) {
   obj.set(arg1, arg2);
-  
 }
 
 function copyWithin$4(to_, obj) {
@@ -894,12 +876,10 @@ function findIndexi$4(arg1, obj) {
 
 function forEach$4(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function forEachi$4(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function map$4(arg1, obj) {
@@ -976,12 +956,10 @@ var $$Uint16Array = {
 
 function setArray$5(arg1, obj) {
   obj.set(arg1);
-  
 }
 
 function setArrayOffset$5(arg1, arg2, obj) {
   obj.set(arg1, arg2);
-  
 }
 
 function copyWithin$5(to_, obj) {
@@ -1086,12 +1064,10 @@ function findIndexi$5(arg1, obj) {
 
 function forEach$5(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function forEachi$5(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function map$5(arg1, obj) {
@@ -1168,12 +1144,10 @@ var $$Int32Array = {
 
 function setArray$6(arg1, obj) {
   obj.set(arg1);
-  
 }
 
 function setArrayOffset$6(arg1, arg2, obj) {
   obj.set(arg1, arg2);
-  
 }
 
 function copyWithin$6(to_, obj) {
@@ -1278,12 +1252,10 @@ function findIndexi$6(arg1, obj) {
 
 function forEach$6(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function forEachi$6(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function map$6(arg1, obj) {
@@ -1360,12 +1332,10 @@ var $$Uint32Array = {
 
 function setArray$7(arg1, obj) {
   obj.set(arg1);
-  
 }
 
 function setArrayOffset$7(arg1, arg2, obj) {
   obj.set(arg1, arg2);
-  
 }
 
 function copyWithin$7(to_, obj) {
@@ -1470,12 +1440,10 @@ function findIndexi$7(arg1, obj) {
 
 function forEach$7(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function forEachi$7(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function map$7(arg1, obj) {
@@ -1552,12 +1520,10 @@ var $$Float32Array = {
 
 function setArray$8(arg1, obj) {
   obj.set(arg1);
-  
 }
 
 function setArrayOffset$8(arg1, arg2, obj) {
   obj.set(arg1, arg2);
-  
 }
 
 function copyWithin$8(to_, obj) {
@@ -1662,12 +1628,10 @@ function findIndexi$8(arg1, obj) {
 
 function forEach$8(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function forEachi$8(arg1, obj) {
   obj.forEach(arg1);
-  
 }
 
 function map$8(arg1, obj) {

--- a/lib/js/js_vector.js
+++ b/lib/js/js_vector.js
@@ -13,17 +13,14 @@ function filterInPlace(p, a) {
     i = i + 1 | 0;
   };
   a.splice(j);
-  
 }
 
 function empty(a) {
   a.splice(0);
-  
 }
 
 function pushBack(x, xs) {
   xs.push(x);
-  
 }
 
 function memByRef(x, xs) {
@@ -34,14 +31,12 @@ function iter(f, xs) {
   for(var i = 0 ,i_finish = xs.length; i < i_finish; ++i){
     f(xs[i]);
   }
-  
 }
 
 function iteri(f, a) {
   for(var i = 0 ,i_finish = a.length; i < i_finish; ++i){
     f(i, a[i]);
   }
-  
 }
 
 function toList(a) {

--- a/lib/js/lexing.js
+++ b/lib/js/lexing.js
@@ -82,7 +82,6 @@ function from_function(f) {
               }
               Bytes.blit(partial_arg, 0, param.lex_buffer, param.lex_buffer_len, n);
               param.lex_buffer_len = param.lex_buffer_len + n | 0;
-              
             }),
           lex_buffer: Caml_bytes.create(1024),
           lex_buffer_len: 0,
@@ -102,7 +101,6 @@ function from_string(s) {
   return {
           refill_buff: (function (lexbuf) {
               lexbuf.lex_eof_reached = true;
-              
             }),
           lex_buffer: Bytes.of_string(s),
           lex_buffer_len: s.length,
@@ -175,7 +173,6 @@ function new_line(lexbuf) {
     pos_bol: lcp.pos_cnum,
     pos_cnum: lcp.pos_cnum
   };
-  
 }
 
 function flush_input(lb) {
@@ -189,7 +186,6 @@ function flush_input(lb) {
     pos_cnum: 0
   };
   lb.lex_buffer_len = 0;
-  
 }
 
 var dummy_pos = {

--- a/lib/js/node_process.js
+++ b/lib/js/node_process.js
@@ -5,7 +5,6 @@ var Process = require("process");
 
 function putEnvVar(key, $$var) {
   Process.env[key] = $$var;
-  
 }
 
 function deleteEnvVar(s) {

--- a/lib/js/parsing.js
+++ b/lib/js/parsing.js
@@ -48,13 +48,11 @@ function grow_stacks(param) {
   $$Array.blit(env.symb_end_stack, 0, new_end, 0, oldsize);
   env.symb_end_stack = new_end;
   env.stacksize = newsize;
-  
 }
 
 function clear_parser(param) {
   $$Array.fill(env.v_stack, 0, env.stacksize, undefined);
   env.lval = undefined;
-  
 }
 
 var current_lookahead_fun = {

--- a/lib/js/pervasives.js
+++ b/lib/js/pervasives.js
@@ -167,27 +167,22 @@ function $at(l1, l2) {
 
 function print_newline(param) {
   console.log("");
-  
 }
 
 function prerr_newline(param) {
   console.error("");
-  
 }
 
 function print_int(i) {
   console.log(String(i));
-  
 }
 
 function print_float(i) {
   console.log(valid_float_lexem(Caml_format.format_float("%.12g", i)));
-  
 }
 
 function print_string(prim) {
   console.log(prim);
-  
 }
 
 var exit_function = {
@@ -202,7 +197,6 @@ function at_exit(f) {
       Curry._1(f, undefined);
       return Curry._1(g, undefined);
     });
-  
 }
 
 function exit(retcode) {

--- a/lib/js/printexc.js
+++ b/lib/js/printexc.js
@@ -97,7 +97,6 @@ function register_printer(fn) {
     hd: fn,
     tl: printers.contents
   };
-  
 }
 
 exports.to_string = to_string;

--- a/lib/js/queue.js
+++ b/lib/js/queue.js
@@ -17,7 +17,6 @@ function clear(q) {
   q.length = 0;
   q.first = /* Nil */0;
   q.last = /* Nil */0;
-  
 }
 
 function add(x, q) {
@@ -35,7 +34,6 @@ function add(x, q) {
     q.first = cell;
     q.last = cell;
   }
-  
 }
 
 function peek(q) {

--- a/lib/js/random.js
+++ b/lib/js/random.js
@@ -16,7 +16,6 @@ function random_seed(param) {
 function assign(st1, st2) {
   $$Array.blit(st2.st, 0, st1.st, 0, 55);
   st1.idx = st2.idx;
-  
 }
 
 function full_init(s, seed) {
@@ -41,7 +40,6 @@ function full_init(s, seed) {
     Caml_array.set(s.st, j, (Caml_array.get(s.st, j) ^ extract(accu)) & 1073741823);
   }
   s.idx = 0;
-  
 }
 
 function make(seed) {

--- a/lib/js/sort.js
+++ b/lib/js/sort.js
@@ -90,7 +90,6 @@ function swap(arr, i, j) {
   var tmp = arr[i];
   arr[i] = arr[j];
   arr[j] = tmp;
-  
 }
 
 function array(cmp, arr) {
@@ -159,7 +158,6 @@ function array(cmp, arr) {
     }
     
   }
-  
 }
 
 exports.list = list;

--- a/lib/js/stack.js
+++ b/lib/js/stack.js
@@ -15,7 +15,6 @@ function create(param) {
 function clear(s) {
   s.c = /* [] */0;
   s.len = 0;
-  
 }
 
 function copy(s) {
@@ -31,7 +30,6 @@ function push(x, s) {
     tl: s.c
   };
   s.len = s.len + 1 | 0;
-  
 }
 
 function pop(s) {

--- a/lib/js/stream.js
+++ b/lib/js/stream.js
@@ -465,7 +465,6 @@ function dump(f, s) {
   dump_data(f, data(s));
   console.log("}");
   console.log("");
-  
 }
 
 var sempty;

--- a/lib/js/string.js
+++ b/lib/js/string.js
@@ -23,14 +23,12 @@ function iter(f, s) {
   for(var i = 0 ,i_finish = s.length; i < i_finish; ++i){
     Curry._1(f, s.codePointAt(i));
   }
-  
 }
 
 function iteri(f, s) {
   for(var i = 0 ,i_finish = s.length; i < i_finish; ++i){
     Curry._2(f, i, s.codePointAt(i));
   }
-  
 }
 
 function map(f, s) {

--- a/lib/js/stringLabels.js
+++ b/lib/js/stringLabels.js
@@ -25,14 +25,12 @@ function iter(f, s) {
   for(var i = 0 ,i_finish = s.length; i < i_finish; ++i){
     Curry._1(f, s.codePointAt(i));
   }
-  
 }
 
 function iteri(f, s) {
   for(var i = 0 ,i_finish = s.length; i < i_finish; ++i){
     Curry._2(f, i, s.codePointAt(i));
   }
-  
 }
 
 function map(f, s) {


### PR DESCRIPTION
- remove a never-hit ++/--/+= peephole
- format
- tweak
- add at_least_two_lines API
- use the new API
- fix force_newline
- avoid empty line in `return undefined`
- snapshot js
- snapshot
