### PR TITLE
Revert "circleci: enable .git directory caching"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,32 +5,26 @@ jobs: # a collection of steps
     docker: # run the steps with Docker
       - image: circleci/node:dubnium # ...with this image as the primary container; this is where all `steps` will run
     steps: # a collection of executable commands
-      - restore_cache: # try to restore .git folder from cache to speed up checkout
-          keys:
-            - source-v1-{{ .Branch }}-{{ .Revision }}
-            - source-v1-{{ .Branch }}-
-            - source-v1-
       - checkout # special step to check out source code to working directory
-      - run:
-          name: "Pull git submodules"
-          command: |
-            git submodule sync
-            git submodule update --init
-      - save_cache: # write .git folder to cache
-          key: source-v1-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - ".git"
-            
       - run:       
-          name: "Set environment variables"
+          name: "Setting env variables"
           command: |
             echo 'export BS_TRAVIS_CI=1' >> $BASH_ENV
             echo 'export NINJA_FORCE_REBUILD=1' >> $BASH_ENV
             echo 'export OCAMLRUNPARAM="b"' >> $BASH_ENV
       - run:    
-          name: "Check environment variables"
+          name: "Check env variables"
           command: |
             echo BS_TRAVIS_CI ${BS_TRAVIS_CI}
+      - run:
+          name: "Pull Submodules"
+          command: |
+            git submodule init
+            git submodule update
+      - run:
+          name: ci-install
+          command: npm ci # `npm ci` is not available on node v8
 
-      - run: npm ci # `npm ci` is not available on node v8
-      - run: npm test
+      - run: # run tests
+          name: test
+          command: npm test


### PR DESCRIPTION
Reverts rescript-lang/rescript-compiler#5182

check the speed difference.

The current status:
10m 16s / 13h ago

cc @Minnozz 

without the cache, it is 8m 53s, the majority of the CI time is spent in `git checout ` and building the ocaml compiler