### PR TITLE
Use Object.prototype.hasOwnProperty.call(a, b) instead of a.hasOwnProperty(b)

### DIFF
--- a/jscomp/runtime/caml_obj.ml
+++ b/jscomp/runtime/caml_obj.ml
@@ -37,6 +37,14 @@ module O = struct
     [%raw{|function(o,foo){
         for (var x in o) { foo(x) }}
       |}]
+  
+  (** 
+     JS objects are not guaranteed to have `Object` in their prototype
+     chain so calling `some_obj.hasOwnProperty(key)` can sometimes throw
+     an exception when dealing with JS interop. This mainly occurs when
+     objects are created via `Object.create(null)`. The only safe way
+     to call this function is directly, e.g. `Object.prototype.hasOwnProperty.call(some_obj, key)`.
+  *)
   external hasOwnProperty :    
     t -> key -> bool = "call" [@@bs.scope ("Object", "prototype", "hasOwnProperty")] [@@bs.val] 
   external get_value : Obj.t -> key -> Obj.t = ""[@@bs.get_index]

--- a/jscomp/runtime/caml_obj.ml
+++ b/jscomp/runtime/caml_obj.ml
@@ -38,7 +38,7 @@ module O = struct
         for (var x in o) { foo(x) }}
       |}]
   external hasOwnProperty :    
-    t -> key -> bool = "hasOwnProperty" [@@bs.send]
+    t -> key -> bool = "call" [@@bs.scope ("Object", "prototype", "hasOwnProperty")] [@@bs.val] 
   external get_value : Obj.t -> key -> Obj.t = ""[@@bs.get_index]
 
 end

--- a/jscomp/test/caml_compare_test.js
+++ b/jscomp/test/caml_compare_test.js
@@ -987,77 +987,89 @@ var suites = {
                                                                                             ],
                                                                                             tl: {
                                                                                               hd: [
-                                                                                                "File \"caml_compare_test.ml\", line 87, characters 4-11",
+                                                                                                "eq_no_prototype",
                                                                                                 (function (param) {
                                                                                                     return {
                                                                                                             TAG: /* Eq */0,
-                                                                                                            _0: Caml_obj.compare(null, {
-                                                                                                                  hd: 3,
-                                                                                                                  tl: /* [] */0
-                                                                                                                }),
-                                                                                                            _1: -1
+                                                                                                            _0: Caml_obj.equal({x:1}, ((function(){let o = Object.create(null);o.x = 1;return o;})())),
+                                                                                                            _1: true
                                                                                                           };
                                                                                                   })
                                                                                               ],
                                                                                               tl: {
                                                                                                 hd: [
-                                                                                                  "File \"caml_compare_test.ml\", line 90, characters 4-11",
+                                                                                                  "File \"caml_compare_test.ml\", line 88, characters 4-11",
                                                                                                   (function (param) {
                                                                                                       return {
                                                                                                               TAG: /* Eq */0,
-                                                                                                              _0: Caml_obj.compare({
+                                                                                                              _0: Caml_obj.compare(null, {
                                                                                                                     hd: 3,
                                                                                                                     tl: /* [] */0
-                                                                                                                  }, null),
-                                                                                                              _1: 1
+                                                                                                                  }),
+                                                                                                              _1: -1
                                                                                                             };
                                                                                                     })
                                                                                                 ],
                                                                                                 tl: {
                                                                                                   hd: [
-                                                                                                    "File \"caml_compare_test.ml\", line 93, characters 4-11",
+                                                                                                    "File \"caml_compare_test.ml\", line 91, characters 4-11",
                                                                                                     (function (param) {
                                                                                                         return {
                                                                                                                 TAG: /* Eq */0,
-                                                                                                                _0: Caml_obj.compare(null, 0),
-                                                                                                                _1: -1
+                                                                                                                _0: Caml_obj.compare({
+                                                                                                                      hd: 3,
+                                                                                                                      tl: /* [] */0
+                                                                                                                    }, null),
+                                                                                                                _1: 1
                                                                                                               };
                                                                                                       })
                                                                                                   ],
                                                                                                   tl: {
                                                                                                     hd: [
-                                                                                                      "File \"caml_compare_test.ml\", line 96, characters 4-11",
+                                                                                                      "File \"caml_compare_test.ml\", line 94, characters 4-11",
                                                                                                       (function (param) {
                                                                                                           return {
                                                                                                                   TAG: /* Eq */0,
-                                                                                                                  _0: Caml_obj.compare(0, null),
-                                                                                                                  _1: 1
+                                                                                                                  _0: Caml_obj.compare(null, 0),
+                                                                                                                  _1: -1
                                                                                                                 };
                                                                                                         })
                                                                                                     ],
                                                                                                     tl: {
                                                                                                       hd: [
-                                                                                                        "File \"caml_compare_test.ml\", line 99, characters 4-11",
+                                                                                                        "File \"caml_compare_test.ml\", line 97, characters 4-11",
                                                                                                         (function (param) {
                                                                                                             return {
                                                                                                                     TAG: /* Eq */0,
-                                                                                                                    _0: Caml_obj.compare(undefined, 0),
-                                                                                                                    _1: -1
+                                                                                                                    _0: Caml_obj.compare(0, null),
+                                                                                                                    _1: 1
                                                                                                                   };
                                                                                                           })
                                                                                                       ],
                                                                                                       tl: {
                                                                                                         hd: [
-                                                                                                          "File \"caml_compare_test.ml\", line 102, characters 4-11",
+                                                                                                          "File \"caml_compare_test.ml\", line 100, characters 4-11",
                                                                                                           (function (param) {
                                                                                                               return {
                                                                                                                       TAG: /* Eq */0,
-                                                                                                                      _0: Caml_obj.compare(0, undefined),
-                                                                                                                      _1: 1
+                                                                                                                      _0: Caml_obj.compare(undefined, 0),
+                                                                                                                      _1: -1
                                                                                                                     };
                                                                                                             })
                                                                                                         ],
-                                                                                                        tl: /* [] */0
+                                                                                                        tl: {
+                                                                                                          hd: [
+                                                                                                            "File \"caml_compare_test.ml\", line 103, characters 4-11",
+                                                                                                            (function (param) {
+                                                                                                                return {
+                                                                                                                        TAG: /* Eq */0,
+                                                                                                                        _0: Caml_obj.compare(0, undefined),
+                                                                                                                        _1: 1
+                                                                                                                      };
+                                                                                                              })
+                                                                                                          ],
+                                                                                                          tl: /* [] */0
+                                                                                                        }
                                                                                                       }
                                                                                                     }
                                                                                                   }
@@ -1119,21 +1131,21 @@ function eq(loc, x, y) {
   Mt.eq_suites(test_id, suites, loc, x, y);
 }
 
-eq("File \"caml_compare_test.ml\", line 112, characters 6-13", true, Caml_obj.greaterthan(1, undefined));
+eq("File \"caml_compare_test.ml\", line 113, characters 6-13", true, Caml_obj.greaterthan(1, undefined));
 
-eq("File \"caml_compare_test.ml\", line 113, characters 6-13", true, Caml_obj.lessthan(/* [] */0, {
+eq("File \"caml_compare_test.ml\", line 114, characters 6-13", true, Caml_obj.lessthan(/* [] */0, {
           hd: 1,
           tl: /* [] */0
         }));
 
-eq("File \"caml_compare_test.ml\", line 114, characters 6-13", false, Caml_obj.greaterthan(undefined, 1));
+eq("File \"caml_compare_test.ml\", line 115, characters 6-13", false, Caml_obj.greaterthan(undefined, 1));
 
-eq("File \"caml_compare_test.ml\", line 115, characters 6-13", false, Caml_obj.greaterthan(undefined, [
+eq("File \"caml_compare_test.ml\", line 116, characters 6-13", false, Caml_obj.greaterthan(undefined, [
           1,
           30
         ]));
 
-eq("File \"caml_compare_test.ml\", line 116, characters 6-13", false, Caml_obj.lessthan([
+eq("File \"caml_compare_test.ml\", line 117, characters 6-13", false, Caml_obj.lessthan([
           1,
           30
         ], undefined));

--- a/jscomp/test/caml_compare_test.ml
+++ b/jscomp/test/caml_compare_test.ml
@@ -83,6 +83,7 @@ let suites = ref Mt.[
     "eq_in_list2", (fun _ -> Eq ([[%bs.obj {x=2}]] = [[%bs.obj {x=2}]], true));
     "eq_with_list", (fun _ -> Eq ([%bs.obj {x=[0]}] = [%bs.obj {x=[0]}], true));
     "eq_with_list2", (fun _ -> Eq ([%bs.obj {x=[0]}] = [%bs.obj {x=[1]}], false));
+    "eq_no_prototype", (fun _ -> Eq ([%bs.raw "{x:1}"] = [%bs.raw "(function(){let o = Object.create(null);o.x = 1;return o;})()"], true));
 
     __LOC__ , begin fun _ ->
         Eq(compare Js.null (Js.Null.return [3]), -1)

--- a/lib/es6/caml_obj.js
+++ b/lib/es6/caml_obj.js
@@ -209,7 +209,7 @@ function aux_obj_compare(a, b) {
   var do_key = function (param, key) {
     var min_key = param[2];
     var b = param[1];
-    if (!(!b.hasOwnProperty(key) || compare(param[0][key], b[key]) > 0)) {
+    if (!(!Object.prototype.hasOwnProperty.call(b, key) || compare(param[0][key], b[key]) > 0)) {
       return ;
     }
     var mk = min_key.contents;
@@ -310,14 +310,14 @@ function equal(a, b) {
         contents: true
       };
       var do_key_a = function (key) {
-        if (!b.hasOwnProperty(key)) {
+        if (!Object.prototype.hasOwnProperty.call(b, key)) {
           result.contents = false;
           return ;
         }
         
       };
       var do_key_b = function (key) {
-        if (!a.hasOwnProperty(key) || !equal(b[key], a[key])) {
+        if (!Object.prototype.hasOwnProperty.call(a, key) || !equal(b[key], a[key])) {
           result.contents = false;
           return ;
         }

--- a/lib/js/caml_obj.js
+++ b/lib/js/caml_obj.js
@@ -209,7 +209,7 @@ function aux_obj_compare(a, b) {
   var do_key = function (param, key) {
     var min_key = param[2];
     var b = param[1];
-    if (!(!b.hasOwnProperty(key) || compare(param[0][key], b[key]) > 0)) {
+    if (!(!Object.prototype.hasOwnProperty.call(b, key) || compare(param[0][key], b[key]) > 0)) {
       return ;
     }
     var mk = min_key.contents;
@@ -310,14 +310,14 @@ function equal(a, b) {
         contents: true
       };
       var do_key_a = function (key) {
-        if (!b.hasOwnProperty(key)) {
+        if (!Object.prototype.hasOwnProperty.call(b, key)) {
           result.contents = false;
           return ;
         }
         
       };
       var do_key_b = function (key) {
-        if (!a.hasOwnProperty(key) || !equal(b[key], a[key])) {
+        if (!Object.prototype.hasOwnProperty.call(a, key) || !equal(b[key], a[key])) {
           result.contents = false;
           return ;
         }


### PR DESCRIPTION
Resolves https://github.com/rescript-lang/rescript-compiler/issues/5357

This is my first contribution to the project so apologies if I've checked in the wrong files or there is some other changes that need to be made. Let me know and I'll adjust the PR accordingly.