### PR TITLE
Add Github actions workflow to run build and tests on multiple platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        # Omit Windows build for now as it is unstable / not deterministic.
+        # os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest]
+
+    runs-on: ${{matrix.os}}
+
+    env:
+      BS_TRAVIS_CI: 1
+      NINJA_FORCE_REBUILD: 1
+      OCAMLRUNPARAM: b
+
+    steps:
+    - name: "Windows: Set git to use LF"
+      if: runner.os == 'Windows'
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
+
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Use OCaml 4.14.0
+      uses: ocaml/setup-ocaml@v2
+      with:
+        ocaml-compiler: 4.14.0
+        opam-pin: false
+        opam-depext: false
+
+    - name: Use Node.js
+      uses: actions/setup-node@v2.1.5
+      with:
+        node-version: 16
+
+    - name: ci-install
+      run: opam exec -- npm ci
+
+    - name: Run tests (macOS)
+      if: runner.os == 'macOS'
+      run: opam exec -- node scripts/ciTest.js -all
+    
+    - name: Run tests (Linux)
+      if: runner.os == 'Linux'
+      run: opam exec -- node scripts/ciTest.js -install-global -ounit -mocha -theme

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test-bsb": "node scripts/ciTest.js -bsb",
     "test-ocaml": "node scripts/ciTest.js -ounit",
     "postinstall": "node scripts/install.js",
-    "test-env-comipler": "BS_TRAVIS_CI=1 node scripts/install.js -use-env-compiler",
+    "test-env-compiler": "BS_TRAVIS_CI=1 node scripts/install.js -use-env-compiler",
     "coverage": "nyc --timeout=3000 --reporter=html mocha jscomp/test/*test.js && open ./coverage/index.html"
   },
   "version": "10.0.0",

--- a/scripts/buildocaml.js
+++ b/scripts/buildocaml.js
@@ -58,7 +58,7 @@ function build(config) {
   if (config) {
     var { make } = require("./config.js");
     cp.execSync(
-      './configure  --disable-naked-pointers --enable-flambda -prefix ' +
+      "bash ./configure --disable-naked-pointers --enable-flambda -prefix " +
         prefix +
         ` && ${make} clean`,
       { cwd: ocamlSrcDir, stdio: [0, 1, 2] }

--- a/scripts/ciTest.js
+++ b/scripts/ciTest.js
@@ -93,7 +93,7 @@ function runTests() {
       }
     );
 
-    cp.execSync(`./test.exe`, { cwd: binDir, stdio: [0, 1, 2] });
+    cp.execSync(path.join(binDir, 'test.exe'), { cwd: binDir, stdio: [0, 1, 2] });
   }
 
   // running generated js tests

--- a/scripts/ciTest.js
+++ b/scripts/ciTest.js
@@ -98,7 +98,7 @@ function runTests() {
 
   // running generated js tests
   if (mochaTest) {
-    cp.execSync(`mocha jscomp/test/**/*test.js`, {
+    cp.execSync(`./node_modules/.bin/mocha jscomp/test/**/*test.js`, {
       cwd: path.join(__dirname, ".."),
       stdio: [0, 1, 2],
     });

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -30,6 +30,7 @@ var my_target =
     : process.platform;
 var bin_path = path.join(root_dir, my_target);
 
+var ninja_bin_filename = process.platform === "win32" ? "ninja.exe" : "ninja";
 var ninja_bin_output = path.join(bin_path, "ninja.exe");
 
 var force_compiler_rebuild = process.argv.includes("-force-compiler-rebuild");
@@ -56,11 +57,11 @@ function provideNinja() {
         cwd: ninja_source_dir,
         stdio: [0, 1, 2],
       });
-      fs.copyFileSync(path.join(ninja_source_dir, "ninja"), ninja_bin_output);
+      fs.copyFileSync(path.join(ninja_source_dir, ninja_bin_filename), ninja_bin_output);
     } else {
       console.log(`ninja.tar.gz not availble in CI mode`);
       require("../ninja/snapshot").build();
-      fs.copyFileSync(path.join(root_dir, "ninja", "ninja"), ninja_bin_output);
+      fs.copyFileSync(path.join(root_dir, "ninja", ninja_bin_filename), ninja_bin_output);
     }
 
     console.log("ninja binary is ready: ", ninja_bin_output);

--- a/scripts/ninjaFactory.js
+++ b/scripts/ninjaFactory.js
@@ -19,7 +19,7 @@ var targetDir = process.platform === 'darwin' && process.arch === 'arm64' ? proc
  */
 function libNinja(config) {
   return `
-ocamlopt = ${config.ocamlopt}
+ocamlopt = ${config.ocamlopt}${config.isWin ? ".exe" : ""}
 ext = .exe
 INCL = ${config.INCL}
 flags = -nodynlink -I $INCL -g -w -a ../jscomp/stubs/ext_basic_hash_stubs.c

--- a/scripts/prebuilt.js
+++ b/scripts/prebuilt.js
@@ -61,10 +61,9 @@ function buildCompiler() {
   // delete process.env.OCAMLLIB
   var prebuilt = "prebuilt.ninja";
   var content = require("./ninjaFactory.js").libNinja({
-    ocamlopt: is_windows
-      ? `ocamlopt.opt.exe` :
-      (use_env_compiler ? `ocamlopt.opt`
-        : `../native/${ocamlVersion}/bin/ocamlopt.opt`),
+    ocamlopt: use_env_compiler
+      ? `ocamlopt.opt`
+      : `../native/${ocamlVersion}/bin/ocamlopt.opt`,
     INCL: ocamlVersion,
     isWin: is_windows,
   });


### PR DESCRIPTION
This is based on #5372 from @cristianoc.

I spent a lot of time trying to get the build and tests to run on macOS, Linux and Windows and only partially succeeded.

I am using the `ocaml/setup-ocaml@v2` action to provide the latest OCaml version 4.14.0 for the build.

Status:
* macOS: build and all tests are working 🎉
* Linux: build is working, and all tests except for the ones run by the `-bsb` option to `ciTest.js` are working, so I disabled this option for now. (The problem with this option is that `npm link rescript` fails for some reason.)
* Windows: If I disable `NINJA_FORCE_REBUILD`, then I can get the Windows build to work sometimes, but most of the time it fails with `Unbound module Obj` when compiling `stdlib-406/printexc.ml`. I was not able to find the reason and have therefore disabled Windows for now.

This PR also includes various fixes to some scripts that I had to make for the Windows build, plus a fix for a typo in package.json.

I think this could be merged as it is now, and the remaining Linux test issue and the Windows issues could be ironed out in future PRs.