### PR TITLE
Github actions: Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
 
     env:
       BS_TRAVIS_CI: 1
-      NINJA_FORCE_REBUILD: 1
       OCAMLRUNPARAM: b
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Omit Windows build for now as it is unstable / not deterministic.
-        # os: [macos-latest, ubuntu-latest, windows-latest]
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,7 @@ jobs:
     - name: Run tests (Linux)
       if: runner.os == 'Linux'
       run: opam exec -- node scripts/ciTest.js -install-global -ounit -mocha -theme
+    
+    - name: Run tests (Windows)
+      if: runner.os == 'Windows'
+      run: opam exec -- node scripts/ciTest.js -mocha -theme

--- a/jscomp/test/a_filename_test.js
+++ b/jscomp/test/a_filename_test.js
@@ -33,101 +33,92 @@ function test(param, param$1) {
   return Ext_filename_test.node_relative_path(true, param, param$1);
 }
 
-eq("File \"a_filename_test.ml\", line 10, characters 5-12", [
-      Ext_filename_test.combine("/tmp", "subdir/file.txt"),
-      Ext_filename_test.combine("/tmp", "/a/tmp.txt"),
-      Ext_filename_test.combine("/a/tmp.txt", "subdir/file.txt")
-    ], [
-      "/tmp/subdir/file.txt",
-      "/a/tmp.txt",
-      "/a/tmp.txt/subdir/file.txt"
-    ]);
-
-eq("File \"a_filename_test.ml\", line 22, characters 5-12", Ext_filename_test.node_relative_path(true, {
-          NAME: "File",
-          VAL: "./a/b.c"
-        }, {
-          NAME: "File",
-          VAL: "./a/u/g.c"
-        }), "./u/g.c");
-
-eq("File \"a_filename_test.ml\", line 27, characters 5-12", Ext_filename_test.node_relative_path(true, {
-          NAME: "File",
-          VAL: "./a/b.c"
-        }, {
-          NAME: "File",
-          VAL: "xxxghsoghos/ghsoghso/node_modules/buckle-stdlib/list.js"
-        }), "buckle-stdlib/list.js");
-
-eq("File \"a_filename_test.ml\", line 33, characters 5-12", Ext_filename_test.node_relative_path(true, {
-          NAME: "File",
-          VAL: "./a/b.c"
-        }, {
-          NAME: "File",
-          VAL: "xxxghsoghos/ghsoghso/node_modules//buckle-stdlib/list.js"
-        }), "buckle-stdlib/list.js");
-
-eq("File \"a_filename_test.ml\", line 39, characters 5-12", Ext_filename_test.node_relative_path(true, {
-          NAME: "File",
-          VAL: "./a/b.c"
-        }, {
-          NAME: "File",
-          VAL: "xxxghsoghos/ghsoghso/node_modules/./buckle-stdlib/list.js"
-        }), "buckle-stdlib/list.js");
-
-eq("File \"a_filename_test.ml\", line 45, characters 5-12", Ext_filename_test.node_relative_path(true, {
-          NAME: "File",
-          VAL: "./a/c.js"
-        }, {
-          NAME: "File",
-          VAL: "./a/b"
-        }), "./b");
-
-eq("File \"a_filename_test.ml\", line 50, characters 5-12", Ext_filename_test.node_relative_path(true, {
-          NAME: "File",
-          VAL: "./a/c"
-        }, {
-          NAME: "File",
-          VAL: "./a/b.js"
-        }), "./b.js");
-
-eq("File \"a_filename_test.ml\", line 55, characters 5-12", Ext_filename_test.node_relative_path(true, {
-          NAME: "Dir",
-          VAL: "./a/"
-        }, {
-          NAME: "File",
-          VAL: "./a/b.js"
-        }), "./b.js");
-
-eq("File \"a_filename_test.ml\", line 60, characters 5-12", Ext_filename_test.get_extension("a.txt"), ".txt");
-
-eq("File \"a_filename_test.ml\", line 64, characters 5-12", Ext_filename_test.get_extension("a"), "");
-
-eq("File \"a_filename_test.ml\", line 68, characters 5-12", Ext_filename_test.get_extension(".txt"), ".txt");
-
-eq("File \"a_filename_test.ml\", line 73, characters 5-12", $$Array.map(Ext_filename_test.normalize_absolute_path, [
-          "/gsho/./..",
-          "/a/b/../c../d/e/f",
-          "/a/b/../c/../d/e/f",
-          "/gsho/./../..",
-          "/a/b/c/d",
-          "/a/b/c/d/",
-          "/a/",
-          "/a",
-          "/a.txt/",
-          "/a.txt"
-        ]), [
-      "/",
-      "/a/c../d/e/f",
-      "/a/d/e/f",
-      "/",
-      "/a/b/c/d",
-      "/a/b/c/d",
-      "/a",
-      "/a",
-      "/a.txt",
-      "/a.txt"
-    ]);
+if (process.platform !== "win32") {
+  eq("File \"a_filename_test.ml\", line 15, characters 5-12", [
+        Ext_filename_test.combine("/tmp", "subdir/file.txt"),
+        Ext_filename_test.combine("/tmp", "/a/tmp.txt"),
+        Ext_filename_test.combine("/a/tmp.txt", "subdir/file.txt")
+      ], [
+        "/tmp/subdir/file.txt",
+        "/a/tmp.txt",
+        "/a/tmp.txt/subdir/file.txt"
+      ]);
+  eq("File \"a_filename_test.ml\", line 27, characters 5-12", Ext_filename_test.node_relative_path(true, {
+            NAME: "File",
+            VAL: "./a/b.c"
+          }, {
+            NAME: "File",
+            VAL: "./a/u/g.c"
+          }), "./u/g.c");
+  eq("File \"a_filename_test.ml\", line 32, characters 5-12", Ext_filename_test.node_relative_path(true, {
+            NAME: "File",
+            VAL: "./a/b.c"
+          }, {
+            NAME: "File",
+            VAL: "xxxghsoghos/ghsoghso/node_modules/buckle-stdlib/list.js"
+          }), "buckle-stdlib/list.js");
+  eq("File \"a_filename_test.ml\", line 38, characters 5-12", Ext_filename_test.node_relative_path(true, {
+            NAME: "File",
+            VAL: "./a/b.c"
+          }, {
+            NAME: "File",
+            VAL: "xxxghsoghos/ghsoghso/node_modules//buckle-stdlib/list.js"
+          }), "buckle-stdlib/list.js");
+  eq("File \"a_filename_test.ml\", line 44, characters 5-12", Ext_filename_test.node_relative_path(true, {
+            NAME: "File",
+            VAL: "./a/b.c"
+          }, {
+            NAME: "File",
+            VAL: "xxxghsoghos/ghsoghso/node_modules/./buckle-stdlib/list.js"
+          }), "buckle-stdlib/list.js");
+  eq("File \"a_filename_test.ml\", line 50, characters 5-12", Ext_filename_test.node_relative_path(true, {
+            NAME: "File",
+            VAL: "./a/c.js"
+          }, {
+            NAME: "File",
+            VAL: "./a/b"
+          }), "./b");
+  eq("File \"a_filename_test.ml\", line 55, characters 5-12", Ext_filename_test.node_relative_path(true, {
+            NAME: "File",
+            VAL: "./a/c"
+          }, {
+            NAME: "File",
+            VAL: "./a/b.js"
+          }), "./b.js");
+  eq("File \"a_filename_test.ml\", line 60, characters 5-12", Ext_filename_test.node_relative_path(true, {
+            NAME: "Dir",
+            VAL: "./a/"
+          }, {
+            NAME: "File",
+            VAL: "./a/b.js"
+          }), "./b.js");
+  eq("File \"a_filename_test.ml\", line 65, characters 5-12", Ext_filename_test.get_extension("a.txt"), ".txt");
+  eq("File \"a_filename_test.ml\", line 69, characters 5-12", Ext_filename_test.get_extension("a"), "");
+  eq("File \"a_filename_test.ml\", line 73, characters 5-12", Ext_filename_test.get_extension(".txt"), ".txt");
+  eq("File \"a_filename_test.ml\", line 78, characters 5-12", $$Array.map(Ext_filename_test.normalize_absolute_path, [
+            "/gsho/./..",
+            "/a/b/../c../d/e/f",
+            "/a/b/../c/../d/e/f",
+            "/gsho/./../..",
+            "/a/b/c/d",
+            "/a/b/c/d/",
+            "/a/",
+            "/a",
+            "/a.txt/",
+            "/a.txt"
+          ]), [
+        "/",
+        "/a/c../d/e/f",
+        "/a/d/e/f",
+        "/",
+        "/a/b/c/d",
+        "/a/b/c/d",
+        "/a",
+        "/a",
+        "/a.txt",
+        "/a.txt"
+      ]);
+}
 
 Mt.from_pair_suites("A_filename_test", suites.contents);
 

--- a/jscomp/test/a_filename_test.ml
+++ b/jscomp/test/a_filename_test.ml
@@ -1,3 +1,6 @@
+external platform : [ `aix  | `darwin  | `freebsd  | `linux  | `openbsd  | `sunos  | `win32 ]
+  = "platform" [@@var] [@@scope "process"]
+
 let suites :  Mt.pair_suites ref  = ref []
 let test_id = ref 0
 let eq loc x y = 
@@ -7,6 +10,8 @@ let eq loc x y =
 
 let test = Ext_filename_test.node_relative_path true 
 let () =
+  (* TODO: adapt these tests to run on Windows. *)
+  if platform != `win32 then (
   eq __LOC__ 
     (let (//) = Ext_filename_test.combine in 
      ("/tmp"// "subdir/file.txt",
@@ -97,6 +102,7 @@ let () =
        "/a.txt"
      |] 
   ;
+  )
 
   
 

--- a/scripts/ciTest.js
+++ b/scripts/ciTest.js
@@ -98,7 +98,7 @@ function runTests() {
 
   // running generated js tests
   if (mochaTest) {
-    cp.execSync(`./node_modules/.bin/mocha jscomp/test/**/*test.js`, {
+    cp.execSync(`npx mocha jscomp/test/**/*test.js`, {
       cwd: path.join(__dirname, ".."),
       stdio: [0, 1, 2],
     });


### PR DESCRIPTION
This PR adds the CI build for Windows.

* ~~For building ninja from source, the configure script was looking for the MSVC compiler which is not present on the Github action runners. However, MinGW is there by default, so I changed the install script to use the `mingw` platform for Windows instead.~~ Using the vendored ninja binaries now.
* There was an issue with `stdlib-406/printexc.ml` not compiling because it contained a template string which causes an indirect reference to `Obj.magic` via some AST transformation, and `obj.ml` is not necessarily built before `printexc.ml`. ~~As a quick/easy fix, I changed the template string to string concatenations.~~ Fixed in #5388.
* Only a subset of the tests is working for Windows now, so I disabled the rest. One problem here are the filename tests because of the different file separator on Windows.

I suggest that we merge this and try to get more tests working on Windows in future PRs.

See also #5384 for more discussion.