### PR TITLE
Fix build dependency issue with curry.ml

### DIFF
--- a/jscomp/runtime/curry.ml
+++ b/jscomp/runtime/curry.ml
@@ -27,6 +27,7 @@
 external function_length : 'a -> int = "#function_length"
 external apply_args : ('a -> 'b) -> _ array -> 'b = "#apply"
 
+let _ = Caml_array.sub (* make the build dependency on Caml_array explicit *)
 let%private sub = Caml_array.sub
 (* Public *)
 let rec app f args = 


### PR DESCRIPTION
The dependency on `Caml_array` is not picked up because of `let%private` and a clean build fails from time to time.