### PR TITLE
Transform "NonEscapeCharacter" in Ast_utf8_string correct.

### DIFF
--- a/jscomp/ounit_tests/ounit_unicode_tests.ml
+++ b/jscomp/ounit_tests/ounit_unicode_tests.ml
@@ -48,6 +48,9 @@ let suites =
             "\\n" =~ "\\n"
         end;
         __LOC__ >:: begin fun _ ->
+            Ast_utf8_string.transform_test {|\h\e\l\lo \"world\"!|} =~ {|\h\e\l\lo \"world\"!|}
+        end;
+        __LOC__ >:: begin fun _ ->
             Ast_utf8_string.transform_test "\\u{1d306}" =~ "\\u{1d306}"
         end;
         __LOC__ >:: begin fun _ ->


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/syntax/issues/473

The [ecmascript spec](https://tc39.es/ecma262/#prod-CharacterEscapeSequence) states that both `SingleEscapeCharacter` and `NonEscapeCharacter` are valid escape sequences.
Previously escape sequences containing a `NonEscapeCharacter`, any regular char like `a` in`\a`, would throw the "Invalid escape code" error.
ReScript strings should have the same semantics as JS.

See [webkit](https://github.com/WebKit/WebKit/blob/263cfc964b750589b0c64a7c2d8fbcdbb6e05440/Source/JavaScriptCore/parser/Lexer.cpp#L849-L856) which implements the spec.

* Safari:
<img width="119" alt="image" src="https://user-images.githubusercontent.com/10634678/169953184-4756f8e0-b3d4-409b-82d6-10a3fc2727e3.png">

* Chrome:
<img width="105" alt="image" src="https://user-images.githubusercontent.com/10634678/169953216-41b4b47a-7a68-459e-aff0-92cf73d6212a.png">

