### PR TITLE
Upload artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,13 @@ jobs:
     - name: Run tests (Windows)
       if: runner.os == 'Windows'
       run: opam exec -- node scripts/ciTest.js -mocha -theme
+
+    - name: Get artifact info
+      id: get_artifact_info
+      run: node .github/workflows/get_artifact_info.js
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ steps.get_artifact_info.outputs.artifact_name }}
+        path: ${{ steps.get_artifact_info.outputs.artifact_path }}

--- a/.github/workflows/get_artifact_info.js
+++ b/.github/workflows/get_artifact_info.js
@@ -1,0 +1,10 @@
+const artifactPath =
+  process.platform === "darwin" && process.arch === "arm64"
+    ? process.platform + process.arch
+    : process.platform;
+
+const artifactName = "binaries-" + artifactPath;
+
+// Pass artifactPath and artifactName to subsequent GitHub actions
+console.log(`::set-output name=artifact_path::${artifactPath}`);
+console.log(`::set-output name=artifact_name::${artifactName}`);


### PR DESCRIPTION
This PR adds artifact upload for all platforms.

For each platform, a zip file is created with the contents of that platform's bin directory:

* bsb_helper.exe
* bsc.exe
* ninja.COPYING
* ninja.exe
* refmt.exe
* rescript.exe

See e.g. https://github.com/rescript-lang/rescript-compiler/actions/runs/2379805466.

<img width="460" alt="Bildschirmfoto 2022-05-24 um 20 46 23" src="https://user-images.githubusercontent.com/591384/170109805-40afeb34-48f1-44ef-906e-bd8aa6567487.png">

Based on this, we can add further automation later, e.g. to automatically publish tag builds to npm including the binaries for all platforms.