### PR TITLE
Ignore self-cycles on bsb_helper to suppress false positives

### DIFF
--- a/jscomp/bsb_helper/bsb_helper_depfile_gen.ml
+++ b/jscomp/bsb_helper/bsb_helper_depfile_gen.ml
@@ -105,6 +105,11 @@ let oc_cmi buf namespace source =
 
     When ns is turned on, `B` is interprted as `Ns-B` which is a cyclic dependency,
     it can be errored out earlier
+
+  #5368: It turns out there are many false positives on detecting self-cycles (see: `jscomp/build_tests/zerocycle`)
+         To properly solve this, we would need to `jscomp/ml/depend.ml` because
+           cmi and cmj is broken in the first place (same problem as in ocaml/ocaml#4618).
+         So we will just ignore the self-cycles. Even if there is indeed a self-cycle, it should fail to compile anyway.
 *)
 let oc_deps (ast_file : string) (is_dev : bool) (db : Bsb_db_decode.t)
     (namespace : string option) (buf : Ext_buffer.t) (kind : [ `impl | `intf ])
@@ -133,9 +138,11 @@ let oc_deps (ast_file : string) (is_dev : bool) (db : Bsb_db_decode.t)
   while !offset < size do
     let next_tab = String.index_from s !offset magic_sep_char in
     let dependent_module = String.sub s !offset (next_tab - !offset) in
-    if dependent_module = cur_module_name then (
-      prerr_endline ("FAILED: " ^ cur_module_name ^ " has a self cycle");
-      exit 2);
+    if dependent_module = cur_module_name then
+      (*prerr_endline ("FAILED: " ^ cur_module_name ^ " has a self cycle");
+      exit 2*)
+      (* #5368 ignore self dependencies *) ()
+    else
     (match Bsb_db_decode.find db dependent_module is_dev with
     | None -> ()
     | Some { dir_name; case } ->

--- a/jscomp/build_tests/zerocycle/src/bar.res
+++ b/jscomp/build_tests/zerocycle/src/bar.res
@@ -1,0 +1,14 @@
+// one-file false positive
+
+module Nested = {
+  module Bar = {
+    type t = private int
+  }
+}
+
+open Nested
+
+module Bar = {
+  open Bar
+  let t : t = Obj.magic(42)
+}

--- a/jscomp/build_tests/zerocycle/src/demo2.res
+++ b/jscomp/build_tests/zerocycle/src/demo2.res
@@ -1,0 +1,1 @@
+module Foo2 = {}

--- a/jscomp/build_tests/zerocycle/src/foo2.res
+++ b/jscomp/build_tests/zerocycle/src/foo2.res
@@ -1,0 +1,2 @@
+open Demo2
+include Foo2


### PR DESCRIPTION
- Closes #5368 
- Related:
  - #2249
  - https://github.com/ocaml/ocaml/issues/4618

This PR disables the self-cycle checking in bsb_helper, because it is causing many false positives.

Notes:
* It seems this was once fixed in #2249, but I can confirm this is now happening again.
* It seems that `build_tests` are currently disabled in CI, which contains the original test for #2249 but left uncaught for a while.