### PR TITLE
Add new function to Option: orElse

### DIFF
--- a/jscomp/others/belt_Option.ml
+++ b/jscomp/others/belt_Option.ml
@@ -64,7 +64,7 @@ let getWithDefault opt default = match opt with
   | None -> default
 
 let withDefault opt default = match opt with
-  | Some x as some -> some
+  | Some _ as some -> some
   | None -> default
 
 let isSome = function

--- a/jscomp/others/belt_Option.ml
+++ b/jscomp/others/belt_Option.ml
@@ -63,9 +63,9 @@ let getWithDefault opt default = match opt with
   | Some x -> x
   | None -> default
 
-let withDefault opt default = match opt with
+let orElse opt other = match opt with
   | Some _ as some -> some
-  | None -> default
+  | None -> other
 
 let isSome = function
   | Some _ -> true

--- a/jscomp/others/belt_Option.ml
+++ b/jscomp/others/belt_Option.ml
@@ -63,6 +63,10 @@ let getWithDefault opt default = match opt with
   | Some x -> x
   | None -> default
 
+let withDefault opt default = match opt with
+  | Some x as some -> some
+  | None -> default
+
 let isSome = function
   | Some _ -> true
   | None -> false

--- a/jscomp/others/belt_Option.mli
+++ b/jscomp/others/belt_Option.mli
@@ -141,6 +141,19 @@ val getWithDefault : 'a option -> 'a -> 'a
    ```
 *)
 
+val withDefault : 'a option -> 'a option -> 'a option
+(**
+   `withDefault optionalValue optionalDefault`
+
+   If `optionalValue` is `Some value`, returns `Some value`, otherwise `optionalDefault`
+
+   ```
+   withDefault (Some 1812) (Some 1066) = Some 1812;;
+   withDefault None (Some 1066) = Some 1066;;
+   withDefault None None = None;;
+   ```
+*)
+
 val isSome : 'a option -> bool
 (**
    Returns `true` if the argument is `Some value`, `false` otherwise

--- a/jscomp/others/belt_Option.mli
+++ b/jscomp/others/belt_Option.mli
@@ -141,16 +141,16 @@ val getWithDefault : 'a option -> 'a -> 'a
    ```
 *)
 
-val withDefault : 'a option -> 'a option -> 'a option
+val orElse : 'a option -> 'a option -> 'a option
 (**
-   `withDefault optionalValue optionalDefault`
+   `orElse optionalValue otherOptional`
 
-   If `optionalValue` is `Some value`, returns `Some value`, otherwise `optionalDefault`
+   If `optionalValue` is `Some value`, returns `Some value`, otherwise `otherOptional`
 
    ```
-   withDefault (Some 1812) (Some 1066) = Some 1812;;
-   withDefault None (Some 1066) = Some 1066;;
-   withDefault None None = None;;
+   orElse (Some 1812) (Some 1066) = Some 1812;;
+   orElse None (Some 1066) = Some 1066;;
+   orElse None None = None;;
    ```
 *)
 


### PR DESCRIPTION
We find ourselves doing the following kind of thing quite often:

```rescript
let opt = switch option {
  | Some(_) as some => some
  | None => alternativeOption
}

let value = opt->Option.getWithDefault("string")
```

Option types in other languages already support using alternative options in the standard lib:
- [Scala – `orElse`](https://www.baeldung.com/scala/option-type#3-option-default-values)
- [F# – `orElse`](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-core-optionmodule.html#orElse)
- [Rust – `or`](https://doc.rust-lang.org/std/option/enum.Option.html#method.or)

In terms of naming, I followed the convention from Scala: [`getOrElse` is to `orElse`](https://www.baeldung.com/scala/option-type#3-option-default-values) as `Belt.Option.getWithDefault` is to `Belt.Option.withDefault`. An alternative would be to use `orElse`, that might be better than using the word "default" for an optional value.

I made this MR by simply changing the `ml` and `mli` files, I can continue with this MR according to contribution guidelines if there is appetite to merge this.

Thanks!

---

**Edit:** I changed the function name to `orElse` based on [feedback from the community](https://forum.rescript-lang.org/t/looking-for-feedback-on-my-belt-pr/3395/26).