### PR TITLE
Sync docs for belt_MutableSet.mli

### DIFF
--- a/jscomp/others/belt_MutableSetInt.mli
+++ b/jscomp/others/belt_MutableSetInt.mli
@@ -140,7 +140,7 @@ val mergeMany: t -> value array -> unit
 
 val remove: t -> value -> unit
 (**
-  Removes element from set. If element wasn't existed in set, value is unchanged.
+  Removes element from set. If element did not exist in set, value is unchanged.
 
   ```res example
   let s0 = Belt.MutableSet.Int.fromArray([2, 3, 1, 4, 5])

--- a/jscomp/others/belt_MutableSetString.mli
+++ b/jscomp/others/belt_MutableSetString.mli
@@ -143,7 +143,7 @@ val mergeMany: t -> value array -> unit
 
 val remove: t -> value -> unit
 (**
-  Removes element from set. If element wasn't existed in set, value is unchanged.
+  Removes element from set. If element did not exist in set, value is unchanged.
 
   ```res example
   let s0 = Belt.MutableSet.String.fromArray(["orange", "banana", "apple"])

--- a/jscomp/others/belt_Set.mli
+++ b/jscomp/others/belt_Set.mli
@@ -59,18 +59,18 @@
   ```
 *)
 
-(** Specalized when value type is `int`, more efficient
+(** Specialized when value type is `int`, more efficient
   than the generic type, its compare behavior is fixed using the built-in comparison
 *)
 module Int = Belt_SetInt
 
-(** Specalized when value type is `string`, more efficient
+(** Specialized when value type is `string`, more efficient
   than the generic type, its compare behavior is fixed using the built-in comparison
 *)
 module String = Belt_SetString
 
 
-(** This module seprate identity from data, it is a bit more verbose but slightly
+(** This module separates identity from data, it is a bit more verbose but slightly
   more efficient due to the fact that there is no need to pack identity and data back
   after each operation
 *)
@@ -177,7 +177,7 @@ val mergeMany: ('value, 'id) t -> 'value array -> ('value, 'id) t
 
 val remove: ('value, 'id) t -> 'value -> ('value, 'id) t
 (**
-  Removes element from set. If element wasn't existed in set, value is unchanged.
+  Removes element from set. If element did not exist in set, value is unchanged.
 
   ```res example
   let s0 = Belt.Set.fromArray([2,3,1,4,5], ~id=module(IntCmp))
@@ -194,7 +194,7 @@ val remove: ('value, 'id) t -> 'value -> ('value, 'id) t
 val removeMany:
   ('value, 'id) t -> 'value array -> ('value, 'id) t
 (**
-  Removes each element of array from set. Unlike [remove](#remove), the reference of return value might be changed even if any values in array not existed in set.
+  Removes each element of array from set. Unlike [remove](#remove), the reference of return value might be changed even if none of values in array existed in set.
 
   ```res example
   let set = Belt.Set.fromArray([1, 2, 3, 4],~id=module(IntCmp))

--- a/jscomp/others/belt_SetDict.mli
+++ b/jscomp/others/belt_SetDict.mli
@@ -142,7 +142,7 @@ val mergeMany: ('value, 'id) t -> 'value array -> cmp:('value, 'id) cmp -> ('val
 
 val remove: ('value, 'id) t -> 'value -> cmp:('value, 'id) cmp -> ('value, 'id) t
 (**
-  Removes element from set. If element wasn't existed in set, value is unchanged.
+  Removes element from set. If element did not exist in set, value is unchanged.
 
   ```res example
   module IntCmp = Belt.Id.MakeComparable({

--- a/jscomp/others/belt_SetInt.mli
+++ b/jscomp/others/belt_SetInt.mli
@@ -126,7 +126,7 @@ val mergeMany: t -> value array -> t
 
 val remove: t -> value -> t
 (**
-  Removes element from set. If element wasn't existed in set, value is unchanged.
+  Removes element from set. If element did not exist in set, value is unchanged.
 
   ```res example
   let s0 = Belt.Set.Int.fromArray([2, 3, 1, 4, 5])

--- a/jscomp/others/belt_SetString.mli
+++ b/jscomp/others/belt_SetString.mli
@@ -127,7 +127,7 @@ val mergeMany: t -> value array -> t
 
 val remove: t -> value -> t
 (**
-  Removes element from set. If element wasn't existed in set, value is unchanged.
+  Removes element from set. If element did not exist in set, value is unchanged.
 
   ```res example
   let s0 = Belt.Set.String.fromArray(["orange", "banana", "apple"])


### PR DESCRIPTION
I continued with the set of `Set`-related header files:
- corrected some English wording across the `Set` header files
- finished `belt_MutableSet.mli` including making a couple of signatures consistent by replacing `'k` with `'value`
- also noticed that `belt_SetInt.mli` was completed in a prior PR but not checked off
cc @ryyppy 
