### PR TITLE
Use bsc.exe to run super errors build test.

### DIFF
--- a/jscomp/build_tests/super_errors/input.js
+++ b/jscomp/build_tests/super_errors/input.js
@@ -3,7 +3,15 @@ const path = require('path')
 const child_process = require('child_process')
 
 
-var  bsc = path.join(__dirname,'..','..','..','bsc')
+var root = path.join(__dirname,'..','..','..')
+var bsc = path.join(
+  root,
+  process.platform === "darwin" && process.arch === "arm64"
+    ? process.platform + process.arch
+    : process.platform,
+  "bsc.exe"
+);
+
 // var  refmt = path.join(__dirname,'..','..','..','lib','refmt.exe')
 
 


### PR DESCRIPTION
See https://github.com/rescript-lang/rescript-compiler/issues/5394