### PR TITLE
Add bsc_path helper + use bsc.exe for super-errors test

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ vendor/
 ninja/
 syntax/
 ocaml-tree/
+_opam

--- a/bsc
+++ b/bsc
@@ -2,14 +2,7 @@
 "use strict";
 
 var child_process = require("child_process");
-var path = require("path");
-var exe = path.join(
-  __dirname,
-  process.platform === "darwin" && process.arch === "arm64"
-    ? process.platform + process.arch
-    : process.platform,
-  "bsc.exe"
-);
+var exe = require("./scripts/bin_path").bsc_exe;
 var delegate_args = process.argv.slice(2);
 
 try {

--- a/bsc
+++ b/bsc
@@ -2,7 +2,14 @@
 "use strict";
 
 var child_process = require("child_process");
-var exe = require("./scripts/bin_path").bsc_exe;
+var path = require("path");
+var exe = path.join(
+  __dirname,
+  process.platform === "darwin" && process.arch === "arm64"
+    ? process.platform + process.arch
+    : process.platform,
+  "bsc.exe"
+);
 var delegate_args = process.argv.slice(2);
 
 try {

--- a/jscomp/build_tests/bs_dependencies_node_path_override/testcase.js
+++ b/jscomp/build_tests/bs_dependencies_node_path_override/testcase.js
@@ -3,8 +3,9 @@ var assert = require('assert')
 var path = require('path')
 var p = require('child_process')
 var fs = require('fs')
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe
 var output = p.spawnSync(
-    `../node_modules/.bin/rescript clean -with-deps && ../node_modules/.bin/rescript build`,
+    `${rescript_exe} clean -with-deps && ${rescript_exe} build`,
     {
         cwd: __dirname,
         encoding: "utf8",

--- a/jscomp/build_tests/bucklescript-tea/input.js
+++ b/jscomp/build_tests/bucklescript-tea/input.js
@@ -1,7 +1,8 @@
 var p = require("child_process");
 const { assert } = require("console");
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe
 
-var o = p.spawnSync(`../node_modules/.bin/rescript`);
+var o = p.spawnSync(rescript_exe);
 
 console.log(o.stderr + "");
 console.log("-----");

--- a/jscomp/build_tests/case/input.js
+++ b/jscomp/build_tests/case/input.js
@@ -2,7 +2,8 @@
 
 var p = require('child_process')
 var assert = require('assert')
-var o  = p.spawnSync(`../node_modules/.bin/rescript`,{encoding: 'utf8',cwd : __dirname})
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe
+var o  = p.spawnSync(rescript_exe,{encoding: 'utf8',cwd : __dirname})
 
 
 assert.ok(o.stderr.match(/different cases/).length > 0 )

--- a/jscomp/build_tests/case2/input.js
+++ b/jscomp/build_tests/case2/input.js
@@ -1,5 +1,6 @@
 var p = require("child_process");
 var assert = require("assert");
-var o = p.spawnSync(`../node_modules/.bin/rescript`, { encoding: "utf8", cwd: __dirname });
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
+var o = p.spawnSync(rescript_exe, { encoding: "utf8", cwd: __dirname });
 
 assert.ok(o.stderr.match(/different cases/).length > 0);

--- a/jscomp/build_tests/case3/input.js
+++ b/jscomp/build_tests/case3/input.js
@@ -4,7 +4,8 @@ var p = require("child_process");
 var fs = require("fs");
 var path = require("path");
 var assert = require("assert");
-p.spawnSync(`../node_modules/.bin/rescript`, {
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
+p.spawnSync(rescript_exe, {
   encoding: "utf8",
   cwd: __dirname,
   stdio: [0, 1, 2],

--- a/jscomp/build_tests/cmd/input.js
+++ b/jscomp/build_tests/cmd/input.js
@@ -2,6 +2,8 @@ var p = require("child_process");
 
 var assert = require("assert");
 
+var bsc_exe_path = require("../../../scripts/bin_path").bsc_exe;
+
 var react = `
 type u 
 
@@ -28,7 +30,7 @@ let d = bar ()
 
 function evalCode(code) {
   var bsc_exe = p.spawnSync(
-    `../node_modules/.bin/bsc -bs-no-version-header -bs-cross-module-opt -w -40 -bs-eval '${code}'`,
+    `${bsc_exe_path} -bs-no-version-header -bs-cross-module-opt -w -40 -bs-eval '${code}'`,
     {
       encoding: "utf8",
       shell: true,

--- a/jscomp/build_tests/customize_namespace/input.js
+++ b/jscomp/build_tests/customize_namespace/input.js
@@ -2,6 +2,7 @@
 
 var cp = require("child_process");
 var assert = require("assert");
-cp.execSync(`../node_modules/.bin/rescript build`, { cwd: __dirname, encoding: "utf8" });
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
+cp.execSync(`${rescript_exe} build`, { cwd: __dirname, encoding: "utf8" });
 
 assert.equal(require("./src/demo.bs").v, 5);

--- a/jscomp/build_tests/cycle/input.js
+++ b/jscomp/build_tests/cycle/input.js
@@ -3,8 +3,9 @@ const cp = require("child_process");
 const assert = require("assert");
 const fs = require('fs')
 const path = require('path')
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
 
-var output = cp.spawnSync(`../node_modules/.bin/rescript`, { encoding: "utf8", shell: true });
+var output = cp.spawnSync(rescript_exe, { encoding: "utf8", shell: true });
 
 assert(/dependency cycle/.test(output.stdout));
 

--- a/jscomp/build_tests/cycle1/input.js
+++ b/jscomp/build_tests/cycle1/input.js
@@ -3,8 +3,9 @@ const cp = require("child_process");
 const assert = require("assert");
 const fs = require('fs')
 const path = require('path')
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe
 
-var output = cp.spawnSync(`../node_modules/.bin/rescript`, { encoding: "utf8", shell: true });
+var output = cp.spawnSync(rescript_exe, { encoding: "utf8", shell: true });
 
 assert(/is dangling/.test(output.stdout));
 

--- a/jscomp/build_tests/dev/input.js
+++ b/jscomp/build_tests/dev/input.js
@@ -2,6 +2,7 @@
 var assert = require("assert");
 var path = require("path");
 var p = require("child_process");
-p.execSync(`npx rescript build`, { cwd: __dirname, shell: true, encoding: "utf8" });
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe
+p.execSync(`${rescript_exe} build`, { cwd: __dirname, shell: true, encoding: "utf8" });
 var u = require("./examples/test.js");
 assert.equal(path.basename(u.v), "demo.mldemo.ml");

--- a/jscomp/build_tests/devdeps/input.js
+++ b/jscomp/build_tests/devdeps/input.js
@@ -4,10 +4,11 @@ var cp = require("child_process");
 var assert = require("assert");
 var targetOne = `test/test.cmj`;
 var targetTwo = `src/demo.cmj`;
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe
 
 
 cp.exec(
-  `../node_modules/.bin/rescript build -- -t commands ${targetOne}`,
+  `${rescript_exe} build -- -t commands ${targetOne}`,
   { encoding: "ascii" },
   function (err, output) {
     if (err !== null) {
@@ -16,7 +17,7 @@ cp.exec(
     }
     assert(output.split("\n").some((x) => x.includes("weird")));
     cp.exec(
-      `../node_modules/.bin/rescript build -- -t commands ${targetTwo}`,
+      `${rescript_exe} build -- -t commands ${targetTwo}`,
       { encoding: "ascii" },
       function (err, output) {
         if (err !== null) {

--- a/jscomp/build_tests/devonly/input.js
+++ b/jscomp/build_tests/devonly/input.js
@@ -1,4 +1,5 @@
 //@ts-check
 var cp = require("child_process");
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe
 
-cp.execSync(`../node_modules/.bin/rescript`, { cwd: __dirname, encoding: "utf8" });
+cp.execSync(rescript_exe, { cwd: __dirname, encoding: "utf8" });

--- a/jscomp/build_tests/duplicated_symlinked_packages/input.js
+++ b/jscomp/build_tests/duplicated_symlinked_packages/input.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 const child_process = require('child_process')
+const rescript_exe = require("../../../scripts/bin_path").rescript_exe
 
 const expectedFilePath = path.join(__dirname, 'out.expected')
 
@@ -11,8 +12,8 @@ function postProcessErrorOutput (output) {
   output = output.replace(new RegExp(__dirname, 'gi'), '.')
   return output
 }
-child_process.execSync(`../node_modules/.bin/rescript clean -with-deps`,{cwd:__dirname})
-child_process.exec('../node_modules/.bin/rescript', {cwd: __dirname}, (err, stdout, stderr) => {
+child_process.execSync(`${rescript_exe} clean -with-deps`,{cwd:__dirname})
+child_process.exec(rescript_exe, {cwd: __dirname}, (err, stdout, stderr) => {
   const actualErrorOutput = postProcessErrorOutput(stderr.toString())
   if (updateTests) {
     fs.writeFileSync(expectedFilePath, actualErrorOutput)

--- a/jscomp/build_tests/exports/input.js
+++ b/jscomp/build_tests/exports/input.js
@@ -1,6 +1,7 @@
 var child_process = require("child_process");
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
 
-child_process.execSync(`../node_modules/.bin/rescript`, {
+child_process.execSync(rescript_exe, {
   cwd: __dirname,
   encoding: "utf8",
   stdio: [0, 1, 2],

--- a/jscomp/build_tests/generator/input.js
+++ b/jscomp/build_tests/generator/input.js
@@ -1,7 +1,8 @@
 var child_process = require("child_process");
 var assert = require("assert");
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
 var output = child_process.spawnSync(
-  `../node_modules/.bin/rescript clean -with-deps && ../node_modules/.bin/rescript build`,
+  `${rescript_exe} clean -with-deps && ${rescript_exe} build`,
   {
     cwd: __dirname,
     encoding: "utf8",

--- a/jscomp/build_tests/hyphen2/input.js
+++ b/jscomp/build_tests/hyphen2/input.js
@@ -1,3 +1,4 @@
 var p = require("child_process");
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
 
-p.execSync(`../node_modules/.bin/rescript`, { cwd: __dirname, stdio: [0, 1, 2] });
+p.execSync(rescript_exe, { cwd: __dirname, stdio: [0, 1, 2] });

--- a/jscomp/build_tests/in_source/input.js
+++ b/jscomp/build_tests/in_source/input.js
@@ -2,12 +2,12 @@ var child_process = require('child_process')
 
 var assert = require('assert')
 
-
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe
 
 
 assert.throws(
     () => {
-        var output = child_process.execSync(`../node_modules/.bin/rescript build -regen`,
+        var output = child_process.execSync(`${rescript_exe} build -regen`,
             { cwd: __dirname, encoding: 'utf8' }
         )
     }

--- a/jscomp/build_tests/install/input.js
+++ b/jscomp/build_tests/install/input.js
@@ -2,13 +2,14 @@ var p = require("child_process");
 var fs = require("fs");
 var path = require("path");
 var assert = require("assert");
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
 
-p.spawnSync(`../node_modules/.bin/rescript`, [`clean`], {
+p.spawnSync(rescript_exe, [`clean`], {
   encoding: "utf8",
   cwd: __dirname,
   stdio: [0, 1, 2]
 });
-p.spawnSync(`../node_modules/.bin/rescript`, [`build`,`-install`], {
+p.spawnSync(rescript_exe, [`build`,`-install`], {
   encoding: "utf8",
   cwd: __dirname,
   stdio: [0, 1, 2]
@@ -17,12 +18,12 @@ p.spawnSync(`../node_modules/.bin/rescript`, [`build`,`-install`], {
 var fooExists = fs.existsSync(path.join(__dirname, "lib", "ocaml", "Foo.cmi"));
 assert.ok(fooExists == false);
 
-p.spawnSync(`../node_modules/.bin/rescript`, {
+p.spawnSync(rescript_exe, {
   encoding: "utf8",
   cwd: __dirname,
   stdio: [0, 1, 2]
 });
-p.spawnSync(`../node_modules/.bin/rescript` ,[`build`,`-install`], {
+p.spawnSync(rescript_exe ,[`build`,`-install`], {
   encoding: "utf8",
   cwd: __dirname,
   stdio: [0, 1, 2]

--- a/jscomp/build_tests/jsxv/input.js
+++ b/jscomp/build_tests/jsxv/input.js
@@ -4,7 +4,9 @@ var assert = require("assert");
 
 var p = require("child_process");
 
-var output = p.spawnSync(`../node_modules/.bin/rescript`, {
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
+
+var output = p.spawnSync(rescript_exe, {
   cwd: __dirname,
   encoding: "utf8",
   shell: true,

--- a/jscomp/build_tests/namespace/input.js
+++ b/jscomp/build_tests/namespace/input.js
@@ -1,7 +1,8 @@
 var child_process = require("child_process");
 var fs = require("fs");
 var path = require("path");
-child_process.execSync(`../node_modules/.bin/rescript clean -with-deps && ../node_modules/.bin/rescript build`, {
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
+child_process.execSync(`${rescript_exe} clean -with-deps && ${rescript_exe} build`, {
   cwd: __dirname,
   stdio: [0, 1, 2],
 });

--- a/jscomp/build_tests/nested/input.js
+++ b/jscomp/build_tests/nested/input.js
@@ -2,7 +2,8 @@ var p = require("child_process");
 var assert = require("assert");
 var fs = require("fs");
 var path = require("path");
-p.execSync(`../node_modules/.bin/rescript`, { cwd: __dirname, stdio: [0, 1, 2] });
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
+p.execSync(rescript_exe, { cwd: __dirname, stdio: [0, 1, 2] });
 
 var content = fs.readFileSync(path.join(__dirname, "src", "demo.js"), "utf8");
 

--- a/jscomp/build_tests/nnest/input.js
+++ b/jscomp/build_tests/nnest/input.js
@@ -4,7 +4,8 @@ var p = require("child_process");
 var assert = require("assert");
 var fs = require("fs");
 var path = require("path");
-p.execSync(`../node_modules/.bin/rescript`, { cwd: __dirname, stdio: [0, 1, 2] });
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
+p.execSync(rescript_exe, { cwd: __dirname, stdio: [0, 1, 2] });
 
 var content = fs.readFileSync(path.join(__dirname, "src", "demo.js"), "utf8");
 

--- a/jscomp/build_tests/ns/input.js
+++ b/jscomp/build_tests/ns/input.js
@@ -1,3 +1,4 @@
 var child_process = require("child_process");
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
 
-child_process.execSync(`../node_modules/.bin/rescript`, { cwd: __dirname, stdio: [0, 1, 2] });
+child_process.execSync(rescript_exe, { cwd: __dirname, stdio: [0, 1, 2] });

--- a/jscomp/build_tests/pinned/input.js
+++ b/jscomp/build_tests/pinned/input.js
@@ -1,6 +1,6 @@
 var cp = require("child_process");
 var assert = require("assert");
-var fs = require("fs");
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
 function checkSpawnOut(out) {
   if (out.error) {
     throw out.error;
@@ -11,13 +11,13 @@ function checkSpawnOut(out) {
 }
 
 // Clean beforehand to force its dependency to be rebuilt
-var out = cp.spawnSync(`../node_modules/.bin/rescript clean`, {
+var out = cp.spawnSync(`${rescript_exe} clean`, {
   encoding: "utf-8",
   shell: true,
 });
 checkSpawnOut(out);
 
-var out = cp.spawnSync(`../node_modules/.bin/rescript build`, {
+var out = cp.spawnSync(`${rescript_exe} build`, {
   encoding: "utf-8",
   shell: true,
 });
@@ -29,7 +29,7 @@ assert.ok(
 );
 
 var out2 = cp.spawnSync(
-  `../node_modules/.bin/rescript build -- -C node_modules/test/lib/bs/ -t targets`,
+  `${rescript_exe} build -- -C node_modules/test/lib/bs/ -t targets`,
   {
     encoding: "utf-8",
     shell: true,

--- a/jscomp/build_tests/post-build/input.js
+++ b/jscomp/build_tests/post-build/input.js
@@ -1,7 +1,8 @@
 var child_process = require("child_process");
 var assert = require("assert");
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
 
-var out = child_process.spawnSync(`../node_modules/.bin/rescript`, { encoding: "utf8" });
+var out = child_process.spawnSync(rescript_exe, { encoding: "utf8" });
 
 if (out.status !== 0) {
   assert.fail(out.stdout + out.stderr);

--- a/jscomp/build_tests/priv/input.js
+++ b/jscomp/build_tests/priv/input.js
@@ -1,7 +1,8 @@
 var child_process = require("child_process");
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
 
 var output = child_process.spawnSync(
-  `npx rescript clean -with-deps && npx rescript build`,
+  `${rescript_exe} -with-deps && ${rescript_exe} build`,
   { cwd: __dirname, shell: true, encoding: "utf8" }
 );
 

--- a/jscomp/build_tests/priv2/input.js
+++ b/jscomp/build_tests/priv2/input.js
@@ -1,9 +1,10 @@
 var child_process = require("child_process");
 var assert = require("assert");
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
 
 assert.throws(
   () => {
-    child_process.execSync(`../node_modules/.bin/rescript clean -with-deps && ../node_modules/.bin/rescript build`, {
+    child_process.execSync(`${rescript_exe} clean -with-deps && ${rescript_exe} build`, {
       cwd: __dirname,
       encoding: "utf8",
     });

--- a/jscomp/build_tests/react_ppx/input.js
+++ b/jscomp/build_tests/react_ppx/input.js
@@ -1,4 +1,5 @@
 //@ts-check
 var cp = require("child_process");
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
 
-cp.execSync(`../node_modules/.bin/rescript`, { cwd: __dirname, stdio: [0, 1, 2] });
+cp.execSync(rescript_exe, { cwd: __dirname, stdio: [0, 1, 2] });

--- a/jscomp/build_tests/rerror/input.js
+++ b/jscomp/build_tests/rerror/input.js
@@ -1,11 +1,12 @@
 var child_process = require("child_process");
 var assert = require("assert");
-child_process.spawnSync(`../node_modules/.bin/rescript clean -with-deps`, {
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
+child_process.spawnSync(`${rescript_exe} clean -with-deps`, {
   cwd: __dirname,
   encoding: "utf8",
   stdio: [0, 1, 2],
 });
-var o = child_process.spawnSync(`../node_modules/.bin/rescript `, {
+var o = child_process.spawnSync(rescript_exe, {
   cwd: __dirname,
   encoding: "utf8",
   shell: true,

--- a/jscomp/build_tests/scoped_ppx/input.js
+++ b/jscomp/build_tests/scoped_ppx/input.js
@@ -1,8 +1,9 @@
 var cp = require("child_process");
 var assert = require("assert");
-cp.execSync(`../node_modules/.bin/rescript`, { cwd: __dirname, stdio: [0, 1, 2], encoding: "utf8" });
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
+cp.execSync(rescript_exe, { cwd: __dirname, stdio: [0, 1, 2], encoding: "utf8" });
 
-var output = cp.execSync(`../node_modules/.bin/rescript build -- -t commands src/hello.ast`, {
+var output = cp.execSync(`${rescript_exe} build -- -t commands src/hello.ast`, {
   cwd: __dirname,
   encoding: "utf8",
 });

--- a/jscomp/build_tests/super_errors/input.js
+++ b/jscomp/build_tests/super_errors/input.js
@@ -3,7 +3,7 @@ const path = require('path')
 const child_process = require('child_process')
 
 
-var  bsc = path.join(__dirname,'..','..','..','bsc')
+var bsc = require("../../../scripts/bin_path").bsc_exe;
 // var  refmt = path.join(__dirname,'..','..','..','lib','refmt.exe')
 
 

--- a/jscomp/build_tests/top/input.js
+++ b/jscomp/build_tests/top/input.js
@@ -2,7 +2,8 @@
 var cp = require("child_process");
 var path = require("path");
 var assert = require("assert");
-var output = cp.execSync(`../node_modules/.bin/rescript build -- -t targets`, {
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
+var output = cp.execSync(`${rescript_exe} build -- -t targets`, {
   encoding: "utf8",
   cwd: __dirname
 });

--- a/jscomp/build_tests/unicode/input.js
+++ b/jscomp/build_tests/unicode/input.js
@@ -1,7 +1,8 @@
 //@ts-check
 var child_process = require("child_process");
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
 
-console.log(child_process.execSync(`../node_modules/.bin/rescript`, { encoding: "utf8" }));
+console.log(child_process.execSync(rescript_exe, { encoding: "utf8" }));
 
 var fs = require("fs");
 var path = require("path");

--- a/jscomp/build_tests/warnerror/input.js
+++ b/jscomp/build_tests/warnerror/input.js
@@ -1,7 +1,8 @@
 var cp = require("child_process");
 var assert = require("assert");
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
 
-var out = cp.spawnSync(`../node_modules/.bin/rescript build`, {
+var out = cp.spawnSync(`${rescript_exe} build`, {
   encoding: "utf-8",
   shell: true,
 });

--- a/jscomp/build_tests/weird_names/input.js
+++ b/jscomp/build_tests/weird_names/input.js
@@ -1,8 +1,9 @@
 var cp = require("child_process");
 var assert = require("assert");
 var path = require("path");
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
 
-var out = cp.spawnSync(`../node_modules/.bin/rescript`, { encoding: "utf8" });
+var out = cp.spawnSync(rescript_exe, { encoding: "utf8" });
 
 console.log(out.stdout);
 if (out.stderr !== "") {

--- a/jscomp/build_tests/white space/input.js
+++ b/jscomp/build_tests/white space/input.js
@@ -2,8 +2,9 @@ var r = require("../../../vendor/rollup.js");
 var path = require("path");
 var assert = require("assert");
 var p = require("child_process");
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
 try {
-  p.execSync(`../node_modules/.bin/rescript build`, {
+  p.execSync(`${rescript_exe} build`, {
     cwd: __dirname,
     encoding: "utf8",
     stdio: [0, 1, 2],
@@ -20,7 +21,7 @@ try {
     .then((output) => {
       // console.log(output.code)
       assert.ok(output.code.length < 1000, "bundled success");
-      p.execSync(`../node_modules/.bin/rescript clean -with-deps`);
+      p.execSync(`${rescript_exe} clean -with-deps`);
     });
 } finally {
 }

--- a/jscomp/build_tests/x-y/input.js
+++ b/jscomp/build_tests/x-y/input.js
@@ -1,3 +1,4 @@
 var p  = require('child_process')
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
 
-p.execSync(`../node_modules/.bin/rescript`)
+p.execSync(rescript_exe)

--- a/jscomp/build_tests/xpkg/input.js
+++ b/jscomp/build_tests/xpkg/input.js
@@ -1,8 +1,9 @@
 var p = require('child_process')
 var assert = require('assert')
 var fs = require('fs')
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
 try {
-    var output = p.spawnSync(`../node_modules/.bin/rescript build -regen`, { shell: true, encoding: 'utf8' })
+    var output = p.spawnSync(`${rescript_exe} build -regen`, { shell: true, encoding: 'utf8' })
 
     assert.ok(output.stderr.match(/reserved package name/))
 }

--- a/jscomp/build_tests/zerocycle/input.js
+++ b/jscomp/build_tests/zerocycle/input.js
@@ -1,4 +1,5 @@
 var p = require("child_process");
 var assert = require("assert");
-var out = p.spawnSync(`../node_modules/.bin/rescript`, { encoding: "utf8", cwd: __dirname });
+var rescript_exe = require("../../../scripts/bin_path").rescript_exe;
+var out = p.spawnSync(rescript_exe, { encoding: "utf8", cwd: __dirname });
 assert(out.status == 0)

--- a/rescript
+++ b/rescript
@@ -11,23 +11,9 @@ var child_process = require("child_process");
 var os = require("os");
 var path = require("path");
 var fs = require("fs");
+var bsc_exe = require("./scripts/bin_path").bsc_exe;
+var rescript_exe = require("./scripts/bin_path").rescript_exe;
 var bsconfig = "bsconfig.json";
-
-/**
- *
- * @type{string}
- */
-var bin_path = path.join(
-  __dirname,
-  process.platform === "darwin" && process.arch === "arm64"
-    ? process.platform + process.arch
-    : process.platform
-);
-
-/**
- * @type{string}
- */
-var rescript_exe = path.join(bin_path, "rescript.exe");
 
 var LAST_BUILD_START = 0;
 var LAST_FIRED_EVENT = 0;
@@ -225,11 +211,6 @@ if (
   maybe_subcommand !== "info"
   // delegate to native
 ) {
-  /**
-   * @type {string}
-   */
-  var bsc_exe = path.join(bin_path, "bsc.exe");
-
   switch (maybe_subcommand) {
     case "format":
       require("./scripts/rescript_format.js").main(

--- a/scripts/bin_path.js
+++ b/scripts/bin_path.js
@@ -20,8 +20,8 @@ var bin_path = path.join(
 var bsc_exe = path.join(bin_path, "bsc.exe");
 
 /**
-* @type{string}
-*/
+ * @type{string}
+ */
 var ninja_exe = path.join(bin_path, "ninja.exe");
 
 /**

--- a/scripts/bin_path.js
+++ b/scripts/bin_path.js
@@ -1,0 +1,35 @@
+//@ts-check
+
+var path = require("path");
+
+/**
+ *
+ * @type{string}
+ */
+var bin_path = path.join(
+  __dirname,
+  "..",
+  process.platform === "darwin" && process.arch === "arm64"
+    ? process.platform + process.arch
+    : process.platform
+);
+
+/**
+ * @type{string}
+ */
+var bsc_exe = path.join(bin_path, "bsc.exe");
+
+/**
+* @type{string}
+*/
+var ninja_exe = path.join(bin_path, "ninja.exe");
+
+/**
+ * @type{string}
+ */
+var rescript_exe = path.join(bin_path, "rescript.exe");
+
+exports.folder = bin_path;
+exports.bsc_exe = bsc_exe;
+exports.ninja_exe = ninja_exe;
+exports.rescript_exe = rescript_exe;

--- a/scripts/ciTest.js
+++ b/scripts/ciTest.js
@@ -130,7 +130,7 @@ function runTests() {
         console.log(`testing ${file}`);
         // note existsSync test already ensure that it is a directory
         try {
-          cp.execSync(`node input.js`, { cwd: testDir, encoding: "utf8" });
+          cp.exec(`node input.js`, { cwd: testDir, encoding: "utf8" });
           console.log("✅ success in ", file);
         } catch (e) {
           failed.push(file);

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -125,9 +125,7 @@ function checkPrebuiltBscCompiler() {
     return;
   }
   try {
-    var version = String(
-      child_process.execFileSync(bsc_exe, ["-v"])
-    );
+    var version = String(child_process.execFileSync(bsc_exe, ["-v"]));
 
     var myOCamlVersion = version.substr(
       version.indexOf(":") + 1,

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -24,14 +24,10 @@ if (supported_os.indexOf(process.platform) < 0) {
 }
 var is_windows = process.platform === "win32";
 
-var my_target =
-  process.platform === "darwin" && process.arch === "arm64"
-    ? process.platform + process.arch
-    : process.platform;
-var bin_path = path.join(root_dir, my_target);
+var bsc_exe = require("./bin_path").bsc_exe;
 
 var ninja_bin_filename = process.platform === "win32" ? "ninja.exe" : "ninja";
-var ninja_bin_output = path.join(bin_path, "ninja.exe");
+var ninja_bin_output = require("./bin_path").ninja_exe;
 
 var force_compiler_rebuild = process.argv.includes("-force-compiler-rebuild");
 var force_lib_rebuild = process.argv.includes("-force-lib-rebuild");
@@ -130,7 +126,7 @@ function checkPrebuiltBscCompiler() {
   }
   try {
     var version = String(
-      child_process.execFileSync(path.join(bin_path, "bsc.exe"), ["-v"])
+      child_process.execFileSync(bsc_exe, ["-v"])
     );
 
     var myOCamlVersion = version.substr(
@@ -159,7 +155,7 @@ function buildLibs(stdlib) {
   ensureExists(path.join(lib_dir, "es6"));
   process.env.NINJA_IGNORE_GENERATOR = "true";
   var releaseNinja = `
-bsc = ../${my_target}/bsc.exe
+bsc = ${bsc_exe}
 stdlib = ${stdlib}
 subninja runtime/release.ninja
 subninja others/release.ninja

--- a/scripts/ninja.js
+++ b/scripts/ninja.js
@@ -28,12 +28,10 @@ var js_package = pseudoTarget("js_pkg");
 var runtimeTarget = pseudoTarget("runtime");
 var othersTarget = pseudoTarget("others");
 var stdlibTarget = pseudoTarget("$stdlib");
-var my_target =
-  process.platform === "darwin" && process.arch === "arm64"
-    ? process.platform + process.arch
-    : process.platform;
+var my_target = require("./bin_path").folder;
+var bsc_exe = require("./bin_path").bsc_exe;
 
-var vendorNinjaPath = path.join(__dirname, "..", my_target, "ninja.exe");
+var vendorNinjaPath = require("./bin_path").ninja_exe;
 
 // Let's enforce a Node version >= 16 to make sure M1 users don't trip up on
 // cryptic issues caused by mismatching assembly architectures Node 16 ships
@@ -666,7 +664,7 @@ function depModulesForBscAsync(files, dir, depsMap) {
   return [
     new Promise((resolve, reject) => {
       cp.exec(
-        `../../${my_target}/bsc.exe  -modules -bs-syntax-only ${resFiles.join(
+        `${bsc_exe}  -modules -bs-syntax-only ${resFiles.join(
           " "
         )} ${reFiles.join(" ")} ${ocamlFiles.join(" ")}`,
         config,
@@ -854,7 +852,7 @@ function generateNinja(depsMap, allTargets, cwd, extraDeps = []) {
   return build_stmts;
 }
 
-var COMPILIER = `../${my_target}/bsc.exe`;
+var COMPILIER = bsc_exe;
 var BSC_COMPILER = `bsc = ${COMPILIER}`;
 
 async function runtimeNinja(devmode = true) {
@@ -1406,7 +1404,7 @@ include body.ninja
   nativeNinja();
   runtimeNinja();
   stdlibNinja(true);
-  if (fs.existsSync(path.join(__dirname, "..", my_target, "bsc.exe"))) {
+  if (fs.existsSync(bsc_exe)) {
     testNinja();
   }
   othersNinja();
@@ -1730,14 +1728,14 @@ o core/js_record_map.ml: p4of core/j.ml
 o core/js_record_fold.ml: p4of core/j.ml
     flags = -record-fold
 
-o ../${my_target}/bsc.exe: link  ${makeLibs(
+o ${my_target}/bsc.exe: link  ${makeLibs(
     bsc_libs
   )} main/rescript_compiler_main.cmx
-o ../${my_target}/rescript.exe: link ${makeLibs(
+o ${my_target}/rescript.exe: link ${makeLibs(
     rescript_libs
   )} main/rescript_main.cmx
       libs =  unix.cmxa str.cmxa    
-o ../${my_target}/bsb_helper.exe: link ${makeLibs(
+o ${my_target}/bsb_helper.exe: link ${makeLibs(
     bsb_helper_libs
   )} main/bsb_helper_main.cmx
     libs =  unix.cmxa str.cmxa
@@ -1750,7 +1748,7 @@ o ./bin/cmij.exe: link ${makeLibs(cmij_libs)} main/cmij_main.cmx
     
 o ./bin/tests.exe: link ${makeLibs(tests_libs)} main/ounit_tests_main.cmx
     libs = str.cmxa unix.cmxa 
-build native: phony ../${my_target}/bsc.exe ../${my_target}/rescript.exe ../${my_target}/bsb_helper.exe ./bin/bspack.exe ./bin/cmjdump.exe ./bin/cmij.exe ./bin/tests.exe
+build native: phony ${my_target}/bsc.exe ${my_target}/rescript.exe ${my_target}/bsb_helper.exe ./bin/bspack.exe ./bin/cmjdump.exe ./bin/cmij.exe ./bin/tests.exe
 
 
 ${mllRule}

--- a/scripts/ninjaFactory.js
+++ b/scripts/ninjaFactory.js
@@ -6,13 +6,7 @@
 // # build bsdep.exe: cc bsdep.mli bsdep.ml
 // ../native/4.06.1/bin/ocamlopt.opt -c -O2 -nodynlink -I 4.06.1 -g -w a+32  4.06.1/whole_compiler.mli 4.06.1/whole_compiler.ml  &> warning.log
 
-/**
- * @type{string}
- */
-var targetDir =
-  process.platform === "darwin" && process.arch === "arm64"
-    ? process.platform + process.arch
-    : process.platform;
+var targetDir = require("./bin_path").folder;
 
 /**
  *
@@ -30,11 +24,11 @@ rule cc
       config.isWin ? "" : "&& strip $out"
     }
     description = Making $out
-build ../${targetDir}/rescript$ext:  cc $INCL/rescript.mli $INCL/rescript.ml
+build ${targetDir}/rescript$ext:  cc $INCL/rescript.mli $INCL/rescript.ml
     flags = $flags -unboxed-types unix.cmxa str.cmxa    
-build ../${targetDir}/bsb_helper$ext:  cc $INCL/bsb_helper.mli $INCL/bsb_helper.ml
+build ${targetDir}/bsb_helper$ext:  cc $INCL/bsb_helper.mli $INCL/bsb_helper.ml
     flags = $flags  -unboxed-types -w -a
-build ../${targetDir}/bsc$ext: cc $INCL/whole_compiler.mli $INCL/whole_compiler.ml
+build ${targetDir}/bsc$ext: cc $INCL/whole_compiler.mli $INCL/whole_compiler.ml
     flags = $flags -w A-4-9-48-40-45-41-44-50-21-30-32-34-37-27-60-42 
 `;
 }

--- a/scripts/prebuilt.js
+++ b/scripts/prebuilt.js
@@ -52,13 +52,7 @@ function rebuild() {
 }
 
 var use_env_compiler = process.argv.includes("-use-env-compiler");
-var bin_path = path.join(
-  __dirname,
-  "..",
-  process.platform === "darwin" && process.arch === "arm64"
-    ? process.platform + process.arch
-    : process.platform
-);
+var bin_path = require("./bin_path").folder;
 
 function buildCompiler() {
   var prebuilt = "prebuilt.ninja";


### PR DESCRIPTION
Fixes #5394.

Alternative to #5469.

- Adds a helper `bin_path.js` where paths to bsc.exe and other binaries can be derived in a single place
- Uses `bsc.exe` path directly in super-errors to avoid issues with [hanging streams](https://github.com/rescript-lang/rescript-compiler/issues/5394#issuecomment-1166412044)
- Replaces manual calculations of paths with `bin_path` values across scripts.