### PR TITLE
Prevent non-terminating build

### DIFF
--- a/rescript
+++ b/rescript
@@ -28,6 +28,8 @@ var lockFileName = path.join(cwd, ".bsb.lock");
 process.env.BSB_PROJECT_ROOT = cwd;
 // console.log('BSB_PROJECT_ROOT:', process.env.BSB_PROJECT_ROOT)
 
+var generatedFileExtension = require(path.join(cwd, "bsconfig.json")).gentypeconfig.generatedFileExtension;
+
 // All clients of type MiniWebSocket
 /**
  * @type {any[]}
@@ -406,6 +408,7 @@ if (
         fileName.endsWith(".mjs") ||
         fileName.endsWith(".cjs") ||
         fileName.endsWith(".gen.tsx") ||
+        fileName.endsWith(generatedFileExtension) ||
         watch_generated.indexOf(fileName) >= 0 ||
         fileName.endsWith(".swp")
       );


### PR DESCRIPTION
using generatedFileExtension in gentypeconfig

This can fix non-terminating build due to custom generated file extensions (#5303).