### PR TITLE
Fix Js.Types.test logic for Object type

### DIFF
--- a/jscomp/others/js_types.ml
+++ b/jscomp/others/js_types.ml
@@ -109,7 +109,7 @@ let test (type a) (x : 'a) (v : a t) : bool =
     Js.typeof x = "function"
   | Object
     ->
-    Js.typeof x = "object"
+    x != (Obj.magic Js_null.empty) && Js.typeof x = "object"
   | Symbol
     ->
     Js.typeof x = "symbol"

--- a/lib/es6/js_types.js
+++ b/lib/es6/js_types.js
@@ -61,7 +61,11 @@ function test(x, v) {
     case /* Function */5 :
         return typeof x === "function";
     case /* Object */6 :
-        return typeof x === "object";
+        if (x !== null) {
+          return typeof x === "object";
+        } else {
+          return false;
+        }
     case /* Symbol */7 :
         return typeof x === "symbol";
     case /* BigInt */8 :

--- a/lib/js/js_types.js
+++ b/lib/js/js_types.js
@@ -61,7 +61,11 @@ function test(x, v) {
     case /* Function */5 :
         return typeof x === "function";
     case /* Object */6 :
-        return typeof x === "object";
+        if (x !== null) {
+          return typeof x === "object";
+        } else {
+          return false;
+        }
     case /* Symbol */7 :
         return typeof x === "symbol";
     case /* BigInt */8 :


### PR DESCRIPTION
I think that the logic of `Js.Types.test(%raw('null'), Object)` is broken

How it works right now:
```rescript
Js.Types.classify(%raw('null')) // JSNull
Js.Types.classify(%raw('{"foo":"bar"}')) // JSObject(_)
Js.Types.test(%raw('null'), Null) // true
Js.Types.test(%raw('null'), Object) // true !!!
Js.Types.test(%raw('{"foo":"bar"}'), Null) // false
Js.Types.test(%raw('{"foo":"bar"}'), Object) // true
```

Since we treat `null` as non-object type in other places, `Js.Types.test(%raw('null'), Object)` should return `false` to keep the consistency. 

> Note: it's a breaking change

