### PR TITLE
Use ubuntu-18.04 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest, macos-arm]
+        # Use ubuntu-18.04 because of glibc issues,
+        # see https://github.com/rescript-lang/rescript-vscode/issues/216.
+        os: [macos-latest, ubuntu-18.04, windows-latest, macos-arm]
         ocaml_compiler: [4.14.0]
 
     runs-on: ${{matrix.os}}


### PR DESCRIPTION
This is because of e.g. Debian 10 not having glibc 2.29, see the discussion in https://github.com/rescript-lang/rescript-vscode/issues/216.