### PR TITLE
Add installation test on FreeBSD to CI script (disabled by default)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,3 +184,30 @@ jobs:
         run: npx rescript -h && npx rescript build && cat src/Test.bs.js
         shell: bash
         working-directory: packages/test
+
+  # The following job tests installation from source on FreeBSD via cross-platform-actions.
+  # Disabled by default, as it takes ~11m.
+  # Can be enabled temporarily in a PR to verify that installation from source
+  # on an "exotic" platform still works.
+  #
+  # installationTestFreeBSD:
+  #   needs: package
+  #   runs-on: macos-latest
+  #
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: npm-packages
+  #         path: packages/test
+  #
+  #     - name: Test installation on FreeBSD
+  #       uses: cross-platform-actions/action@v0.6.2
+  #       with:
+  #         operating_system: freebsd
+  #         version: "13.0"
+  #         shell: bash
+  #         run: cd packages/test && ./test_freebsd.sh

--- a/packages/test/test_freebsd.sh
+++ b/packages/test/test_freebsd.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Node 16 doesn't work, see https://forums.freebsd.org/threads/nodejs-and-libcrypto-so-wrong-version-after-upgrade.82471/
+sudo pkg install -y npm-node14 python gcc
+
+npm i rescript*.tgz
+
+npx rescript -h
+npx rescript build
+cat src/Test.bs.js
+
+# Cleanup
+rm -rf node_modules


### PR DESCRIPTION
This PR adds a job for testing installation from source on FreeBSD via https://github.com/cross-platform-actions/action to CI.yml.

In total (spinning up the VM, installing required packages and installing the ReScript npm package with postinstall from source) takes around 11 minutes.

As this would slow down CI quite a bit, I have kept it commented out.

It can be enabled in a PR anytime one wants to test if installing from source on an exotic platform still works.