### PR TITLE
Fix build lock not releasing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 #### :bug: Bug Fix
 
 - Fix issue where pipe `->` processing eats up attributes https://github.com/rescript-lang/rescript-compiler/pull/5581
+- Fix issue where cancelling `rescript build` would leave the `.bsb.lock` file behind and block future builds
 
 #### :nail_care: Polish
 

--- a/rescript
+++ b/rescript
@@ -215,6 +215,28 @@ function acquireBuild() {
   }
 }
 
+
+function onUncaughtException(err) {
+  console.error("Uncaught Exception", err);
+  releaseBuild();
+  process.exit(1);
+}
+function exitProcess() {
+  releaseBuild();
+  process.exit(0);
+}
+
+process.on("uncaughtException", onUncaughtException);
+
+// OS signal handlers
+// Ctrl+C
+process.on("SIGINT", exitProcess);
+// kill pid
+process.on("SIGUSR1", exitProcess);
+process.on("SIGUSR2", exitProcess);
+process.on("SIGTERM", exitProcess);
+process.on("SIGHUP", exitProcess);
+
 if (
   maybe_subcommand !== undefined &&
   maybe_subcommand !== "build" &&
@@ -336,27 +358,6 @@ if (
      * watchers are held so that we close it later
      */
     var watchers = [];
-
-    function onUncaughtException(err) {
-      console.error("Uncaught Exception", err);
-      releaseBuild();
-      process.exit(1);
-    }
-    function exitProcess() {
-      releaseBuild();
-      process.exit(0);
-    }
-
-    process.on("uncaughtException", onUncaughtException);
-
-    // OS signal handlers
-    // Ctrl+C
-    process.on("SIGINT", exitProcess);
-    // kill pid
-    process.on("SIGUSR1", exitProcess);
-    process.on("SIGUSR2", exitProcess);
-    process.on("SIGTERM", exitProcess);
-    process.on("SIGHUP", exitProcess);
 
     process.stdin.on("close", exitProcess);
     // close when stdin stops


### PR DESCRIPTION
I tried a few different ways to fix this, but in the end just moving the watch mode exit handlers out to run all the time was the best approach.

Fixes #5590.