### PR TITLE
Close the lock file after opening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@
 
 - Print patterns in warnings using rescript printer https://github.com/rescript-lang/rescript-compiler/pull/5492
 
+# 10.0.1
+
+#### :bug: Bug Fix
+
+- Fix issue where watch mode would give an error on Windows https://github.com/rescript-lang/rescript-compiler/pull/5621
+
 # 10.0.0
 
 **Compiler**

--- a/rescript
+++ b/rescript
@@ -204,7 +204,8 @@ function acquireBuild() {
     return false;
   } else {
     try {
-      fs.openSync(lockFileName, "wx", 0o664);
+      const fid = fs.openSync(lockFileName, "wx", 0o664);
+      fs.closeSync(fid);
       is_building = true;
     } catch (err) {
       if (err.code === "EEXIST") {


### PR DESCRIPTION
This PR resolves an issue where `fs.openSync` is throwing a permission error on windows, preventing any building from happening.

View the linked issues for more information, attached is a screenshot of the lock file performing it's duty

![image](https://user-images.githubusercontent.com/4062679/187478980-5e0034d8-de81-47db-b8e3-13b149474fc3.png)

Fixes #5620 
Fixes #5617 

