### PR TITLE
Use python3 for building ninja in all cases

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -53,7 +53,7 @@ function provideNinja() {
         stdio: [0, 1, 2],
       });
       console.log("No prebuilt Ninja, building Ninja now");
-      var build_ninja_command = "./configure.py --bootstrap";
+      var build_ninja_command = "python3 ./configure.py --bootstrap";
       child_process.execSync(build_ninja_command, {
         cwd: ninja_source_dir,
         stdio: [0, 1, 2],


### PR DESCRIPTION
After #5673, we are using `python3` to build ninja in local dev (from the ninja subfolder in the repo), but not in npm package postinstall (from `vendor/ninja.tar.gz`).

We should use `python3` in this case, too. For consistency and because many newer systems only have `python3` in the path, not `python`.