### PR TITLE
CI: replace deprecated set-output command with GITHUB_ENV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,14 +69,13 @@ jobs:
         run: opam exec -- node scripts/ciTest.js -mocha -theme -format
 
       - name: Get artifact info
-        id: get_artifact_info
         run: node .github/workflows/get_artifact_info.js
 
       - name: "Upload artifacts: binaries"
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ steps.get_artifact_info.outputs.artifact_name }}
-          path: ${{ steps.get_artifact_info.outputs.artifact_path }}
+          name: ${{ env.artifact_name }}
+          path: ${{ env.artifact_path }}
 
       - name: "Upload artifacts: lib/ocaml"
         if: runner.os == 'Linux'
@@ -140,7 +139,6 @@ jobs:
         working-directory: packages/std
 
       - name: Get package info
-        id: get_package_info
         # For pull requests, pass the correct commit SHA explicitly as GITHUB_SHA points to the wrong commit.
         run: node .github/workflows/get_package_info.js ${{ github.event.pull_request.head.sha }}
 
@@ -149,8 +147,8 @@ jobs:
         with:
           name: npm-packages
           path: |
-            ${{ steps.get_package_info.outputs.rescript_package }}
-            ${{ steps.get_package_info.outputs.stdlib_package }}
+            ${{ env.rescript_package }}
+            ${{ env.stdlib_package }}
 
   installationTest:
     needs: package

--- a/.github/workflows/get_artifact_info.js
+++ b/.github/workflows/get_artifact_info.js
@@ -1,3 +1,6 @@
+const fs = require("fs");
+const os = require("os");
+
 const artifactPath =
   process.platform === "darwin" && process.arch === "arm64"
     ? process.platform + process.arch
@@ -6,5 +9,7 @@ const artifactPath =
 const artifactName = "binaries-" + artifactPath;
 
 // Pass artifactPath and artifactName to subsequent GitHub actions
-console.log(`::set-output name=artifact_path::${artifactPath}`);
-console.log(`::set-output name=artifact_name::${artifactName}`);
+fs.appendFileSync(
+  process.env.GITHUB_ENV,
+  `artifact_path=${artifactPath}${os.EOL}artifact_name=${artifactName}${os.EOL}`
+);

--- a/.github/workflows/get_package_info.js
+++ b/.github/workflows/get_package_info.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const os = require("os");
 
 const packageSpec = JSON.parse(fs.readFileSync("./package.json", "utf8"));
 const { name, version } = packageSpec;
@@ -16,5 +17,7 @@ fs.renameSync(rescriptPackagePath, rescriptArtifactName);
 fs.renameSync(stdlibPackagePath, stdlibArtifactName);
 
 // Pass information to subsequent GitHub actions
-console.log(`::set-output name=rescript_package::${rescriptArtifactName}`);
-console.log(`::set-output name=stdlib_package::${stdlibArtifactName}`);
+fs.appendFileSync(
+  process.env.GITHUB_ENV,
+  `rescript_package=${rescriptArtifactName}${os.EOL}stdlib_package=${stdlibArtifactName}${os.EOL}`
+);


### PR DESCRIPTION
Got rid of all warnings coming from our scripts.
The few remaining ones are coming from Github's download artifact action and need to be fixed there.