### PR TITLE
Fix .bs.js timestamp being reset to 1970-01-01 when there are warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 #### :bug: Bug Fix
 
+- Fix issue with changes not being applied with React Native's Metro bundler for files with warnings https://github.com/rescript-lang/rescript-compiler/pull/5738
 - Fix emitting unary minus for floats in case of negative constants https://github.com/rescript-lang/rescript-compiler/pull/5737
 - Fix issue where a spread `...x` in non-last position would not be reported as syntax error https://github.com/rescript-lang/syntax/pull/673/
 - Fix issue where the formatter would delete `async` in a function with labelled arguments.

--- a/jscomp/core/lam_compile_main.ml
+++ b/jscomp/core/lam_compile_main.ml
@@ -327,12 +327,18 @@ let lambda_as_module
         if !Warnings.has_warnings  then begin 
           Warnings.has_warnings := false ;
           
-# 322 "core/lam_compile_main.pp.ml"
-          if Sys.file_exists target_file then begin 
-            Bs_hash_stubs.set_as_old_file target_file
+# 321 "core/lam_compile_main.pp.ml"
+          (* 5206: When there were warnings found during the compilation, we want the file
+             to be rebuilt on the next "rescript build" so that the warnings keep being shown.
+             Set the timestamp of the ast file to 1970-01-01 to make this rebuild happen.
+             (Do *not* set the timestamp of the JS output file instead
+             as that does not play well with every bundler.) *)
+          let ast_file = output_prefix ^ Literals.suffix_ast in
+          if Sys.file_exists ast_file then begin 
+            Bs_hash_stubs.set_as_old_file ast_file
           end          
         
-# 326 "core/lam_compile_main.pp.ml"
+# 331 "core/lam_compile_main.pp.ml"
         end             
       )
 

--- a/jscomp/core/lam_compile_main.pp.ml
+++ b/jscomp/core/lam_compile_main.pp.ml
@@ -317,10 +317,15 @@ let lambda_as_module
              target_file output_chan );
         if !Warnings.has_warnings  then begin 
           Warnings.has_warnings := false ;
-#ifdef BROWSER
-#else          
-          if Sys.file_exists target_file then begin 
-            Bs_hash_stubs.set_as_old_file target_file
+#ifndef BROWSER
+          (* 5206: When there were warnings found during the compilation, we want the file
+             to be rebuilt on the next "rescript build" so that the warnings keep being shown.
+             Set the timestamp of the ast file to 1970-01-01 to make this rebuild happen.
+             (Do *not* set the timestamp of the JS output file instead
+             as that does not play well with every bundler.) *)
+          let ast_file = output_prefix ^ Literals.suffix_ast in
+          if Sys.file_exists ast_file then begin 
+            Bs_hash_stubs.set_as_old_file ast_file
           end          
 #endif          
         end             


### PR DESCRIPTION
Closes #5206.