### PR TITLE
Rename syntax cli from "rescript" to "res_parser"

### DIFF
--- a/res_syntax/README.md
+++ b/res_syntax/README.md
@@ -57,11 +57,11 @@ Debug a file:
 
 ```sh
 # write code in test.res
-dune exec -- rescript test.res # test printer
-dune exec -- rescript -print ast test.res # print ast
-dune exec -- rescript -print comments test.res # print comment table
-dune exec -- rescript -print ml test.res # show ocaml code
-dune exec -- rescript -print res -width 80 test.res # test printer and change default print width
+dune exec -- res_parser test.res # test printer
+dune exec -- res_parser -print ast test.res # print ast
+dune exec -- res_parser -print comments test.res # print comment table
+dune exec -- res_parser -print ml test.res # show ocaml code
+dune exec -- res_parser -print res -width 80 test.res # test printer and change default print width
 ```
 
 Benchmark:

--- a/res_syntax/cli/dune
+++ b/res_syntax/cli/dune
@@ -1,6 +1,6 @@
 (executable
  (name res_cli)
- (public_name rescript)
+ (public_name res_parser)
  (modes byte exe)
  (flags
   (-open Syntax -open Compilerlibs406)

--- a/res_syntax/cli/res_cli.ml
+++ b/res_syntax/cli/res_cli.ml
@@ -185,9 +185,10 @@ end = struct
     "\n\
      **This command line is for the repo developer's testing purpose only. DO \
      NOT use it in production**!\n\n"
-    ^ "Usage:\n  rescript <options> <file>\n\n" ^ "Examples:\n"
-    ^ "  rescript myFile.res\n" ^ "  rescript -parse ml -print res myFile.ml\n"
-    ^ "  rescript -parse res -print binary -interface myFile.resi\n\n"
+    ^ "Usage:\n  res_parser <options> <file>\n\n" ^ "Examples:\n"
+    ^ "  res_parser myFile.res\n"
+    ^ "  res_parser -parse ml -print res myFile.ml\n"
+    ^ "  res_parser -parse res -print binary -interface myFile.resi\n\n"
     ^ "Options are:"
 
   let spec =

--- a/res_syntax/scripts/bootstrap.sh
+++ b/res_syntax/scripts/bootstrap.sh
@@ -4,6 +4,6 @@
 rm -rf ./bootstrap
 mkdir ./bootstrap
 
-ocaml unix.cma ./scripts/bspack.ml -bs-main Res_cli -I cli -I src -o ./bootstrap/rescript.ml
-rescript ./bootstrap/rescript.ml > ./bootstrap/rescript.res
-ocamlopt.opt -w a -pp "rescript -print binary" -O2 -o rescript -I +compiler-libs ocamlcommon.cmxa -I lib -impl ./bootstrap/rescript.res
+ocaml unix.cma ./scripts/bspack.ml -bs-main Res_cli -I cli -I src -o ./bootstrap/res_parser.ml
+res_parser ./bootstrap/res_parser.ml > ./bootstrap/res_parser.res
+ocamlopt.opt -w a -pp "res_parser -print binary" -O2 -o res_parser -I +compiler-libs ocamlcommon.cmxa -I lib -impl ./bootstrap/res_parser.res

--- a/res_syntax/scripts/test.sh
+++ b/res_syntax/scripts/test.sh
@@ -22,23 +22,23 @@ mkdir temp
 # parsing
 find tests/parsing/{errors,infiniteLoops,recovery} -name "*.res" -o -name "*.resi" >temp/files.txt
 while read file; do
-  rescript -recover -print ml $file &> $(exp $file) & maybeWait
+  res_parser -recover -print ml $file &> $(exp $file) & maybeWait
 done <temp/files.txt
 find tests/parsing/{grammar,other} -name "*.res" -o -name "*.resi" >temp/files.txt
 while read file; do
-  rescript -print ml $file &> $(exp $file) & maybeWait
+  res_parser -print ml $file &> $(exp $file) & maybeWait
 done <temp/files.txt
 
 # printing
 find tests/{printer,conversion} -name "*.res" -o -name "*.resi" -o -name "*.ml" -o -name "*.mli" >temp/files.txt
 while read file; do
-  rescript $file &> $(exp $file) & maybeWait
+  res_parser $file &> $(exp $file) & maybeWait
 done <temp/files.txt
 
 # printing with ppx
 find tests/ppx/react -name "*.res" -o -name "*.resi" >temp/files.txt
 while read file; do
-  rescript -jsx-version 4 -jsx-mode "automatic" $file &> $(exp $file) & maybeWait
+  res_parser -jsx-version 4 -jsx-mode "automatic" $file &> $(exp $file) & maybeWait
 done <temp/files.txt
 
 wait
@@ -78,11 +78,11 @@ if [[ $ROUNDTRIP_TEST = 1 ]]; then
       *.resi ) class="res"; resIntf=-interface ;;
     esac
 
-    rescript $resIntf -parse $class -print sexp $file > $sexpAst1
-    rescript $resIntf -parse $class -print res $file > $rescript1
+    res_parser $resIntf -parse $class -print sexp $file > $sexpAst1
+    res_parser $resIntf -parse $class -print res $file > $rescript1
 
-    rescript $resIntf -print sexp $rescript1 > $sexpAst2
-    rescript $resIntf -print res $rescript1 > $rescript2
+    res_parser $resIntf -print sexp $rescript1 > $sexpAst2
+    res_parser $resIntf -print res $rescript1 > $rescript2
 
     diff --unified $sexpAst1 $sexpAst2
     [[ "$?" = 1 ]] && echo 1 > $roundtripTestsResult


### PR DESCRIPTION
Currently, both the compiler and the syntax have an executable named "rescript".
This will lead to a conflict when we merge everything into a single dune project.

Therefore, rename the "rescript" executable in the syntax repo to "res_parser".