### PR TITLE
Parser/Printer: unify uncurried functions of arity 0, and of arity 1 taking unit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 - Add support for partial application of uncurried functions: with uncurried application one can provide a
 subset of the arguments, and return a curried type with the remaining ones https://github.com/rescript-lang/rescript-compiler/pull/5805
 - Add support for uncurried externals https://github.com/rescript-lang/rescript-compiler/pull/5815 https://github.com/rescript-lang/rescript-compiler/pull/5819
+- Unify uncurried functions of arity 0 with functions of arity 1 taking unit. They're now equivalent. https://github.com/rescript-lang/rescript-compiler/pull/5825
+
 
 #### :boom: Breaking Change
 
@@ -32,7 +34,6 @@ subset of the arguments, and return a curried type with the remaining ones https
 - Curried after uncurried is not fused anymore: `(. x) => y => 3` is not equivalent to `(. x, y) => 3` anymore. It's instead equivalent to `(. x) => { y => 3 }`.
 Also, `(. int) => string => bool` is not equivalen to `(. int, string) => bool` anymore.
 These are only breaking changes for unformatted code.
-- Distinguish between uncurried type `(. ()) => int`, whch takes 0 arguments, and `(. unit) => int` which takes 1 argument of type `unit` https://github.com/rescript-lang/rescript-compiler/pull/5821
 
 #### :bug: Bug Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Add support for partial application of uncurried functions: with uncurried application one can provide a
 subset of the arguments, and return a curried type with the remaining ones https://github.com/rescript-lang/rescript-compiler/pull/5805
 - Add support for uncurried externals https://github.com/rescript-lang/rescript-compiler/pull/5815 https://github.com/rescript-lang/rescript-compiler/pull/5819
-- Unify uncurried functions of arity 0 with functions of arity 1 taking unit. They're now equivalent. https://github.com/rescript-lang/rescript-compiler/pull/5825
+- Parser/Printer: unify uncurried functions of arity 0, and of arity 1 taking unit. There's now only arity 1 in the source language. https://github.com/rescript-lang/rescript-compiler/pull/5825
 
 
 #### :boom: Breaking Change

--- a/jscomp/frontend/ast_attributes.ml
+++ b/jscomp/frontend/ast_attributes.ml
@@ -305,9 +305,12 @@ let iter_process_bs_string_or_int_as (attrs : Parsetree.attributes) =
                         _;
                       };
                     ]
-                  when Ast_utf8_string_interp.parse_processed_delim delim_ <> None -> (
+                  when Ast_utf8_string_interp.parse_processed_delim delim_
+                       <> None -> (
                     let delim =
-                      match Ast_utf8_string_interp.parse_processed_delim delim_ with
+                      match
+                        Ast_utf8_string_interp.parse_processed_delim delim_
+                      with
                       | None -> assert false
                       | Some delim -> delim
                     in
@@ -337,6 +340,9 @@ let locg = Location.none
 
 let is_bs (attr : attr) =
   match attr with { Location.txt = "bs"; _ }, _ -> true | _ -> false
+
+let is_uncurried_app (attr : attr) =
+  match attr with { Location.txt = "res.uapp"; _ }, _ -> true | _ -> false
 
 let bs_get : attr = ({ txt = "bs.get"; loc = locg }, Ast_payload.empty)
 

--- a/jscomp/frontend/ast_attributes.ml
+++ b/jscomp/frontend/ast_attributes.ml
@@ -341,7 +341,7 @@ let locg = Location.none
 let is_bs (attr : attr) =
   match attr with { Location.txt = "bs"; _ }, _ -> true | _ -> false
 
-let is_uncurried_app (attr : attr) =
+let is_res_uapp (attr : attr) =
   match attr with { Location.txt = "res.uapp"; _ }, _ -> true | _ -> false
 
 let bs_get : attr = ({ txt = "bs.get"; loc = locg }, Ast_payload.empty)

--- a/jscomp/frontend/ast_attributes.mli
+++ b/jscomp/frontend/ast_attributes.mli
@@ -72,6 +72,8 @@ val is_bs : attr -> bool
 (* val is_optional : attr -> bool
    val is_bs_as : attr -> bool *)
 
+val is_uncurried_app : attr -> bool
+
 val bs_get : attr
 
 val bs_get_index : attr

--- a/jscomp/frontend/ast_attributes.mli
+++ b/jscomp/frontend/ast_attributes.mli
@@ -72,7 +72,8 @@ val is_bs : attr -> bool
 (* val is_optional : attr -> bool
    val is_bs_as : attr -> bool *)
 
-val is_uncurried_app : attr -> bool
+(* Attribute for uncurried application coming from the ReScript parser *)
+val is_res_uapp : attr -> bool
 
 val bs_get : attr
 

--- a/jscomp/frontend/ast_exp_apply.ml
+++ b/jscomp/frontend/ast_exp_apply.ml
@@ -160,7 +160,7 @@ let app_exp_mapper (e : exp) (self : Bs_ast_mapper.mapper) (fn : exp)
               match
                 ( Ext_list.exclude_with_val f_.pexp_attributes (fun a ->
                       Ast_attributes.is_bs a
-                      || Ast_attributes.is_uncurried_app a),
+                      || Ast_attributes.is_res_uapp a),
                   f_.pexp_desc )
               with
               | Some other_attributes, Pexp_apply (fn1, args) ->
@@ -296,7 +296,7 @@ let app_exp_mapper (e : exp) (self : Bs_ast_mapper.mapper) (fn : exp)
           | None -> (
               match
                 Ext_list.exclude_with_val e.pexp_attributes
-                  Ast_attributes.is_uncurried_app
+                  Ast_attributes.is_res_uapp
               with
               | Some pexp_attributes ->
                   {

--- a/jscomp/frontend/ast_exp_apply.ml
+++ b/jscomp/frontend/ast_exp_apply.ml
@@ -173,7 +173,7 @@ let app_exp_mapper (e : exp) (self : Bs_ast_mapper.mapper) (fn : exp)
                     fn1.pexp_attributes;
                   {
                     pexp_desc =
-                      Ast_uncurry_apply.uncurry_fn_apply e.pexp_loc self fn1
+                      Ast_uncurry_apply.uncurry_fn_apply ~arity0:(op="|.") e.pexp_loc self fn1
                         ((Nolabel, a) :: args);
                     pexp_loc = e.pexp_loc;
                     pexp_attributes = e.pexp_attributes @ other_attributes;
@@ -183,7 +183,7 @@ let app_exp_mapper (e : exp) (self : Bs_ast_mapper.mapper) (fn : exp)
                      Uncurried unary application *)
                   {
                     pexp_desc =
-                      Ast_uncurry_apply.uncurry_fn_apply e.pexp_loc self f
+                      Ast_uncurry_apply.uncurry_fn_apply ~arity0:false e.pexp_loc self f
                         [ (Nolabel, a) ];
                     pexp_loc = e.pexp_loc;
                     pexp_attributes = e.pexp_attributes;
@@ -288,6 +288,6 @@ let app_exp_mapper (e : exp) (self : Bs_ast_mapper.mapper) (fn : exp)
               {
                 e with
                 pexp_desc =
-                  Ast_uncurry_apply.uncurry_fn_apply e.pexp_loc self fn args;
+                  Ast_uncurry_apply.uncurry_fn_apply ~arity0:true e.pexp_loc self fn args;
                 pexp_attributes;
               }))

--- a/jscomp/frontend/ast_uncurry_apply.ml
+++ b/jscomp/frontend/ast_uncurry_apply.ml
@@ -59,6 +59,18 @@ let generic_apply loc (self : Bs_ast_mapper.mapper) (obj : Parsetree.expression)
      (Nolabel, { pexp_desc = Pexp_construct ({ txt = Lident "()" }, None) });
     ] ->
         []
+    | [
+     ( Nolabel,
+       ({ pexp_desc = Pexp_construct (({ txt = Lident "(u)" } as lid), None) }
+       as e) );
+    ] ->
+        [
+          ( Asttypes.Nolabel,
+            {
+              e with
+              pexp_desc = Pexp_construct ({ lid with txt = Lident "()" }, None);
+            } );
+        ]
     | _ -> args
   in
   let arity = List.length args in

--- a/jscomp/frontend/ast_uncurry_apply.mli
+++ b/jscomp/frontend/ast_uncurry_apply.mli
@@ -25,6 +25,7 @@
 (* TODO: the interface is not reusable, it depends on too much context *)
 
 val uncurry_fn_apply :
+  arity0:bool ->
   Location.t ->
   Bs_ast_mapper.mapper ->
   Parsetree.expression ->

--- a/jscomp/test/UncurriedExternals.js
+++ b/jscomp/test/UncurriedExternals.js
@@ -32,6 +32,8 @@ var te = (function (prim) {
       RE_EXN_ID: "Not_found"
     });
 
+var tcr = {};
+
 var StandardNotation = {
   dd: dd,
   h: h,
@@ -40,7 +42,8 @@ var StandardNotation = {
   mf: mf,
   tg: tg,
   tc: tc,
-  te: te
+  te: te,
+  tcr: tcr
 };
 
 function dd$1(param) {
@@ -74,6 +77,8 @@ var te$1 = (function (prim) {
       RE_EXN_ID: "Not_found"
     });
 
+var tcr$1 = {};
+
 exports.StandardNotation = StandardNotation;
 exports.dd = dd$1;
 exports.h = h$1;
@@ -83,4 +88,5 @@ exports.mf = mf$1;
 exports.tg = tg$1;
 exports.tc = tc$1;
 exports.te = te$1;
+exports.tcr = tcr$1;
 /* h Not a pure module */

--- a/jscomp/test/UncurriedExternals.res
+++ b/jscomp/test/UncurriedExternals.res
@@ -23,6 +23,9 @@ module StandardNotation = {
 
   external toException: (. exn) => exn = "%identity"
   let te = toException(. Not_found)
+
+  @obj external ccreate : () => string = ""
+  let tcr = ccreate()
 }
 
 @@uncurried
@@ -51,3 +54,6 @@ let tc = copy("abc")
 
 external toException: exn => exn = "%identity"
 let te = toException(Not_found)
+
+@obj external ucreate : unit => string = ""
+let tcr = ucreate( (():unit))

--- a/jscomp/test/UncurriedExternals.res
+++ b/jscomp/test/UncurriedExternals.res
@@ -24,8 +24,8 @@ module StandardNotation = {
   external toException: (. exn) => exn = "%identity"
   let te = toException(. Not_found)
 
-  @obj external ccreate : () => string = ""
-  let tcr = ccreate()
+  @obj external ccreate : (. unit) => string = ""
+  let tcr = ccreate(.)
 }
 
 @@uncurried
@@ -56,4 +56,4 @@ external toException: exn => exn = "%identity"
 let te = toException(Not_found)
 
 @obj external ucreate : unit => string = ""
-let tcr = ucreate( (():unit))
+let tcr = ucreate()

--- a/jscomp/test/reactTestUtils.js
+++ b/jscomp/test/reactTestUtils.js
@@ -7,14 +7,14 @@ var Caml_option = require("../../lib/js/caml_option.js");
 var TestUtils = require("react-dom/test-utils");
 
 function act(func) {
-  var reactFunc = function () {
+  var reactFunc = function (param) {
     Curry._1(func, undefined);
   };
   TestUtils.act(reactFunc);
 }
 
 function actAsync(func) {
-  return TestUtils.act(function () {
+  return TestUtils.act(function (param) {
               return Curry._1(func, undefined);
             });
 }

--- a/jscomp/test/uncurried_cast.js
+++ b/jscomp/test/uncurried_cast.js
@@ -76,7 +76,7 @@ var StandardNotation = {
   anInt: anInt
 };
 
-function testRaise$1() {
+function testRaise$1(param) {
   return raise({
               RE_EXN_ID: E
             });

--- a/res_syntax/src/res_core.ml
+++ b/res_syntax/src/res_core.ml
@@ -148,7 +148,7 @@ module ErrorMessages = struct
 end
 
 let jsxAttr = (Location.mknoloc "JSX", Parsetree.PStr [])
-let uncurryAttr = (Location.mknoloc "bs", Parsetree.PStr [])
+let uncurriedAppAttr = (Location.mknoloc "res.uapp", Parsetree.PStr [])
 let ternaryAttr = (Location.mknoloc "ns.ternary", Parsetree.PStr [])
 let ifLetAttr = (Location.mknoloc "ns.iflet", Parsetree.PStr [])
 let optionalAttr = (Location.mknoloc "ns.optional", Parsetree.PStr [])
@@ -1596,7 +1596,7 @@ and parseEs6ArrowExpression ?(arrowAttrs = []) ?(arrowStartPos = None) ?context
           let uncurried =
             if p.uncurried_by_default then not dotted else dotted
           in
-          let attrs = if uncurried then uncurryAttr :: attrs else attrs in
+          let attrs = if uncurried then uncurriedAppAttr :: attrs else attrs in
           ( paramNum - 1,
             makeNewtypes ~attrs ~loc:(mkLoc startPos endPos) newtypes expr,
             arity ))
@@ -3665,7 +3665,7 @@ and parseCallExpr p funExpr =
             if p.uncurried_by_default then not dotted else dotted
           in
           if uncurried then
-            let attrs = [uncurryAttr] in
+            let attrs = [uncurriedAppAttr] in
             Ast_helper.Exp.apply ~loc ~attrs callBody args
           else Ast_helper.Exp.apply ~loc callBody args
         in

--- a/res_syntax/src/res_core.ml
+++ b/res_syntax/src/res_core.ml
@@ -3503,9 +3503,7 @@ and parseArgument p : argument option =
       | Rparen ->
         let unitExpr =
           Ast_helper.Exp.construct
-            (Location.mknoloc
-               (Longident.Lident
-                  (if p.uncurried_by_default then "()" else "(u)")))
+            (Location.mknoloc (Longident.Lident "()"))
             None
         in
         Some {dotted; label = Asttypes.Nolabel; expr = unitExpr}
@@ -3598,10 +3596,7 @@ and parseCallExpr p funExpr =
           label = Nolabel;
           expr =
             Ast_helper.Exp.construct ~loc
-              (Location.mkloc
-                 (Longident.Lident
-                    (if p.uncurried_by_default then "(u)" else "()"))
-                 loc)
+              (Location.mkloc (Longident.Lident "()") loc)
               None;
         };
       ]

--- a/res_syntax/src/res_parsetree_viewer.ml
+++ b/res_syntax/src/res_parsetree_viewer.ml
@@ -57,6 +57,21 @@ let processBsAttribute attrs =
   in
   process false [] attrs
 
+let processUncurriedAppAttribute attrs =
+  let rec process bsSpotted acc attrs =
+    match attrs with
+    | [] -> (bsSpotted, List.rev acc)
+    | ( {
+          Location.txt =
+            "bs" (* still support @bs to convert .ml files *) | "res.uapp";
+        },
+        _ )
+      :: rest ->
+      process true acc rest
+    | attr :: rest -> process bsSpotted (attr :: acc) rest
+  in
+  process false [] attrs
+
 type functionAttributesInfo = {
   async: bool;
   bs: bool;
@@ -186,7 +201,7 @@ let filterParsingAttrs attrs =
       match attr with
       | ( {
             Location.txt =
-              ( "bs" | "ns.braces" | "ns.iflet" | "ns.namedArgLoc"
+              ( "bs" | "res.uapp" | "ns.braces" | "ns.iflet" | "ns.namedArgLoc"
               | "ns.optional" | "ns.ternary" | "res.async" | "res.await"
               | "res.template" );
           },
@@ -335,8 +350,8 @@ let hasAttributes attrs =
       match attr with
       | ( {
             Location.txt =
-              ( "bs" | "ns.braces" | "ns.iflet" | "ns.ternary" | "res.async"
-              | "res.await" | "res.template" );
+              ( "bs" | "res.uapp" | "ns.braces" | "ns.iflet" | "ns.ternary"
+              | "res.async" | "res.await" | "res.template" );
           },
           _ ) ->
         false
@@ -517,8 +532,8 @@ let isPrintableAttribute attr =
   match attr with
   | ( {
         Location.txt =
-          ( "bs" | "ns.iflet" | "ns.braces" | "JSX" | "res.async" | "res.await"
-          | "res.template" | "ns.ternary" );
+          ( "bs" | "res.uapp" | "ns.iflet" | "ns.braces" | "JSX" | "res.async"
+          | "res.await" | "res.template" | "ns.ternary" );
       },
       _ ) ->
     false

--- a/res_syntax/src/res_parsetree_viewer.mli
+++ b/res_syntax/src/res_parsetree_viewer.mli
@@ -17,6 +17,9 @@ val functorType :
 (* filters @bs out of the provided attributes *)
 val processBsAttribute : Parsetree.attributes -> bool * Parsetree.attributes
 
+val processUncurriedAppAttribute :
+  Parsetree.attributes -> bool * Parsetree.attributes
+
 type functionAttributesInfo = {
   async: bool;
   bs: bool;

--- a/res_syntax/src/res_printer.ml
+++ b/res_syntax/src/res_printer.ml
@@ -3953,7 +3953,7 @@ and printPexpApply ~state expr cmtTbl =
         args
     in
     let hasBs, attrs =
-      ParsetreeViewer.processBsAttribute expr.pexp_attributes
+      ParsetreeViewer.processUncurriedAppAttribute expr.pexp_attributes
     in
     let dotted =
       if state.State.uncurried_by_default then not hasBs else hasBs

--- a/res_syntax/src/res_printer.ml
+++ b/res_syntax/src/res_printer.ml
@@ -1657,12 +1657,6 @@ and printTypExpr ~state (typExpr : Parsetree.core_type) cmtTbl =
     | Ptyp_object (fields, openFlag) ->
       printObject ~state ~inline:false fields openFlag cmtTbl
     | Ptyp_arrow _ -> printArrow ~uncurried:false typExpr
-    | Ptyp_constr ({txt = Lident "()"}, []) -> Doc.text "()"
-    | Ptyp_constr ({txt = Ldot (Ldot (Lident "Js", "Fn"), "arity0")}, [tArg]) ->
-      let parensConstr = Location.mkloc (Longident.Lident "()") tArg.ptyp_loc in
-      let tUnit = Ast_helper.Typ.constr parensConstr [] in
-      printArrow ~uncurried:true ~arity:1
-        {tArg with ptyp_desc = Ptyp_arrow (Nolabel, tUnit, tArg)}
     | Ptyp_constr ({txt = Ldot (Ldot (Lident "Js", "Fn"), arity)}, [tArg])
       when String.length arity >= 5
            && (String.sub [@doesNotRaise]) arity 0 5 = "arity" ->
@@ -2686,7 +2680,8 @@ and printExpression ~state (e : Parsetree.expression) cmtTbl =
       printConstant ~templateLiteral:(ParsetreeViewer.isTemplateLiteral e) c
     | Pexp_construct _ when ParsetreeViewer.hasJsxAttribute e.pexp_attributes ->
       printJsxFragment ~state e cmtTbl
-    | Pexp_construct ({txt = Longident.Lident "()"}, _) -> Doc.text "()"
+    | Pexp_construct ({txt = Longident.Lident ("()" | "(u)")}, _) ->
+      Doc.text "()"
     | Pexp_construct ({txt = Longident.Lident "[]"}, _) ->
       Doc.concat
         [Doc.text "list{"; printCommentsInside cmtTbl e.pexp_loc; Doc.rbrace]
@@ -4517,7 +4512,7 @@ and printArguments ~state ~dotted
   | [
    ( Nolabel,
      {
-       pexp_desc = Pexp_construct ({txt = Longident.Lident "()"}, _);
+       pexp_desc = Pexp_construct ({txt = Longident.Lident ("()" | "(u)")}, _);
        pexp_loc = loc;
      } );
   ] -> (

--- a/res_syntax/src/res_printer.ml
+++ b/res_syntax/src/res_printer.ml
@@ -2680,8 +2680,7 @@ and printExpression ~state (e : Parsetree.expression) cmtTbl =
       printConstant ~templateLiteral:(ParsetreeViewer.isTemplateLiteral e) c
     | Pexp_construct _ when ParsetreeViewer.hasJsxAttribute e.pexp_attributes ->
       printJsxFragment ~state e cmtTbl
-    | Pexp_construct ({txt = Longident.Lident ("()" | "(u)")}, _) ->
-      Doc.text "()"
+    | Pexp_construct ({txt = Longident.Lident "()"}, _) -> Doc.text "()"
     | Pexp_construct ({txt = Longident.Lident "[]"}, _) ->
       Doc.concat
         [Doc.text "list{"; printCommentsInside cmtTbl e.pexp_loc; Doc.rbrace]
@@ -4512,7 +4511,7 @@ and printArguments ~state ~dotted
   | [
    ( Nolabel,
      {
-       pexp_desc = Pexp_construct ({txt = Longident.Lident ("()" | "(u)")}, _);
+       pexp_desc = Pexp_construct ({txt = Longident.Lident "()"}, _);
        pexp_loc = loc;
      } );
   ] -> (

--- a/res_syntax/tests/parsing/grammar/expressions/UncurriedByDefault.res
+++ b/res_syntax/tests/parsing/grammar/expressions/UncurriedByDefault.res
@@ -90,7 +90,3 @@ let _ = @att x  => 34
 let _ = @att async x  => 34
 let _ = preserveAttr(@att x => 34)
 let _ = preserveAttr(@att async x => 34)
-
-let foo : unit =>string = () => "abc"
-
-let s = foo()

--- a/res_syntax/tests/parsing/grammar/expressions/UncurriedByDefault.res
+++ b/res_syntax/tests/parsing/grammar/expressions/UncurriedByDefault.res
@@ -90,3 +90,7 @@ let _ = @att x  => 34
 let _ = @att async x  => 34
 let _ = preserveAttr(@att x => 34)
 let _ = preserveAttr(@att async x => 34)
+
+let foo : unit =>string = () => "abc"
+
+let s = foo()

--- a/res_syntax/tests/parsing/grammar/expressions/expected/UncurriedByDefault.res.txt
+++ b/res_syntax/tests/parsing/grammar/expressions/expected/UncurriedByDefault.res.txt
@@ -102,6 +102,3 @@ let _ = { Js.Fn.I1 = ((fun x -> 34)[@res.async ][@att ]) }
 let _ = ((preserveAttr { Js.Fn.I1 = ((fun x -> 34)[@att ]) })[@res.uapp ])
 let _ = ((preserveAttr { Js.Fn.I1 = ((fun x -> 34)[@res.async ][@att ]) })
   [@res.uapp ])
-let (foo : (unit -> string) Js.Fn.arity1) =
-  { Js.Fn.I1 = (fun () -> {js|abc|js}) }
-let s = ((foo ())[@res.uapp ])

--- a/res_syntax/tests/parsing/grammar/expressions/expected/UncurriedByDefault.res.txt
+++ b/res_syntax/tests/parsing/grammar/expressions/expected/UncurriedByDefault.res.txt
@@ -1,5 +1,5 @@
 let cApp = foo 3
-let uApp = ((foo 3)[@bs ])
+let uApp = ((foo 3)[@res.uapp ])
 let cFun x = 3
 let uFun = { Js.Fn.I1 = (fun x -> 3) }
 let mixFun a =
@@ -33,11 +33,11 @@ type nonrec cpp = unit -> unit -> int
 type nonrec cu2 = unit -> unit -> unit
 type nonrec cp2 = unit -> unit -> unit
 type nonrec uu = (unit -> int) Js.Fn.arity1
-type nonrec up = int Js.Fn.arity0
+type nonrec up = (unit -> int) Js.Fn.arity1
 type nonrec uuu = (unit -> (unit -> int) Js.Fn.arity1) Js.Fn.arity1
-type nonrec upu = (unit -> int) Js.Fn.arity1 Js.Fn.arity0
-type nonrec uup = (unit -> int Js.Fn.arity0) Js.Fn.arity1
-type nonrec upp = int Js.Fn.arity0 Js.Fn.arity0
+type nonrec upu = (unit -> (unit -> int) Js.Fn.arity1) Js.Fn.arity1
+type nonrec uup = (unit -> (unit -> int) Js.Fn.arity1) Js.Fn.arity1
+type nonrec upp = (unit -> (unit -> int) Js.Fn.arity1) Js.Fn.arity1
 type nonrec uu2 = (unit -> unit -> unit) Js.Fn.arity2
 type nonrec up2 = (unit -> unit -> unit) Js.Fn.arity2
 type nonrec cnested = (string -> unit) -> unit
@@ -50,7 +50,7 @@ let _ = preserveAttr { Js.Fn.I1 = ((fun x -> 34)[@att ]) }
 let _ = preserveAttr { Js.Fn.I1 = ((fun x -> 34)[@res.async ][@att ]) }
 [@@@uncurried ]
 let cApp = foo 3
-let uApp = ((foo 3)[@bs ])
+let uApp = ((foo 3)[@res.uapp ])
 let cFun x = 3
 let uFun = { Js.Fn.I1 = (fun x -> 3) }
 let mixFun a =
@@ -85,11 +85,11 @@ type nonrec cpp = unit -> unit -> int
 type nonrec cu2 = unit -> unit -> unit
 type nonrec cp2 = unit -> unit -> unit
 type nonrec uu = (unit -> int) Js.Fn.arity1
-type nonrec up = int Js.Fn.arity0
+type nonrec up = (unit -> int) Js.Fn.arity1
 type nonrec uuu = (unit -> (unit -> int) Js.Fn.arity1) Js.Fn.arity1
-type nonrec upu = (unit -> int) Js.Fn.arity1 Js.Fn.arity0
-type nonrec uup = (unit -> int Js.Fn.arity0) Js.Fn.arity1
-type nonrec upp = int Js.Fn.arity0 Js.Fn.arity0
+type nonrec upu = (unit -> (unit -> int) Js.Fn.arity1) Js.Fn.arity1
+type nonrec uup = (unit -> (unit -> int) Js.Fn.arity1) Js.Fn.arity1
+type nonrec upp = (unit -> (unit -> int) Js.Fn.arity1) Js.Fn.arity1
 type nonrec uu2 = (unit -> unit -> unit) Js.Fn.arity2
 type nonrec up2 = (unit -> unit -> unit) Js.Fn.arity2
 type nonrec cnested = (string -> unit) -> unit
@@ -99,6 +99,9 @@ let (uannpoly : ('a -> string) Js.Fn.arity1) = xx
 let (uannint : (int -> string) Js.Fn.arity1) = xx
 let _ = { Js.Fn.I1 = ((fun x -> 34)[@att ]) }
 let _ = { Js.Fn.I1 = ((fun x -> 34)[@res.async ][@att ]) }
-let _ = ((preserveAttr { Js.Fn.I1 = ((fun x -> 34)[@att ]) })[@bs ])
+let _ = ((preserveAttr { Js.Fn.I1 = ((fun x -> 34)[@att ]) })[@res.uapp ])
 let _ = ((preserveAttr { Js.Fn.I1 = ((fun x -> 34)[@res.async ][@att ]) })
-  [@bs ])
+  [@res.uapp ])
+let (foo : (unit -> string) Js.Fn.arity1) =
+  { Js.Fn.I1 = (fun () -> {js|abc|js}) }
+let s = ((foo ())[@res.uapp ])

--- a/res_syntax/tests/parsing/grammar/expressions/expected/apply.res.txt
+++ b/res_syntax/tests/parsing/grammar/expressions/expected/apply.res.txt
@@ -4,5 +4,5 @@
 ;;foo (fun _ -> bla) (fun _ -> blaz)
 ;;List.map (fun x -> x + 1) myList
 ;;List.reduce (fun acc -> fun curr -> acc + curr) 0 myList
-let unitUncurried = ((apply (u))[@bs ])
+let unitUncurried = ((apply ())[@bs ])
 ;;call ~a:(((((a)[@ns.namedArgLoc ]) : int))[@ns.namedArgLoc ])

--- a/res_syntax/tests/parsing/grammar/expressions/expected/apply.res.txt
+++ b/res_syntax/tests/parsing/grammar/expressions/expected/apply.res.txt
@@ -4,5 +4,5 @@
 ;;foo (fun _ -> bla) (fun _ -> blaz)
 ;;List.map (fun x -> x + 1) myList
 ;;List.reduce (fun acc -> fun curr -> acc + curr) 0 myList
-let unitUncurried = ((apply ())[@bs ])
+let unitUncurried = ((apply (u))[@bs ])
 ;;call ~a:(((((a)[@ns.namedArgLoc ]) : int))[@ns.namedArgLoc ])

--- a/res_syntax/tests/parsing/grammar/expressions/expected/apply.res.txt
+++ b/res_syntax/tests/parsing/grammar/expressions/expected/apply.res.txt
@@ -4,5 +4,5 @@
 ;;foo (fun _ -> bla) (fun _ -> blaz)
 ;;List.map (fun x -> x + 1) myList
 ;;List.reduce (fun acc -> fun curr -> acc + curr) 0 myList
-let unitUncurried = ((apply ())[@bs ])
+let unitUncurried = ((apply ())[@res.uapp ])
 ;;call ~a:(((((a)[@ns.namedArgLoc ]) : int))[@ns.namedArgLoc ])

--- a/res_syntax/tests/parsing/grammar/expressions/expected/argument.res.txt
+++ b/res_syntax/tests/parsing/grammar/expressions/expected/argument.res.txt
@@ -9,5 +9,5 @@ let comparisonResult =
 ;;((document.createElementWithOptions {js|div|js}
       (elementProps ~onClick:((fun _ -> Js.log {js|hello world|js})
          [@ns.namedArgLoc ])))[@bs ])
-;;((resolve (u))[@bs ])
+;;((resolve ())[@bs ])
 ;;((resolve (let __res_unit = () in __res_unit))[@bs ])

--- a/res_syntax/tests/parsing/grammar/expressions/expected/argument.res.txt
+++ b/res_syntax/tests/parsing/grammar/expressions/expected/argument.res.txt
@@ -1,13 +1,13 @@
 let foo ~a:((a)[@ns.namedArgLoc ])  =
-  ((a (let __res_unit = () in __res_unit))[@bs ]) +. 1.
+  ((a (let __res_unit = () in __res_unit))[@res.uapp ]) +. 1.
 let a = { Js.Fn.I1 = (fun () -> 2) }
 let bar = foo ~a:((a)[@ns.namedArgLoc ])
 let comparisonResult =
   ((compare currentNode.value ~targetValue:((targetValue)[@ns.namedArgLoc ]))
-  [@bs ])
-;;((callback firstNode ~y:((y)[@ns.namedArgLoc ]))[@bs ])
+  [@res.uapp ])
+;;((callback firstNode ~y:((y)[@ns.namedArgLoc ]))[@res.uapp ])
 ;;((document.createElementWithOptions {js|div|js}
       (elementProps ~onClick:((fun _ -> Js.log {js|hello world|js})
-         [@ns.namedArgLoc ])))[@bs ])
-;;((resolve ())[@bs ])
-;;((resolve (let __res_unit = () in __res_unit))[@bs ])
+         [@ns.namedArgLoc ])))[@res.uapp ])
+;;((resolve ())[@res.uapp ])
+;;((resolve (let __res_unit = () in __res_unit))[@res.uapp ])

--- a/res_syntax/tests/parsing/grammar/expressions/expected/argument.res.txt
+++ b/res_syntax/tests/parsing/grammar/expressions/expected/argument.res.txt
@@ -1,6 +1,6 @@
 let foo ~a:((a)[@ns.namedArgLoc ])  =
   ((a (let __res_unit = () in __res_unit))[@bs ]) +. 1.
-let a = { Js.Fn.I0 = (fun () -> 2) }
+let a = { Js.Fn.I1 = (fun () -> 2) }
 let bar = foo ~a:((a)[@ns.namedArgLoc ])
 let comparisonResult =
   ((compare currentNode.value ~targetValue:((targetValue)[@ns.namedArgLoc ]))
@@ -9,5 +9,5 @@ let comparisonResult =
 ;;((document.createElementWithOptions {js|div|js}
       (elementProps ~onClick:((fun _ -> Js.log {js|hello world|js})
          [@ns.namedArgLoc ])))[@bs ])
-;;((resolve ())[@bs ])
+;;((resolve (u))[@bs ])
 ;;((resolve (let __res_unit = () in __res_unit))[@bs ])

--- a/res_syntax/tests/parsing/grammar/expressions/expected/arrow.res.txt
+++ b/res_syntax/tests/parsing/grammar/expressions/expected/arrow.res.txt
@@ -40,8 +40,8 @@ let f ?a:(((x : int option))[@ns.namedArgLoc ])
   ?b:(((y : int option))[@ns.namedArgLoc ])  c =
   match (x, y) with | (Some a, Some b) -> (a + b) + c | _ -> 3
 let f a b = a + b
-let f = { Js.Fn.I0 = (fun () -> ()) }
-let f = { Js.Fn.I0 = (fun () -> ()) }
+let f = { Js.Fn.I1 = (fun () -> ()) }
+let f = { Js.Fn.I1 = (fun () -> ()) }
 let f = { Js.Fn.I3 = (fun a -> fun b -> fun c -> ()) }
 let f =
   { Js.Fn.I2 = (fun a -> fun b -> { Js.Fn.I2 = (fun c -> fun d -> ()) }) }

--- a/res_syntax/tests/parsing/grammar/expressions/expected/async.res.txt
+++ b/res_syntax/tests/parsing/grammar/expressions/expected/async.res.txt
@@ -1,16 +1,23 @@
 let greetUser =
   ((fun userId ->
-      ((let name = ((getUserName userId)[@res.await ][@bs ]) in
+      ((let name = ((getUserName userId)[@res.await ][@res.uapp ]) in
         ({js|Hello |js} ^ name) ^ {js|!|js})
       [@ns.braces ]))
   [@res.async ])
 ;;((fun () -> 123)[@res.async ])
 let fetch =
-  (({ Js.Fn.I1 = ((fun url -> ((browserFetch url)[@bs ]))[@res.async ]) })
+  (({ Js.Fn.I1 = ((fun url -> ((browserFetch url)[@res.uapp ]))[@res.async ])
+    })
   [@ns.braces ])
 let fetch2 =
-  (({ Js.Fn.I1 = (((fun url -> ((browserFetch url)[@bs ])))[@res.async ]) };
-    { Js.Fn.I1 = (((fun url -> ((browserFetch2 url)[@bs ])))[@res.async ]) })
+  (({
+      Js.Fn.I1 = (((fun url -> ((browserFetch url)[@res.uapp ])))
+        [@res.async ])
+    };
+    {
+      Js.Fn.I1 = (((fun url -> ((browserFetch2 url)[@res.uapp ])))
+        [@res.async ])
+    })
   [@ns.braces ])
 let async =
   ((let f = async () in

--- a/res_syntax/tests/parsing/grammar/expressions/expected/binary.res.txt
+++ b/res_syntax/tests/parsing/grammar/expressions/expected/binary.res.txt
@@ -20,5 +20,5 @@ let x = a -. b
 ;;Constructor (a, b)
 ;;`Constructor (a, b)
 let _ = ((Constructor (a, b); `Constructor (a, b))[@ns.braces ])
-;;((library.getBalance account)[@bs ]) |.
+;;((library.getBalance account)[@res.uapp ]) |.
     (Promise.Js.catch (fun _ -> ((Promise.resolved None)[@ns.braces ])))

--- a/res_syntax/tests/parsing/grammar/expressions/expected/uncurried.res.txt
+++ b/res_syntax/tests/parsing/grammar/expressions/expected/uncurried.res.txt
@@ -30,5 +30,5 @@ let f =
          fun ((b)[@attr2 ]) ->
            { Js.Fn.I2 = (fun ((c)[@attr3 ]) -> fun ((d)[@attr4 ]) -> ()) })
   }
-;;((add 1 2)[@bs ])
-;;((((((add 2 3 4)[@bs ]) 5 6 7)[@bs ]) 8 9 10)[@bs ])
+;;((add 1 2)[@res.uapp ])
+;;((((((add 2 3 4)[@res.uapp ]) 5 6 7)[@res.uapp ]) 8 9 10)[@res.uapp ])

--- a/res_syntax/tests/parsing/grammar/typexpr/expected/uncurried.res.txt
+++ b/res_syntax/tests/parsing/grammar/typexpr/expected/uncurried.res.txt
@@ -16,7 +16,7 @@ type nonrec t =
      ((int)[@attr2 ]) ->
        (((bool)[@attr3 ]) -> ((string)[@attr4 ]) -> unit) Js.Fn.arity2)
     Js.Fn.arity2
-external setTimeout : unit Js.Fn.arity0 -> int -> timerId = "setTimeout"
-[@@bs.val ]
+external setTimeout :
+  (unit -> unit) Js.Fn.arity1 -> int -> timerId = "setTimeout"[@@bs.val ]
 external setTimeout :
   ((unit -> unit) -> int -> timerId) Js.Fn.arity2 = "setTimeout"

--- a/res_syntax/tests/parsing/infiniteLoops/expected/equalAfterBinaryExpr.res.txt
+++ b/res_syntax/tests/parsing/infiniteLoops/expected/equalAfterBinaryExpr.res.txt
@@ -151,6 +151,6 @@ let removeNode rbt node =
                            ((sibling.left |. castNotOption).color <- Black;
                             rotateLeft rbt successorParent))))
             done));
-    if ((isLeaf successor)[@bs ])
+    if ((isLeaf successor)[@res.uapp ])
     then (if (rbt |. root) == (Some successor) then (rbt |. root) = None))
   [@ns.braces ])

--- a/res_syntax/tests/parsing/recovery/expression/expected/infinite.res.txt
+++ b/res_syntax/tests/parsing/recovery/expression/expected/infinite.res.txt
@@ -1,1 +1,1 @@
-let smallest = ((heap.compare ())[@bs ]) < (a |. (f b))
+let smallest = ((heap.compare ())[@res.uapp ]) < (a |. (f b))

--- a/res_syntax/tests/parsing/recovery/expression/expected/infinite.res.txt
+++ b/res_syntax/tests/parsing/recovery/expression/expected/infinite.res.txt
@@ -1,1 +1,1 @@
-let smallest = ((heap.compare (u))[@bs ]) < (a |. (f b))
+let smallest = ((heap.compare ())[@bs ]) < (a |. (f b))

--- a/res_syntax/tests/parsing/recovery/expression/expected/infinite.res.txt
+++ b/res_syntax/tests/parsing/recovery/expression/expected/infinite.res.txt
@@ -1,1 +1,1 @@
-let smallest = ((heap.compare ())[@bs ]) < (a |. (f b))
+let smallest = ((heap.compare (u))[@bs ]) < (a |. (f b))

--- a/res_syntax/tests/printer/expr/expected/UncurriedByDefault.res.txt
+++ b/res_syntax/tests/printer/expr/expected/UncurriedByDefault.res.txt
@@ -23,11 +23,11 @@ type cpp = (unit, unit) => int
 type cu2 = (unit, unit) => unit
 type cp2 = (unit, unit) => unit
 type uu = (. unit) => int
-type up = (. ()) => int
+type up = (. unit) => int
 type uuu = (. unit) => (. unit) => int
-type upu = (. ()) => (. unit) => int
-type uup = (. unit) => (. ()) => int
-type upp = (. ()) => (. ()) => int
+type upu = (. unit) => (. unit) => int
+type uup = (. unit) => (. unit) => int
+type upp = (. unit) => (. unit) => int
 type uu2 = (. unit, unit) => unit
 type up2 = (. unit, unit) => unit
 
@@ -77,11 +77,11 @@ type cpp = (. unit, unit) => int
 type cu2 = (. unit, unit) => unit
 type cp2 = (. unit, unit) => unit
 type uu = unit => int
-type up = () => int
+type up = unit => int
 type uuu = unit => unit => int
-type upu = () => unit => int
-type uup = unit => () => int
-type upp = () => () => int
+type upu = unit => unit => int
+type uup = unit => unit => int
+type upp = unit => unit => int
 type uu2 = (unit, unit) => unit
 type up2 = (unit, unit) => unit
 


### PR DESCRIPTION
- Don't emit arity 0 for uncurried functions and types
- Get around the front-end's special treatment of application with `()` as zero-arity application, by using  annotation `@res.uapp` for uncurried applications and have the compiler front-end treat it specially.
- Don't distinguish between types `(. ) => int` and `(. unit) => int` or in uncurried notation, between `() => int` and `unit=>int`.
- Don't distinguish between `foo(.)` and `foo(. e)`, both unary applications
- Don't distinguish between `(. ) => 3` and `(. x) => x+1` both unary function definitions

This brings the uncurried subset of the language closer to the curried one.