### PR TITLE
CI: auto-cancel previous build when new one is started

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ci-${{ github.ref }}-1
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
When a commit is pushed to a branch and CI starts a build for it, auto-cancel the previous build for that branch.