### PR TITLE
Cancel previous builds for pull requests only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,8 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}-1
-  cancel-in-progress: true
+  # Cancel previous builds for pull requests only.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:


### PR DESCRIPTION
To prevent red builds on the master branch, only cancel previous builds for pull requests.