### PR TITLE
Remove errors for curried application of uncurried functions.

### DIFF
--- a/jscomp/ml/typecore.ml
+++ b/jscomp/ml/typecore.ml
@@ -3672,8 +3672,6 @@ let report_error env ppf = function
             type_expr typ;
           fprintf ppf "@ @[It is applied to too many arguments;@ %s@]@]"
                       "maybe you forgot a `;'."
-      | Tconstr (Pdot (Pdot(Pident {name = "Js"},"Fn",_),_,_),_,_) ->                 
-          fprintf ppf "This function has uncurried type, it needs to be applied in ucurried style";
       | _ ->
           fprintf ppf "@[<v>@[<2>This expression has type@ %a@]@ %s@]"
             type_expr typ

--- a/jscomp/super_errors/super_typecore.ml
+++ b/jscomp/super_errors/super_typecore.ml
@@ -202,19 +202,6 @@ let report_error env ppf = function
           type_expr typ;
         fprintf ppf "@ @[It only accepts %i %s; here, it's called with more.@]@]"
           acceptsCount (if acceptsCount == 1 then "argument" else "arguments")
-      | Tconstr (
-          (Path.Pdot (((Pdot (Path.Pident {name="Js"}, "Fn", _)) ), _, _)),
-          _,
-          _
-        )
-        ->
-        fprintf
-          ppf
-          "@[<v>This is an uncurried ReScript function. @{<info>It must be applied with a dot@}.@,@,\
-           Like this: @{<info>foo(. a, b)@}@,\
-           Not like this: @{<dim>foo(a, b)@}@,@,\
-           This guarantees that your function is fully applied. More info here:@,\
-           https://rescript-lang.org/docs/manual/latest/function#uncurried-function@]"
       | _ ->
         fprintf ppf "@[<v>@[<2>This expression has type@ %a@]@ %s@]"
           type_expr typ


### PR DESCRIPTION
This is not an error anymore since the introduction of partial application in https://github.com/rescript-lang/rescript-compiler/pull/5805

See: https://github.com/rescript-lang/rescript-compiler/issues/5888