### PR TITLE
Build with OCaml 5.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{matrix.os}}
 
     container:
-      image: ghcr.io/rescript-lang/rescript-ci-build:alpine-3.19-ocaml-4.14.1-02
+      image: ghcr.io/rescript-lang/rescript-ci-build:alpine-3.19-ocaml-5.1.0-01
 
     steps:
       # See https://github.com/actions/runner/issues/801#issuecomment-1374967227.
@@ -115,7 +115,7 @@ jobs:
             ubuntu-latest,
             windows-latest,
           ]
-        ocaml_compiler: [4.14.1]
+        ocaml_compiler: [5.1.0]
 
     runs-on: ${{matrix.os}}
 
@@ -158,11 +158,12 @@ jobs:
         uses: ocaml/setup-ocaml@v2
         if: matrix.os == 'windows-latest'
         with:
-          ocaml-compiler: ${{matrix.ocaml_compiler}}
+          ocaml-compiler: ocaml-variants.5.1.0+options,ocaml-option-mingw
           opam-pin: false
           opam-depext: false
           opam-repositories: |
-            opam-repository-mingw: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
+            windows-5.0: https://github.com/dra27/opam-repository.git#windows-5.0
+            sunset: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
             default: https://github.com/ocaml/opam-repository.git
 
       - name: "Install OPAM dependencies"
@@ -238,7 +239,7 @@ jobs:
       # Build the playground compiler on the fastest runner (ubuntu-latest)
       - name: Install JSOO
         if: matrix.os == 'ubuntu-latest'
-        run: opam install js_of_ocaml.4.0.0
+        run: opam install js_of_ocaml.5.6.0
 
       - name: Build playground compiler
         if: matrix.os == 'ubuntu-latest'

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,12 @@ test: lib
 
 test-syntax:
 	bash ./scripts/test_syntax.sh
-	make reanalyze
+	# make reanalyze
 	bash ./scripts/testok.sh
 
 test-syntax-roundtrip:
 	ROUNDTRIP_TEST=1 bash ./scripts/test_syntax.sh
-	make reanalyze
+	# make reanalyze
 	bash ./scripts/testok.sh
 
 test-gentype:

--- a/dune-project
+++ b/dune-project
@@ -25,9 +25,10 @@
   (cppo
    (= 1.6.9))
   (js_of_ocaml-compiler
-   (= 4.0.0))
+   (= 5.6.0))
   (ounit2
-   (= 2.2.6))
-  (reanalyze
-   (= 2.23.0))
+   (= 2.2.7))
+  ; No OCaml 5 compatible reanalyze on OPAM yet
+  ; (reanalyze
+  ;  (= 2.23.0))
   dune))

--- a/jscomp/frontend/bs_ast_mapper.ml
+++ b/jscomp/frontend/bs_ast_mapper.ml
@@ -21,7 +21,7 @@
 *)
 
 open! Parsetree
-open Ast_helper
+open! Ast_helper
 open Location
 
 type mapper = {

--- a/jscomp/syntax/src/jsx_v4.ml
+++ b/jscomp/syntax/src/jsx_v4.ml
@@ -1,4 +1,4 @@
-open Ast_helper
+open! Ast_helper
 open Ast_mapper
 open Asttypes
 open Parsetree

--- a/rescript.opam
+++ b/rescript.opam
@@ -10,9 +10,8 @@ depends: [
   "ocaml" {>= "4.10"}
   "ocamlformat" {= "0.26.1"}
   "cppo" {= "1.6.9"}
-  "js_of_ocaml-compiler" {= "4.0.0"}
-  "ounit2" {= "2.2.6"}
-  "reanalyze" {= "2.23.0"}
+  "js_of_ocaml-compiler" {= "5.6.0"}
+  "ounit2" {= "2.2.7"}
   "dune"
 ]
 build: [


### PR DESCRIPTION
Build the master branch / v12 with OCaml 5.1.0.

Binaries are a bit bigger than those built with 4.14. And I haven't compared the performance.
Nonetheless, I think it would be good to have this active for v12 development. In case we discover any issues, we can still fall back to 4.14 before the v12 release.

Also, I had to deactivate reanalyze for now as there is no 5.x-compatible version of it on opam yet.