### PR TITLE
Support {} for empty inlined record literals and types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ These are only breaking changes for unformatted code.
 
 # 10.1.1
 
+#### :rocket: New Feature
+
+- Add support for empty inlined record literal `{}` for inlined records where all fields are optional https://github.com/rescript-lang/rescript-compiler/pull/5900
+
 #### :bug: Bug Fix
 
 - Prevent inlining of async functions in additional cases https://github.com/rescript-lang/rescript-compiler/issues/5860

--- a/jscomp/ml/typecore.ml
+++ b/jscomp/ml/typecore.ml
@@ -2169,6 +2169,7 @@ and type_expect_ ?in_function ?(recarg=Rejected) env sexp ty_expected =
         | [], Some (representation) when lid_sexp_list = [] ->
             let optional_labels = match representation with
             | Record_optional_labels optional_labels -> optional_labels
+            | Record_inlined {optional_labels} -> optional_labels
             | _ -> [] in
             let filter_missing (ld : Types.label_declaration) =
               let name = Ident.name ld.ld_id in

--- a/jscomp/test/record_regression.js
+++ b/jscomp/test/record_regression.js
@@ -257,6 +257,12 @@ var h = newrecord$2;
 
 var h10 = newrecord$3;
 
+var ir4 = /* V0 */{
+  x: 3
+};
+
+var ir5 = /* V0 */{};
+
 exports.f1 = f1;
 exports.f2 = f2;
 exports.f3 = f3;
@@ -280,4 +286,6 @@ exports.pm2 = pm2;
 exports.inlinedRecord = inlinedRecord;
 exports.pm3 = pm3;
 exports.pm4 = pm4;
+exports.ir4 = ir4;
+exports.ir5 = ir5;
 /*  Not a pure module */

--- a/jscomp/test/record_regression.res
+++ b/jscomp/test/record_regression.res
@@ -123,3 +123,7 @@ let inlinedRecord = ir =>
   }
 let pm3 = inlinedRecord(ir2)
 let pm4 = inlinedRecord(ir3)
+
+type inlinedOptional2 = V0({x?: int})
+let ir4 = V0({x: 3})
+let ir5 = V0({})


### PR DESCRIPTION
This PR fixes #5899 