### PR TITLE
Fix dropping attributes of props in JSX v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@ These are only breaking changes for unformatted code.
 
 # 10.1.1
 
+#### :boom: Breaking Change
+
+- The prop names duplicated to keyword are not mangled automatically in JSX v4.
+  - Use `@as` instead
+
 #### :rocket: New Feature
 
 - Add support for empty inlined record literal `{}` for inlined records where all fields are optional https://github.com/rescript-lang/rescript-compiler/pull/5900

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@ These are only breaking changes for unformatted code.
 
 # 10.1.1
 
+#### :boom: Breaking Change
+
+- The prop names duplicated to keyword are not mangled automatically in JSX v4.
+  - Use `@as` instead
+
 #### :rocket: New Feature
 
 - Add support for empty inlined record literal `{}` for inlined records where all fields are optional https://github.com/rescript-lang/rescript-compiler/pull/5900
@@ -73,11 +78,6 @@ These are only breaking changes for unformatted code.
 - Fix dropping attributes from props in make function in JSX V4 https://github.com/rescript-lang/rescript-compiler/pull/5905
 
 # 10.1.0
-
-#### :boom: Breaking Change
-
-- The prop names duplicated to keyword are not mangled automatically in JSX v4.
-  - Use `@as` instead
 
 #### :bug: Bug Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,11 +61,6 @@ These are only breaking changes for unformatted code.
 
 # 10.1.1
 
-#### :boom: Breaking Change
-
-- The prop names duplicated to keyword are not mangled automatically in JSX v4.
-  - Use `@as` instead
-
 #### :rocket: New Feature
 
 - Add support for empty inlined record literal `{}` for inlined records where all fields are optional https://github.com/rescript-lang/rescript-compiler/pull/5900
@@ -78,6 +73,11 @@ These are only breaking changes for unformatted code.
 - Fix dropping attributes from props in make function in JSX V4 https://github.com/rescript-lang/rescript-compiler/pull/5905
 
 # 10.1.0
+
+#### :boom: Breaking Change
+
+- The prop names duplicated to keyword are not mangled automatically in JSX v4.
+  - Use `@as` instead
 
 #### :bug: Bug Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ These are only breaking changes for unformatted code.
 - Prevent inlining of async functions in additional cases https://github.com/rescript-lang/rescript-compiler/issues/5860
 - Fix build error where aliasing arguments to `_` in the make function with JSX V4. https://github.com/rescript-lang/rescript-compiler/pull/5881
 - Fix parsing of spread props as an expression in JSX V4 https://github.com/rescript-lang/rescript-compiler/pull/5885
+- Fix dropping attributes from props in make function in JSX V4 https://github.com/rescript-lang/rescript-compiler/pull/5905
 
 # 10.1.0
 

--- a/res_syntax/tests/ppx/react/expected/mangleKeyword.res.txt
+++ b/res_syntax/tests/ppx/react/expected/mangleKeyword.res.txt
@@ -1,25 +1,25 @@
 @@jsxConfig({version: 3})
 
-module C0 = {
+module C30 = {
   @obj external makeProps: (~_open: 'T_open, ~key: string=?, unit) => {"_open": 'T_open} = ""
 
   @react.component let make = @warning("-16") (~_open) => React.string(_open)
   let make = {
-    let \"MangleKeyword$C0" = (\"Props": {"_open": 'T_open}) => make(~_open=\"Props"["_open"])
-    \"MangleKeyword$C0"
+    let \"MangleKeyword$C30" = (\"Props": {"_open": 'T_open}) => make(~_open=\"Props"["_open"])
+    \"MangleKeyword$C30"
   }
 }
-module C1 = {
+module C31 = {
   @obj external makeProps: (~_open: string, ~key: string=?, unit) => {"_open": string} = ""
   external make: React.componentLike<{"_open": string}, React.element> = "default"
 }
 
-let c0 = React.createElement(C0.make, C0.makeProps(~_open="x", ()))
-let c1 = React.createElement(C1.make, C1.makeProps(~_open="x", ()))
+let c30 = React.createElement(C30.make, C30.makeProps(~_open="x", ()))
+let c31 = React.createElement(C31.make, C31.makeProps(~_open="x", ()))
 
 @@jsxConfig({version: 4, mode: "classic"})
 
-module C0 = {
+module C4C0 = {
   type props<'T_open, 'T_type> = {
     @as("open") _open: 'T_open,
     @as("type") _type: 'T_type,
@@ -29,12 +29,12 @@ module C0 = {
   let make = ({@as("open") _open, @as("type") _type, _}: props<'T_open, string>) =>
     React.string(_open)
   let make = {
-    let \"MangleKeyword$C0" = (props: props<_>) => make(props)
+    let \"MangleKeyword$C4C0" = (props: props<_>) => make(props)
 
-    \"MangleKeyword$C0"
+    \"MangleKeyword$C4C0"
   }
 }
-module C1 = {
+module C4C1 = {
   type props<'T_open, 'T_type> = {
     @as("open") _open: 'T_open,
     @as("type") _type: 'T_type,
@@ -43,12 +43,12 @@ module C1 = {
   external make: @as("open") React.componentLike<props<string, string>, React.element> = "default"
 }
 
-let c0 = React.createElement(C0.make, {_open: "x", _type: "t"})
-let c1 = React.createElement(C1.make, {_open: "x", _type: "t"})
+let c4c0 = React.createElement(C4C0.make, {_open: "x", _type: "t"})
+let c4c1 = React.createElement(C4C1.make, {_open: "x", _type: "t"})
 
 @@jsxConfig({version: 4, mode: "automatic"})
 
-module C0 = {
+module C4A0 = {
   type props<'T_open, 'T_type> = {
     @as("open") _open: 'T_open,
     @as("type") _type: 'T_type,
@@ -58,12 +58,12 @@ module C0 = {
   let make = ({@as("open") _open, @as("type") _type, _}: props<'T_open, string>) =>
     React.string(_open)
   let make = {
-    let \"MangleKeyword$C0" = (props: props<_>) => make(props)
+    let \"MangleKeyword$C4A0" = (props: props<_>) => make(props)
 
-    \"MangleKeyword$C0"
+    \"MangleKeyword$C4A0"
   }
 }
-module C1 = {
+module C4A1 = {
   type props<'T_open, 'T_type> = {
     @as("open") _open: 'T_open,
     @as("type") _type: 'T_type,
@@ -72,5 +72,5 @@ module C1 = {
   external make: @as("open") React.componentLike<props<string, string>, React.element> = "default"
 }
 
-let c0 = React.jsx(C0.make, {_open: "x", _type: "t"})
-let c1 = React.jsx(C1.make, {_open: "x", _type: "t"})
+let c4a0 = React.jsx(C4A0.make, {_open: "x", _type: "t"})
+let c4a1 = React.jsx(C4A1.make, {_open: "x", _type: "t"})

--- a/res_syntax/tests/ppx/react/expected/mangleKeyword.res.txt
+++ b/res_syntax/tests/ppx/react/expected/mangleKeyword.res.txt
@@ -1,0 +1,68 @@
+@@jsxConfig({version: 3})
+
+module C0 = {
+  @obj external makeProps: (~_open: 'T_open, ~key: string=?, unit) => {"_open": 'T_open} = ""
+
+  @react.component let make = @warning("-16") (~_open) => React.string(_open)
+  let make = {
+    let \"MangleKeyword$C0" = (\"Props": {"_open": 'T_open}) => make(~_open=\"Props"["_open"])
+    \"MangleKeyword$C0"
+  }
+}
+module C1 = {
+  @obj external makeProps: (~_open: string, ~key: string=?, unit) => {"_open": string} = ""
+  external make: React.componentLike<{"_open": string}, React.element> = "default"
+}
+
+let c0 = React.createElement(C0.make, C0.makeProps(~_open="x", ()))
+let c1 = React.createElement(C1.make, C1.makeProps(~_open="x", ()))
+
+@@jsxConfig({version: 4, mode: "classic"})
+
+module C0 = {
+  type props<'T_open> = {
+    _open: 'T_open,
+  }
+
+  @react.component let make = ({@as("open") _open, _}: props<'T_open>) => React.string(_open)
+  let make = {
+    let \"MangleKeyword$C0" = (props: props<_>) => make(props)
+
+    \"MangleKeyword$C0"
+  }
+}
+module C1 = {
+  type props<'T_open> = {
+    _open: 'T_open,
+  }
+
+  external make: @as("open") React.componentLike<props<string>, React.element> = "default"
+}
+
+let c0 = React.createElement(C0.make, {_open: "x"})
+let c1 = React.createElement(C1.make, {_open: "x"})
+
+@@jsxConfig({version: 4, mode: "automatic"})
+
+module C0 = {
+  type props<'T_open> = {
+    _open: 'T_open,
+  }
+
+  @react.component let make = ({@as("open") _open, _}: props<'T_open>) => React.string(_open)
+  let make = {
+    let \"MangleKeyword$C0" = (props: props<_>) => make(props)
+
+    \"MangleKeyword$C0"
+  }
+}
+module C1 = {
+  type props<'T_open> = {
+    _open: 'T_open,
+  }
+
+  external make: @as("open") React.componentLike<props<string>, React.element> = "default"
+}
+
+let c0 = React.jsx(C0.make, {_open: "x"})
+let c1 = React.jsx(C1.make, {_open: "x"})

--- a/res_syntax/tests/ppx/react/expected/mangleKeyword.res.txt
+++ b/res_syntax/tests/ppx/react/expected/mangleKeyword.res.txt
@@ -20,11 +20,14 @@ let c1 = React.createElement(C1.make, C1.makeProps(~_open="x", ()))
 @@jsxConfig({version: 4, mode: "classic"})
 
 module C0 = {
-  type props<'T_open> = {
-    _open: 'T_open,
+  type props<'T_open, 'T_type> = {
+    @as("open") _open: 'T_open,
+    @as("type") _type: 'T_type,
   }
 
-  @react.component let make = ({@as("open") _open, _}: props<'T_open>) => React.string(_open)
+  @react.component
+  let make = ({@as("open") _open, @as("type") _type, _}: props<'T_open, string>) =>
+    React.string(_open)
   let make = {
     let \"MangleKeyword$C0" = (props: props<_>) => make(props)
 
@@ -32,24 +35,28 @@ module C0 = {
   }
 }
 module C1 = {
-  type props<'T_open> = {
-    _open: 'T_open,
+  type props<'T_open, 'T_type> = {
+    @as("open") _open: 'T_open,
+    @as("type") _type: 'T_type,
   }
 
-  external make: @as("open") React.componentLike<props<string>, React.element> = "default"
+  external make: @as("open") React.componentLike<props<string, string>, React.element> = "default"
 }
 
-let c0 = React.createElement(C0.make, {_open: "x"})
-let c1 = React.createElement(C1.make, {_open: "x"})
+let c0 = React.createElement(C0.make, {_open: "x", _type: "t"})
+let c1 = React.createElement(C1.make, {_open: "x", _type: "t"})
 
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module C0 = {
-  type props<'T_open> = {
-    _open: 'T_open,
+  type props<'T_open, 'T_type> = {
+    @as("open") _open: 'T_open,
+    @as("type") _type: 'T_type,
   }
 
-  @react.component let make = ({@as("open") _open, _}: props<'T_open>) => React.string(_open)
+  @react.component
+  let make = ({@as("open") _open, @as("type") _type, _}: props<'T_open, string>) =>
+    React.string(_open)
   let make = {
     let \"MangleKeyword$C0" = (props: props<_>) => make(props)
 
@@ -57,12 +64,13 @@ module C0 = {
   }
 }
 module C1 = {
-  type props<'T_open> = {
-    _open: 'T_open,
+  type props<'T_open, 'T_type> = {
+    @as("open") _open: 'T_open,
+    @as("type") _type: 'T_type,
   }
 
-  external make: @as("open") React.componentLike<props<string>, React.element> = "default"
+  external make: @as("open") React.componentLike<props<string, string>, React.element> = "default"
 }
 
-let c0 = React.jsx(C0.make, {_open: "x"})
-let c1 = React.jsx(C1.make, {_open: "x"})
+let c0 = React.jsx(C0.make, {_open: "x", _type: "t"})
+let c1 = React.jsx(C1.make, {_open: "x", _type: "t"})

--- a/res_syntax/tests/ppx/react/mangleKeyword.res
+++ b/res_syntax/tests/ppx/react/mangleKeyword.res
@@ -17,27 +17,29 @@ let c1 = <C1 _open="x" />
 module C0 = {
   @react.component
   let make =
-    (@as("open") ~_open) => React.string(_open)
+    (@as("open") ~_open, @as("type") ~_type: string) => React.string(_open)
 }
 module C1 = {
   @react.component
-  external make: (@as("open") ~_open: string) => React.element = "default"
+  external make: (@as("open") ~_open: string, @as("type") ~_type: string) => React.element =
+    "default"
 }
 
-let c0 = <C0 _open="x" />
-let c1 = <C1 _open="x" />
+let c0 = <C0 _open="x" _type="t" />
+let c1 = <C1 _open="x" _type="t" />
 
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module C0 = {
   @react.component
   let make =
-    (@as("open") ~_open) => React.string(_open)
+    (@as("open") ~_open, @as("type") ~_type: string) => React.string(_open)
 }
 module C1 = {
   @react.component
-  external make: (@as("open") ~_open: string) => React.element = "default"
+  external make: (@as("open") ~_open: string, @as("type") ~_type: string) => React.element =
+    "default"
 }
 
-let c0 = <C0 _open="x" />
-let c1 = <C1 _open="x" />
+let c0 = <C0 _open="x" _type="t" />
+let c1 = <C1 _open="x" _type="t" />

--- a/res_syntax/tests/ppx/react/mangleKeyword.res
+++ b/res_syntax/tests/ppx/react/mangleKeyword.res
@@ -1,0 +1,43 @@
+@@jsxConfig({version: 3})
+
+module C0 = {
+  @react.component
+  let make = (~_open) => React.string(_open)
+}
+module C1 = {
+  @react.component
+  external make: (~_open: string) => React.element = "default"
+}
+
+let c0 = <C0 _open="x" />
+let c1 = <C1 _open="x" />
+
+@@jsxConfig({version: 4, mode: "classic"})
+
+module C0 = {
+  @react.component
+  let make =
+    (@as("open") ~_open) => React.string(_open)
+}
+module C1 = {
+  @react.component
+  external make: (@as("open") ~_open: string) => React.element = "default"
+}
+
+let c0 = <C0 _open="x" />
+let c1 = <C1 _open="x" />
+
+@@jsxConfig({version: 4, mode: "automatic"})
+
+module C0 = {
+  @react.component
+  let make =
+    (@as("open") ~_open) => React.string(_open)
+}
+module C1 = {
+  @react.component
+  external make: (@as("open") ~_open: string) => React.element = "default"
+}
+
+let c0 = <C0 _open="x" />
+let c1 = <C1 _open="x" />

--- a/res_syntax/tests/ppx/react/mangleKeyword.res
+++ b/res_syntax/tests/ppx/react/mangleKeyword.res
@@ -1,45 +1,45 @@
 @@jsxConfig({version: 3})
 
-module C0 = {
+module C30 = {
   @react.component
   let make = (~_open) => React.string(_open)
 }
-module C1 = {
+module C31 = {
   @react.component
   external make: (~_open: string) => React.element = "default"
 }
 
-let c0 = <C0 _open="x" />
-let c1 = <C1 _open="x" />
+let c30 = <C30 _open="x" />
+let c31 = <C31 _open="x" />
 
 @@jsxConfig({version: 4, mode: "classic"})
 
-module C0 = {
+module C4C0 = {
   @react.component
   let make =
     (@as("open") ~_open, @as("type") ~_type: string) => React.string(_open)
 }
-module C1 = {
+module C4C1 = {
   @react.component
   external make: (@as("open") ~_open: string, @as("type") ~_type: string) => React.element =
     "default"
 }
 
-let c0 = <C0 _open="x" _type="t" />
-let c1 = <C1 _open="x" _type="t" />
+let c4c0 = <C4C0 _open="x" _type="t" />
+let c4c1 = <C4C1 _open="x" _type="t" />
 
 @@jsxConfig({version: 4, mode: "automatic"})
 
-module C0 = {
+module C4A0 = {
   @react.component
   let make =
     (@as("open") ~_open, @as("type") ~_type: string) => React.string(_open)
 }
-module C1 = {
+module C4A1 = {
   @react.component
   external make: (@as("open") ~_open: string, @as("type") ~_type: string) => React.element =
     "default"
 }
 
-let c0 = <C0 _open="x" _type="t" />
-let c1 = <C1 _open="x" _type="t" />
+let c4a0 = <C4A0 _open="x" _type="t" />
+let c4a1 = <C4A1 _open="x" _type="t" />


### PR DESCRIPTION
This PR fixes dropping the attributes from the arguments and core_type in the make function or make primitive in JSX v4.
It can fix issue #5904 either.