### PR TITLE
Support optional named arguments without a final unit in uncurried functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ subset of the arguments, and return a curried type with the remaining ones https
 - Add support for default arguments in uncurried functions https://github.com/rescript-lang/rescript-compiler/pull/5835
 - Inline uncurried application when it is safe https://github.com/rescript-lang/rescript-compiler/pull/5847
 - Add support for toplevel `await` https://github.com/rescript-lang/rescript-compiler/pull/5940
+- Allow default arguments in uncurried functions without a final unit argument https://github.com/rescript-lang/rescript-compiler/pull/5907
 
 #### :boom: Breaking Change
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ subset of the arguments, and return a curried type with the remaining ones https
 - Add support for default arguments in uncurried functions https://github.com/rescript-lang/rescript-compiler/pull/5835
 - Inline uncurried application when it is safe https://github.com/rescript-lang/rescript-compiler/pull/5847
 - Add support for toplevel `await` https://github.com/rescript-lang/rescript-compiler/pull/5940
-- Allow default arguments in uncurried functions without a final unit argument https://github.com/rescript-lang/rescript-compiler/pull/5907
+- Support optional named arguments without a final unit in uncurried functions https://github.com/rescript-lang/rescript-compiler/pull/5907
 
 #### :boom: Breaking Change
 

--- a/jscomp/ml/typecore.ml
+++ b/jscomp/ml/typecore.ml
@@ -3019,7 +3019,7 @@ and type_application uncurried env funct (sargs : sargs) : targs * Types.type_ex
     match has_uncurried_type t with
     | Some (arity, _) ->
       let newarity = arity - nargs in
-      let fully_applied = newarity = 0 in
+      let fully_applied = newarity <= 0 in
       if uncurried && not fully_applied then
         raise(Error(funct.exp_loc, env,
           Uncurried_arity_mismatch (t, arity, List.length sargs)));
@@ -3046,6 +3046,10 @@ and type_application uncurried env funct (sargs : sargs) : targs * Types.type_ex
           | _ -> collect_args ())
         else
           collect_args ()
+    | [(Nolabel, {pexp_desc = Pexp_construct ({txt = Lident "()"}, None)})]
+      when uncurried && omitted = [] && List.length args = List.length !ignored ->
+      (* foo(. ) treated as empty application if all args are optional (hence ignored) *)
+        type_unknown_args max_arity args omitted ty_fun []
     | (l1, sarg1) :: sargl ->
         let (ty1, ty2) =
           let ty_fun = expand_head env ty_fun in

--- a/jscomp/test/uncurried_default.args.js
+++ b/jscomp/test/uncurried_default.args.js
@@ -20,11 +20,42 @@ var partial = Curry._1((function (param) {
 
 var total = withOpt(10, 3)(4, 11);
 
+function foo1(xOpt, y) {
+  var x = xOpt !== undefined ? xOpt : 3;
+  return x + y | 0;
+}
+
+var x = 3;
+
+var r1 = x + 11 | 0;
+
+function foo2(y, xOpt, zOpt) {
+  var x = xOpt !== undefined ? xOpt : 3;
+  var z = zOpt !== undefined ? zOpt : 4;
+  return (x + y | 0) + z | 0;
+}
+
+var r2 = foo2(11, undefined, undefined);
+
+function foo3(xOpt, yOpt) {
+  var x = xOpt !== undefined ? xOpt : 3;
+  var y = yOpt !== undefined ? yOpt : 4;
+  return x + y | 0;
+}
+
+var r3 = foo3(undefined, undefined);
+
 var StandardNotation = {
   withOpt: withOpt,
   testWithOpt: testWithOpt,
   partial: partial,
-  total: total
+  total: total,
+  foo1: foo1,
+  r1: r1,
+  foo2: foo2,
+  r2: r2,
+  foo3: foo3,
+  r3: r3
 };
 
 function withOpt$1(xOpt, y) {
@@ -45,30 +76,40 @@ var partial$1 = Curry._1((function (param) {
 
 var total$1 = withOpt$1(10, 3)(4, 11);
 
-function foo1(xOpt, y) {
+function foo1$1(xOpt, y) {
   var x = xOpt !== undefined ? xOpt : 3;
   return x + y | 0;
 }
 
-var x = 3;
+var x$1 = 3;
 
-var r1 = x + 11 | 0;
+var r1$1 = x$1 + 11 | 0;
 
-function foo2(y, xOpt, zOpt) {
+function foo2$1(y, xOpt, zOpt) {
   var x = xOpt !== undefined ? xOpt : 3;
   var z = zOpt !== undefined ? zOpt : 4;
   return (x + y | 0) + z | 0;
 }
 
-var r2 = foo2(11, undefined, undefined);
+var r2$1 = foo2$1(11, undefined, undefined);
+
+function foo3$1(xOpt, yOpt) {
+  var x = xOpt !== undefined ? xOpt : 3;
+  var y = yOpt !== undefined ? yOpt : 4;
+  return x + y | 0;
+}
+
+var r3$1 = foo3$1(undefined, undefined);
 
 exports.StandardNotation = StandardNotation;
 exports.withOpt = withOpt$1;
 exports.testWithOpt = testWithOpt$1;
 exports.partial = partial$1;
 exports.total = total$1;
-exports.foo1 = foo1;
-exports.r1 = r1;
-exports.foo2 = foo2;
-exports.r2 = r2;
+exports.foo1 = foo1$1;
+exports.r1 = r1$1;
+exports.foo2 = foo2$1;
+exports.r2 = r2$1;
+exports.foo3 = foo3$1;
+exports.r3 = r3$1;
 /* testWithOpt Not a pure module */

--- a/jscomp/test/uncurried_default.args.js
+++ b/jscomp/test/uncurried_default.args.js
@@ -45,9 +45,30 @@ var partial$1 = Curry._1((function (param) {
 
 var total$1 = withOpt$1(10, 3)(4, 11);
 
+function foo1(xOpt, y) {
+  var x = xOpt !== undefined ? xOpt : 3;
+  return x + y | 0;
+}
+
+var x = 3;
+
+var r1 = x + 11 | 0;
+
+function foo2(y, xOpt, zOpt) {
+  var x = xOpt !== undefined ? xOpt : 3;
+  var z = zOpt !== undefined ? zOpt : 4;
+  return (x + y | 0) + z | 0;
+}
+
+var r2 = foo2(11, undefined, undefined);
+
 exports.StandardNotation = StandardNotation;
 exports.withOpt = withOpt$1;
 exports.testWithOpt = testWithOpt$1;
 exports.partial = partial$1;
 exports.total = total$1;
+exports.foo1 = foo1;
+exports.r1 = r1;
+exports.foo2 = foo2;
+exports.r2 = r2;
 /* testWithOpt Not a pure module */

--- a/jscomp/test/uncurried_default.args.res
+++ b/jscomp/test/uncurried_default.args.res
@@ -17,5 +17,5 @@ let total = withOpt(~x=10, 3)(~z=4, 11)
 let foo1 = (~x=3, ~y) => x+y
 let r1 = foo1(~y=11)
 
-let foo2 = @warning("-16") (~y, ~x=3, ~z=4) => x+y+z
+let foo2 = (~y, ~x=3, ~z=4) => x+y+z
 let r2 = foo2(~y=11)

--- a/jscomp/test/uncurried_default.args.res
+++ b/jscomp/test/uncurried_default.args.res
@@ -13,3 +13,9 @@ let withOpt = (~x=1, y) => (~z=1, w) => x+y+z+w
 let testWithOpt = withOpt(3)(4)
 let partial = withOpt(. ~x=10)(. 3)(. ~z=4)(. 11)
 let total = withOpt(~x=10, 3)(~z=4, 11)
+
+let foo1 = (~x=3, ~y) => x+y
+let r1 = foo1(~y=11)
+
+let foo2 = @warning("-16") (~y, ~x=3, ~z=4) => x+y+z
+let r2 = foo2(~y=11)

--- a/jscomp/test/uncurried_default.args.res
+++ b/jscomp/test/uncurried_default.args.res
@@ -3,6 +3,15 @@ module StandardNotation = {
   let testWithOpt = withOpt(. 3)(. 4)
   let partial = withOpt(~x=10)(3)(~z=4)(11)
   let total = withOpt(. ~x=10, 3)(. ~z=4, 11)
+
+  let foo1 = (. ~x=3, ~y) => x+y
+  let r1 = foo1(. ~y=11)
+
+  let foo2 = (. ~y, ~x=3, ~z=4) => x+y+z
+  let r2 = foo2(. ~y=11)
+
+  let foo3 = (. ~x=3, ~y=4) => x+y
+  let r3 = foo3(. )
 }
 
 @@uncurried
@@ -19,3 +28,6 @@ let r1 = foo1(~y=11)
 
 let foo2 = (~y, ~x=3, ~z=4) => x+y+z
 let r2 = foo2(~y=11)
+
+let foo3 = (~x=3, ~y=4) => x+y
+let r3 = foo3()


### PR DESCRIPTION
Functions with optional named arguments normally require a final unit (or some other unnamed argument) to specify the end of supplied arguments: https://rescript-lang.org/docs/manual/latest/function#optional-labeled-arguments
With uncurried functions, the number of arguments is fixed, and there is no such ambiguity.
This PR supports the use of optional named arguments without a final unit.

For example:
```res
let foo = (. ~x=3, ~y) => x+y
```
can now be applied omitting `x` as
```res
let n = foo(. ~y=11)
```

There's one special case where all arguments are optional:
```res
let allOpt = (. ~x=3, ~y=4) => x+y
```
this can be applied without arguments as follows
```res
let z = allOpt(. )
```

Note that this application `foo(. )` normally supplies a single argument of type `unit`. However, the type of `foo` is enough to disambiguate an interpret it as passing zero arguments when `foo` does not take any unnamed arguments.

This means in practice that uncurried functions are now strictly more expressive than curried ones.

- [x] Figure out what to do with the warning "This optional parameter in final position will, in practice, not be optional": disabled for uncurried functions via the type checker.
- [x] Figure out the case of all optional arguments: interpret `foo(. )`, as empty application when `foo` is an uncurried function which only has optional arguments.