### PR TITLE
Added `as` property to DOM props

### DIFF
--- a/jscomp/others/jsxDOM.res
+++ b/jscomp/others/jsxDOM.res
@@ -162,6 +162,8 @@ type domProps = {
   action?: string /* uri */,
   allowFullScreen?: bool,
   alt?: string,
+  @as("as")
+  as_?: string,
   async?: bool,
   autoComplete?: string /* has a fixed, but large-ish, set of possible values */,
   autoCapitalize?: string /* Mobile Safari specific */,


### PR DESCRIPTION
Changes from https://github.com/reasonml/reason-react/pull/603

See https://html.spec.whatwg.org/multipage/links.html#link-type-preload for when this can be used. For example:

```html
<link rel="preload" as="style" href="..." />
```