### PR TITLE
Require return type annotation for async functions to be of promise type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ These are only breaking changes for unformatted code.
 - Fix compiler ppx issue when combining `async` and uncurried application https://github.com/rescript-lang/rescript-compiler/pull/5856
 - Fix issue where the internal representation of uncurried types would leak when a non-function is applied in a curried way https://github.com/rescript-lang/rescript-compiler/pull/5892
 - In GenType, check annotations also in module types to decide whether to produce the `.gen.tsx` file https://github.com/rescript-lang/rescript-compiler/pull/5903
+- Require return type annotation for async functions to be of promise type https://github.com/rescript-lang/rescript-compiler/issues/5912
 
 #### :nail_care: Polish
 

--- a/jscomp/frontend/ast_async.ml
+++ b/jscomp/frontend/ast_async.ml
@@ -1,11 +1,21 @@
+let isResReturnType : Parsetree.attribute -> bool =
+  fun ({ txt }, _) -> txt = "res.returnType"
+ 
 let add_promise_type ~async (result : Parsetree.expression) =
   if async then
     let loc = result.pexp_loc in
+    let isTypeAnnotated = Ext_list.exists result.pexp_attributes isResReturnType in
     let unsafe_async =
       Ast_helper.Exp.ident ~loc
         { txt = Ldot (Ldot (Lident "Js", "Promise"), "unsafe_async"); loc }
     in
-    Ast_helper.Exp.apply ~loc unsafe_async [ (Nolabel, result) ]
+  match result.pexp_desc with
+    | Pexp_constraint (e,t) when isTypeAnnotated ->
+      let loc = t.ptyp_loc in
+      let e = Ast_helper.Exp.apply ~loc unsafe_async [ (Nolabel, e) ] in
+      Ast_helper.Exp.constraint_ ~loc e t
+    | _ ->
+      Ast_helper.Exp.apply ~loc unsafe_async [ (Nolabel, result) ]
   else result
 
 let add_async_attribute ~async (body : Parsetree.expression) =

--- a/jscomp/test/async_await.js
+++ b/jscomp/test/async_await.js
@@ -1,6 +1,18 @@
 'use strict';
 
 
+async function withAnnotations1(param) {
+  return 3;
+}
+
+async function withAnnotations2(param) {
+  return 3;
+}
+
+async function withAnnotations3(param) {
+  return 3;
+}
+
 function next(n) {
   return n + 1 | 0;
 }
@@ -18,6 +30,9 @@ function Make(I) {
         };
 }
 
+exports.withAnnotations1 = withAnnotations1;
+exports.withAnnotations2 = withAnnotations2;
+exports.withAnnotations3 = withAnnotations3;
 exports.next = next;
 exports.useNext = useNext;
 exports.Make = Make;

--- a/jscomp/test/async_await.res
+++ b/jscomp/test/async_await.res
@@ -1,3 +1,7 @@
+let withAnnotations1 = async () : promise<int> => 3
+let withAnnotations2 = async () : promise<int> => 3
+let withAnnotations3 = async () : promise<int> => (3:int)
+
 @@uncurried
 
 let next = n => n + 1

--- a/res_syntax/src/res_parsetree_viewer.ml
+++ b/res_syntax/src/res_parsetree_viewer.ml
@@ -95,6 +95,13 @@ let hasAwaitAttribute attrs =
       | _ -> false)
     attrs
 
+let hasReturnTypeAttribute attrs =
+  List.exists
+    (function
+      | {Location.txt = "res.returnType"}, _ -> true
+      | _ -> false)
+    attrs
+
 let collectListExpressions expr =
   let rec collect acc expr =
     match expr.pexp_desc with
@@ -205,7 +212,7 @@ let filterParsingAttrs attrs =
             Location.txt =
               ( "bs" | "res.uapp" | "res.arity" | "res.braces" | "res.iflet"
               | "res.namedArgLoc" | "res.optional" | "res.ternary" | "res.async"
-              | "res.await" | "res.template" );
+              | "res.await" | "res.template" | "res.returnType" );
           },
           _ ) ->
         false
@@ -353,7 +360,8 @@ let hasAttributes attrs =
       | ( {
             Location.txt =
               ( "bs" | "res.uapp" | "res.arity" | "res.braces" | "res.iflet"
-              | "res.ternary" | "res.async" | "res.await" | "res.template" );
+              | "res.ternary" | "res.async" | "res.await" | "res.template"
+              | "res.returnType" );
           },
           _ ) ->
         false
@@ -535,7 +543,8 @@ let isPrintableAttribute attr =
   | ( {
         Location.txt =
           ( "bs" | "res.uapp" | "res.arity" | "res.iflet" | "res.braces" | "JSX"
-          | "res.async" | "res.await" | "res.template" | "res.ternary" );
+          | "res.async" | "res.await" | "res.template" | "res.ternary"
+          | "res.returnType" );
       },
       _ ) ->
     false

--- a/res_syntax/src/res_parsetree_viewer.mli
+++ b/res_syntax/src/res_parsetree_viewer.mli
@@ -31,6 +31,8 @@ val processFunctionAttributes : Parsetree.attributes -> functionAttributesInfo
 
 val hasAwaitAttribute : Parsetree.attributes -> bool
 
+val hasReturnTypeAttribute : Parsetree.attributes -> bool
+
 type ifConditionKind =
   | If of Parsetree.expression
   | IfLet of Parsetree.pattern * Parsetree.expression

--- a/res_syntax/src/res_printer.ml
+++ b/res_syntax/src/res_printer.ml
@@ -2602,7 +2602,10 @@ and printExpression ~state (e : Parsetree.expression) cmtTbl =
     let uncurried = uncurried || bs in
     let returnExpr, typConstraint =
       match returnExpr.pexp_desc with
-      | Pexp_constraint (expr, typ) ->
+      | Pexp_constraint (expr, typ)
+        when (not async)
+             || Res_parsetree_viewer.hasReturnTypeAttribute
+                  returnExpr.pexp_attributes ->
         ( {
             expr with
             pexp_attributes =
@@ -3308,7 +3311,10 @@ and printPexpFun ~state ~inCallback e cmtTbl =
   let uncurried = bs || uncurried in
   let returnExpr, typConstraint =
     match returnExpr.pexp_desc with
-    | Pexp_constraint (expr, typ) ->
+    | Pexp_constraint (expr, typ)
+      when (not async)
+           || Res_parsetree_viewer.hasReturnTypeAttribute
+                returnExpr.pexp_attributes ->
       ( {
           expr with
           pexp_attributes =

--- a/res_syntax/tests/parsing/grammar/expressions/expected/async.res.txt
+++ b/res_syntax/tests/parsing/grammar/expressions/expected/async.res.txt
@@ -26,8 +26,10 @@ let async =
   [@res.braces ])
 let f =
   ((if isPositive
-    then ((fun a -> fun b -> (a + b : int))[@res.async ])
-    else (((fun c -> fun d -> (c - d : int)))[@res.async ]))
+    then ((fun a -> fun b -> (((a + b : int))[@res.returnType ]))
+      [@res.async ])
+    else (((fun c -> fun d -> (((c - d : int))[@res.returnType ])))
+      [@res.async ]))
   [@res.ternary ])
 let foo = async ~a:((34)[@res.namedArgLoc ])
 let bar = ((fun ~a:((a)[@res.namedArgLoc ]) -> a + 1)[@res.async ])

--- a/res_syntax/tests/printer/expr/asyncAwait.res
+++ b/res_syntax/tests/printer/expr/asyncAwait.res
@@ -120,3 +120,10 @@ let c3 = (. x) => @foo y => x+y
 
 type t1 = (. int) => string => bool
 type t2 = (. int, string) => bool
+
+let ann1 = async () => (3:int)
+let ann2 = async () : promise<int> => 3
+let ann3 = async () : promise<int> => (3:int)
+let ann4 = foo(async () => (3:int))
+let ann5 = foo(async () : promise<int> => 3)
+let ann6 = foo(async () : promise<int> => (3:int))

--- a/res_syntax/tests/printer/expr/expected/asyncAwait.res.txt
+++ b/res_syntax/tests/printer/expr/expected/asyncAwait.res.txt
@@ -142,3 +142,10 @@ let c3 = (. x) => {@foo y => x + y}
 
 type t1 = (. int) => string => bool
 type t2 = (. int, string) => bool
+
+let ann1 = async () => (3: int)
+let ann2 = async (): promise<int> => 3
+let ann3 = async (): promise<int> => (3: int)
+let ann4 = foo(async () => (3: int))
+let ann5 = foo(async (): promise<int> => 3)
+let ann6 = foo(async (): promise<int> => (3: int))


### PR DESCRIPTION
- Add annotation`@res.returnType` to type annotation on the return type of async functions
- Don't reformat type annotations on the body of async functions
- Add the type constraint on the return type after promoting the body of async functions