### PR TITLE
Treat *.ml{i} in Linguist as OCaml

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.ml linguist-language=OCaml
+*.mli linguist-language=OCaml


### PR DESCRIPTION
Some *.ml{i} files are being incorrectly recognized as SML; this fixes them to be OCaml instead.