### PR TITLE
Fix jsx mode being ignored when set via @@jsxConfig

### DIFF
--- a/res_syntax/src/reactjs_jsx_ppx.ml
+++ b/res_syntax/src/reactjs_jsx_ppx.ml
@@ -28,7 +28,8 @@ let getJsxConfigByKey ~key ~type_ recordFields =
           Some value
         | ( String,
             {txt = Lident k},
-            {pexp_desc = Pexp_constant (Pconst_string (value, None))} )
+            (* accept both normal strings and "js" strings *)
+            {pexp_desc = Pexp_constant (Pconst_string (value, _))} )
           when k = key ->
           Some value
         | _ -> None)


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-compiler/issues/5927 for the master branch.