### PR TITLE
Clean up postinstall script

### DIFF
--- a/scripts/rescript_dump.js
+++ b/scripts/rescript_dump.js
@@ -5,6 +5,9 @@ var dump_usage = `Usage: rescript dump <options> [target]
 `;
 var child_process = require("child_process");
 var path = require("path");
+/**
+ * @type {arg.specs}
+ */
 var specs = [];
 
 /**

--- a/scripts/rescript_postinstall.js
+++ b/scripts/rescript_postinstall.js
@@ -1,62 +1,43 @@
 //@ts-check
-var child_process = require("child_process");
-var fs = require("fs");
+const child_process = require("child_process");
+const fs = require("fs");
 
-var supported_os = ["darwin", "freebsd", "linux", "openbsd", "win32"];
-if (supported_os.indexOf(process.platform) < 0) {
-  throw new Error("Not supported platform" + process.platform);
-}
-
-var bsc_exe = require("./bin_path").bsc_exe;
-
-var ninja_bin_output = require("./bin_path").ninja_exe;
+const bsc_exe = require("./bin_path").bsc_exe;
+const ninja_exe = require("./bin_path").ninja_exe;
 
 function checkNinja() {
-  var vendor_ninja_version = "1.9.0.git";
-
-  // sanity check to make sure the binary actually runs. Used for Linux. Too many variants
-  /**
-   *
-   * @param {string} binary_path
-   */
-  function test_ninja_compatible(binary_path) {
-    var version;
-    try {
-      version = child_process
-        .execSync(JSON.stringify(binary_path) + " --version", {
-          encoding: "utf8",
-          stdio: ["pipe", "pipe", "ignore"], // execSync outputs to stdout even if we catch the error. Silent it here
-        })
-        .trim();
-    } catch (e) {
-      console.log("ninja not compatible?", String(e));
-      return false;
-    }
-    return version === vendor_ninja_version;
+  if (!fs.existsSync(ninja_exe)) {
+    throw new Error(
+      `No ninja binary found for this platform. ${ninja_exe} does not exist.`
+    );
   }
 
-  if (
-    fs.existsSync(ninja_bin_output) &&
-    test_ninja_compatible(ninja_bin_output)
-  ) {
-    console.log(
-      "ninja binary is already cached and installed: ",
-      ninja_bin_output
+  try {
+    return String(child_process.execFileSync(ninja_exe, ["--version"])).trim();
+  } catch (e) {
+    throw new Error(
+      `Error getting ninja version. The ninja binary at ${ninja_exe} may not be compatible with this platform: ${e}`
     );
-  } else {
-    throw new Error("No matching ninja binary found");
   }
 }
 
 function checkCompiler() {
+  if (!fs.existsSync(bsc_exe)) {
+    throw new Error(
+      `No ReScript compiler binary found for this platform. ${bsc_exe} does not exist.`
+    );
+  }
+
   try {
-    var version = String(child_process.execFileSync(bsc_exe, ["-v"]));
-    console.log("ReScript compiler version:", version);
+    return String(child_process.execFileSync(bsc_exe, ["-v"])).trim();
   } catch (e) {
-    throw new Error("No working ReScript compiler");
+    throw new Error(
+      `Error getting ReScript compiler version. The compiler binary at ${bsc_exe} may not be compatible with this platform: ${e}`
+    );
   }
 }
 
-checkNinja();
+var ninjaVersion = checkNinja();
+var compilerVersion = checkCompiler();
 
-checkCompiler();
+console.log(`${compilerVersion} (ninja ${ninjaVersion})`);


### PR DESCRIPTION
Simplify the postinstall script and provide better error messages.

Do not explicitly limit supported operating systems here. The user will get a corresponding error message anyway when no binary is found for the platform. Also this prepares us for supporting user-provided binaries for exotic platforms.