### PR TITLE
Prepare bin_path logic for more platforms/architectures

### DIFF
--- a/bsc
+++ b/bsc
@@ -2,18 +2,12 @@
 "use strict";
 
 var child_process = require("child_process");
-var path = require("path");
-var exe = path.join(
-  __dirname,
-  process.platform === "darwin" && process.arch === "arm64"
-    ? process.platform + process.arch
-    : process.platform,
-  "bsc.exe"
-);
+var bsc_exe = require("./scripts/bin_path").bsc_exe;
+
 var delegate_args = process.argv.slice(2);
 
 try {
-  child_process.execFileSync(exe, delegate_args, { stdio: "inherit" });
+  child_process.execFileSync(bsc_exe, delegate_args, { stdio: "inherit" });
 } catch (e) {
   if (e.code === "ENOENT") {
     console.error(String(e));

--- a/scripts/bin_path.js
+++ b/scripts/bin_path.js
@@ -4,11 +4,13 @@ var path = require("path");
 
 /**
  * @type{string}
+ *
+ * For compatibility reasons, if the architecture is x64, omit it from the bin directory name.
+ * So we'll have "darwin", "linux" and "win32" for x64 arch,
+ * but "darwinarm64" and "linuxarm64" for arm64 arch.
  */
 var binDirName =
-  process.platform === "darwin" && process.arch === "arm64"
-    ? process.platform + process.arch
-    : process.platform;
+  process.arch === "x64" ? process.platform : process.platform + process.arch;
 
 /**
  *


### PR DESCRIPTION
If we want to include binaries for additional platforms/architectures in the npm package (Linux arm64 would be the next candidate), we need to think about the bin path / directory name for those.

Currently we are supporting the following architectures:
* x64: darwin, linux, windows
* arm64: darwin

and we have some special logic in place to use "darwinarm64" for darwin on arm64.

To generalize while keeping compatible with the existing naming, we can use the following rule:
* For architecture x64, the directory name is just the platform name.
* For all other architectures, it is platform name + architecture name.