### PR TITLE
Add loc to each props in JSX4

### DIFF
--- a/jscomp/ml/typedecl.ml
+++ b/jscomp/ml/typedecl.ml
@@ -1844,11 +1844,11 @@ let tys_of_constr_args = function
 
 let report_error ppf = function
   | Repeated_parameter ->
-      fprintf ppf "A type parameter occurs several times. If this is a component, check for duplicated props."
+      fprintf ppf "A type parameter occurs several times"
   | Duplicate_constructor s ->
       fprintf ppf "Two constructors are named %s" s
   | Duplicate_label s ->
-      fprintf ppf "Two labels are named %s. If this is a component, check for duplicated props." s
+      fprintf ppf "Two labels are named %s" s
   | Recursive_abbrev s ->
       fprintf ppf "The type abbreviation %s is cyclic" s
   | Cycle_in_def (s, ty) ->

--- a/jscomp/ml/typedecl.ml
+++ b/jscomp/ml/typedecl.ml
@@ -1844,11 +1844,11 @@ let tys_of_constr_args = function
 
 let report_error ppf = function
   | Repeated_parameter ->
-      fprintf ppf "A type parameter occurs several times"
+      fprintf ppf "A type parameter occurs several times. If this is a component, check duplicated props"
   | Duplicate_constructor s ->
       fprintf ppf "Two constructors are named %s" s
   | Duplicate_label s ->
-      fprintf ppf "Two labels are named %s" s
+      fprintf ppf "Two labels are named %s. If this is a component, check duplicated props" s
   | Recursive_abbrev s ->
       fprintf ppf "The type abbreviation %s is cyclic" s
   | Cycle_in_def (s, ty) ->

--- a/jscomp/ml/typedecl.ml
+++ b/jscomp/ml/typedecl.ml
@@ -1844,7 +1844,7 @@ let tys_of_constr_args = function
 
 let report_error ppf = function
   | Repeated_parameter ->
-      fprintf ppf "A type parameter occurs several times. If this is a component, check duplicated props."
+      fprintf ppf "A type parameter occurs several times. If this is a component, check for duplicated props."
   | Duplicate_constructor s ->
       fprintf ppf "Two constructors are named %s" s
   | Duplicate_label s ->

--- a/jscomp/ml/typedecl.ml
+++ b/jscomp/ml/typedecl.ml
@@ -1848,7 +1848,7 @@ let report_error ppf = function
   | Duplicate_constructor s ->
       fprintf ppf "Two constructors are named %s" s
   | Duplicate_label s ->
-      fprintf ppf "Two labels are named %s. If this is a component, check duplicated props." s
+      fprintf ppf "Two labels are named %s. If this is a component, check for duplicated props." s
   | Recursive_abbrev s ->
       fprintf ppf "The type abbreviation %s is cyclic" s
   | Cycle_in_def (s, ty) ->

--- a/jscomp/ml/typedecl.ml
+++ b/jscomp/ml/typedecl.ml
@@ -1844,11 +1844,11 @@ let tys_of_constr_args = function
 
 let report_error ppf = function
   | Repeated_parameter ->
-      fprintf ppf "A type parameter occurs several times. If this is a component, check duplicated props"
+      fprintf ppf "A type parameter occurs several times. If this is a component, check duplicated props."
   | Duplicate_constructor s ->
       fprintf ppf "Two constructors are named %s" s
   | Duplicate_label s ->
-      fprintf ppf "Two labels are named %s. If this is a component, check duplicated props" s
+      fprintf ppf "Two labels are named %s. If this is a component, check duplicated props." s
   | Recursive_abbrev s ->
       fprintf ppf "The type abbreviation %s is cyclic" s
   | Cycle_in_def (s, ty) ->

--- a/res_syntax/src/reactjs_jsx_v4.ml
+++ b/res_syntax/src/reactjs_jsx_v4.ml
@@ -304,7 +304,7 @@ let makeLabelDecls namedTypeList =
   in
   match duplicatedProp with
   | Some (label, loc) ->
-    React_jsx_common.raiseError ~loc "JSX: Duplicated prop %s" label
+    React_jsx_common.raiseError ~loc "JSX: found the duplicated prop `%s`" label
   | None ->
     namedTypeList
     |> List.map (fun (isOptional, label, attrs, loc, interiorType) ->

--- a/res_syntax/src/reactjs_jsx_v4.ml
+++ b/res_syntax/src/reactjs_jsx_v4.ml
@@ -242,9 +242,9 @@ let recordFromProps ~loc ~removeKey callArguments =
 (* let make = ({id, name, children}: props<'id, 'name, 'children>) *)
 let makePropsTypeParamsTvar namedTypeList =
   namedTypeList
-  |> List.filter_map (fun (_isOptional, label, _, _interiorType) ->
+  |> List.filter_map (fun (_isOptional, label, _, loc, _interiorType) ->
          if label = "key" then None
-         else Some (Typ.var @@ safeTypeFromValue (Labelled label)))
+         else Some (Typ.var ~loc @@ safeTypeFromValue (Labelled label)))
 
 let stripOption coreType =
   match coreType with
@@ -268,7 +268,7 @@ let stripJsNullable coreType =
 let makePropsTypeParams ?(stripExplicitOption = false)
     ?(stripExplicitJsNullableOfRef = false) namedTypeList =
   namedTypeList
-  |> List.filter_map (fun (isOptional, label, _, interiorType) ->
+  |> List.filter_map (fun (isOptional, label, _, loc, interiorType) ->
          if label = "key" then None
            (* TODO: Worth thinking how about "ref_" or "_ref" usages *)
          else if label = "ref" then
@@ -277,7 +277,7 @@ let makePropsTypeParams ?(stripExplicitOption = false)
                 For example, if JSX ppx is used for React Native, type would be different.
              *)
            match interiorType with
-           | {ptyp_desc = Ptyp_var "ref"} -> Some (refType Location.none)
+           | {ptyp_desc = Ptyp_var "ref"} -> Some (refType loc)
            | _ ->
              (* Strip explicit Js.Nullable.t in case of forwardRef *)
              if stripExplicitJsNullableOfRef then stripJsNullable interiorType
@@ -287,9 +287,9 @@ let makePropsTypeParams ?(stripExplicitOption = false)
          else if isOptional && stripExplicitOption then stripOption interiorType
          else Some interiorType)
 
-let makeLabelDecls ~loc namedTypeList =
+let makeLabelDecls namedTypeList =
   namedTypeList
-  |> List.map (fun (isOptional, label, attrs, interiorType) ->
+  |> List.map (fun (isOptional, label, attrs, loc, interiorType) ->
          if label = "key" then
            Type.field ~loc ~attrs:(optionalAttrs @ attrs) {txt = label; loc}
              interiorType
@@ -301,7 +301,7 @@ let makeLabelDecls ~loc namedTypeList =
              (Typ.var @@ safeTypeFromValue @@ Labelled label))
 
 let makeTypeDecls propsName loc namedTypeList =
-  let labelDeclList = makeLabelDecls ~loc namedTypeList in
+  let labelDeclList = makeLabelDecls namedTypeList in
   (* 'id, 'className, ... *)
   let params =
     makePropsTypeParamsTvar namedTypeList
@@ -702,17 +702,22 @@ let argToType ~newtypes ~(typeConstraints : core_type option) types
   in
   match (type_, name, default) with
   | Some type_, name, _ when isOptional name ->
-    (true, getLabel name, attrs, {type_ with ptyp_attributes = optionalAttrs})
+    ( true,
+      getLabel name,
+      attrs,
+      loc,
+      {type_ with ptyp_attributes = optionalAttrs} )
     :: types
-  | Some type_, name, _ -> (false, getLabel name, attrs, type_) :: types
+  | Some type_, name, _ -> (false, getLabel name, attrs, loc, type_) :: types
   | None, name, _ when isOptional name ->
     ( true,
       getLabel name,
       attrs,
+      loc,
       Typ.var ~loc ~attrs:optionalAttrs (safeTypeFromValue name) )
     :: types
   | None, name, _ when isLabelled name ->
-    (false, getLabel name, attrs, Typ.var ~loc (safeTypeFromValue name))
+    (false, getLabel name, attrs, loc, Typ.var ~loc (safeTypeFromValue name))
     :: types
   | _ -> types
 
@@ -721,10 +726,12 @@ let argWithDefaultValue (name, default, _, _, _, _) =
   | Some default when isOptional name -> Some (getLabel name, default)
   | _ -> None
 
-let argToConcreteType types (name, attrs, _loc, type_) =
+let argToConcreteType types (name, attrs, loc, type_) =
   match name with
-  | name when isLabelled name -> (false, getLabel name, attrs, type_) :: types
-  | name when isOptional name -> (true, getLabel name, attrs, type_) :: types
+  | name when isLabelled name ->
+    (false, getLabel name, attrs, loc, type_) :: types
+  | name when isOptional name ->
+    (true, getLabel name, attrs, loc, type_) :: types
   | _ -> types
 
 let check_string_int_attribute_iter =
@@ -1306,7 +1313,8 @@ let transformSignatureItem ~config _mapper item =
         makePropsRecordTypeSig ~coreTypeOfAttr ~typVarsOfCoreType "props"
           psig_loc
           ((* If there is Nolabel arg, regard the type as ref in forwardRef *)
-           (if !hasForwardRef then [(true, "ref", [], refType Location.none)]
+           (if !hasForwardRef then
+            [(true, "ref", [], Location.none, refType Location.none)]
            else [])
           @ namedTypeList)
       in

--- a/res_syntax/tests/ppx/react/expected/aliasProps.res.txt
+++ b/res_syntax/tests/ppx/react/expected/aliasProps.res.txt
@@ -1,10 +1,7 @@
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module C0 = {
-  type props<'priority, 'text> = {
-    priority: 'priority,
-    text?: 'text,
-  }
+  type props<'priority, 'text> = {priority: 'priority, text?: 'text}
 
   @react.component
   let make = ({priority: _, ?text, _}: props<'priority, 'text>) => {
@@ -23,10 +20,7 @@ module C0 = {
 }
 
 module C1 = {
-  type props<'priority, 'text> = {
-    priority: 'priority,
-    text?: 'text,
-  }
+  type props<'priority, 'text> = {priority: 'priority, text?: 'text}
 
   @react.component
   let make = ({priority: p, ?text, _}: props<'priority, 'text>) => {

--- a/res_syntax/tests/ppx/react/expected/commentAtTop.res.txt
+++ b/res_syntax/tests/ppx/react/expected/commentAtTop.res.txt
@@ -1,6 +1,4 @@
-type props<'msg> = { // test React JSX file
-  msg: 'msg,
-}
+type props<'msg> = {msg: 'msg} // test React JSX file
 
 @react.component
 let make = ({msg, _}: props<'msg>) => {

--- a/res_syntax/tests/ppx/react/expected/externalWithCustomName.res.txt
+++ b/res_syntax/tests/ppx/react/expected/externalWithCustomName.res.txt
@@ -13,10 +13,7 @@ let t = React.createElement(Foo.component, Foo.componentProps(~a=1, ~b={"1"}, ()
 @@jsxConfig({version: 4, mode: "classic"})
 
 module Foo = {
-  type props<'a, 'b> = {
-    a: 'a,
-    b: 'b,
-  }
+  type props<'a, 'b> = {a: 'a, b: 'b}
 
   @module("Foo")
   external component: React.componentLike<props<int, string>, React.element> = "component"
@@ -27,10 +24,7 @@ let t = React.createElement(Foo.component, {a: 1, b: "1"})
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module Foo = {
-  type props<'a, 'b> = {
-    a: 'a,
-    b: 'b,
-  }
+  type props<'a, 'b> = {a: 'a, b: 'b}
 
   @module("Foo")
   external component: React.componentLike<props<int, string>, React.element> = "component"

--- a/res_syntax/tests/ppx/react/expected/fileLevelConfig.res.txt
+++ b/res_syntax/tests/ppx/react/expected/fileLevelConfig.res.txt
@@ -18,9 +18,7 @@ module V3 = {
 @@jsxConfig({version: 4, mode: "classic"})
 
 module V4C = {
-  type props<'msg> = {
-    msg: 'msg,
-  }
+  type props<'msg> = {msg: 'msg}
 
   @react.component
   let make = ({msg, _}: props<'msg>) => {
@@ -36,9 +34,7 @@ module V4C = {
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module V4A = {
-  type props<'msg> = {
-    msg: 'msg,
-  }
+  type props<'msg> = {msg: 'msg}
 
   @react.component
   let make = ({msg, _}: props<'msg>) => {

--- a/res_syntax/tests/ppx/react/expected/interface.res.txt
+++ b/res_syntax/tests/ppx/react/expected/interface.res.txt
@@ -1,7 +1,5 @@
 module A = {
-  type props<'x> = {
-    x: 'x,
-  }
+  type props<'x> = {x: 'x}
   @react.component let make = ({x, _}: props<'x>) => React.string(x)
   let make = {
     let \"Interface$A" = (props: props<_>) => make(props)

--- a/res_syntax/tests/ppx/react/expected/interface.resi.txt
+++ b/res_syntax/tests/ppx/react/expected/interface.resi.txt
@@ -1,7 +1,5 @@
 module A: {
-  type props<'x> = {
-    x: 'x,
-  }
+  type props<'x> = {x: 'x}
   let make: React.componentLike<props<string>, React.element>
 }
 

--- a/res_syntax/tests/ppx/react/expected/interfaceWithRef.res.txt
+++ b/res_syntax/tests/ppx/react/expected/interfaceWithRef.res.txt
@@ -1,7 +1,4 @@
-type props<'x, 'ref> = {
-  x: 'x,
-  ref?: 'ref,
-}
+type props<'x, 'ref> = {x: 'x, ref?: 'ref}
 @react.component
 let make = (
   {x, _}: props<string, ReactDOM.Ref.currentDomRef>,

--- a/res_syntax/tests/ppx/react/expected/interfaceWithRef.resi.txt
+++ b/res_syntax/tests/ppx/react/expected/interfaceWithRef.resi.txt
@@ -1,5 +1,2 @@
-type props<'x, 'ref> = {
-  x: 'x,
-  ref?: 'ref,
-}
+type props<'x, 'ref> = {x: 'x, ref?: 'ref}
 let make: React.componentLike<props<string, ReactDOM.Ref.currentDomRef>, React.element>

--- a/res_syntax/tests/ppx/react/expected/mangleKeyword.res.txt
+++ b/res_syntax/tests/ppx/react/expected/mangleKeyword.res.txt
@@ -20,10 +20,7 @@ let c31 = React.createElement(C31.make, C31.makeProps(~_open="x", ()))
 @@jsxConfig({version: 4, mode: "classic"})
 
 module C4C0 = {
-  type props<'T_open, 'T_type> = {
-    @as("open") _open: 'T_open,
-    @as("type") _type: 'T_type,
-  }
+  type props<'T_open, 'T_type> = {@as("open") _open: 'T_open, @as("type") _type: 'T_type}
 
   @react.component
   let make = ({@as("open") _open, @as("type") _type, _}: props<'T_open, string>) =>
@@ -35,10 +32,7 @@ module C4C0 = {
   }
 }
 module C4C1 = {
-  type props<'T_open, 'T_type> = {
-    @as("open") _open: 'T_open,
-    @as("type") _type: 'T_type,
-  }
+  type props<'T_open, 'T_type> = {@as("open") _open: 'T_open, @as("type") _type: 'T_type}
 
   external make: @as("open") React.componentLike<props<string, string>, React.element> = "default"
 }
@@ -49,10 +43,7 @@ let c4c1 = React.createElement(C4C1.make, {_open: "x", _type: "t"})
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module C4A0 = {
-  type props<'T_open, 'T_type> = {
-    @as("open") _open: 'T_open,
-    @as("type") _type: 'T_type,
-  }
+  type props<'T_open, 'T_type> = {@as("open") _open: 'T_open, @as("type") _type: 'T_type}
 
   @react.component
   let make = ({@as("open") _open, @as("type") _type, _}: props<'T_open, string>) =>
@@ -64,10 +55,7 @@ module C4A0 = {
   }
 }
 module C4A1 = {
-  type props<'T_open, 'T_type> = {
-    @as("open") _open: 'T_open,
-    @as("type") _type: 'T_type,
-  }
+  type props<'T_open, 'T_type> = {@as("open") _open: 'T_open, @as("type") _type: 'T_type}
 
   external make: @as("open") React.componentLike<props<string, string>, React.element> = "default"
 }

--- a/res_syntax/tests/ppx/react/expected/newtype.res.txt
+++ b/res_syntax/tests/ppx/react/expected/newtype.res.txt
@@ -24,11 +24,7 @@ module V3 = {
 @@jsxConfig({version: 4, mode: "classic"})
 
 module V4C = {
-  type props<'a, 'b, 'c> = {
-    a: 'a,
-    b: 'b,
-    c: 'c,
-  }
+  type props<'a, 'b, 'c> = {a: 'a, b: 'b, c: 'c}
 
   @react.component
   let make = ({a, b, c, _}: props<'\"type-a", array<option<[#Foo('\"type-a")]>>, 'a>) =>
@@ -43,11 +39,7 @@ module V4C = {
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module V4A = {
-  type props<'a, 'b, 'c> = {
-    a: 'a,
-    b: 'b,
-    c: 'c,
-  }
+  type props<'a, 'b, 'c> = {a: 'a, b: 'b, c: 'c}
 
   @react.component
   let make = ({a, b, c, _}: props<'\"type-a", array<option<[#Foo('\"type-a")]>>, 'a>) =>

--- a/res_syntax/tests/ppx/react/expected/optimizeAutomaticMode.res.txt
+++ b/res_syntax/tests/ppx/react/expected/optimizeAutomaticMode.res.txt
@@ -4,9 +4,7 @@ module User = {
   type t = {firstName: string, lastName: string}
 
   let format = user => "Dr." ++ user.lastName
-  type props<'doctor> = {
-    doctor: 'doctor,
-  }
+  type props<'doctor> = {doctor: 'doctor}
 
   @react.component
   let make = ({doctor, _}: props<'doctor>) => {

--- a/res_syntax/tests/ppx/react/expected/removedKeyProp.res.txt
+++ b/res_syntax/tests/ppx/react/expected/removedKeyProp.res.txt
@@ -1,10 +1,7 @@
 @@jsxConfig({version: 4, mode: "classic"})
 
 module Foo = {
-  type props<'x, 'y> = {
-    x: 'x,
-    y: 'y,
-  }
+  type props<'x, 'y> = {x: 'x, y: 'y}
 
   @react.component let make = ({x, y, _}: props<'x, 'y>) => React.string(x ++ y)
   let make = {
@@ -15,9 +12,7 @@ module Foo = {
 }
 
 module HasChildren = {
-  type props<'children> = {
-    children: 'children,
-  }
+  type props<'children> = {children: 'children}
 
   @react.component
   let make = ({children, _}: props<'children>) => ReactDOM.createElement(React.fragment, [children])

--- a/res_syntax/tests/ppx/react/expected/topLevel.res.txt
+++ b/res_syntax/tests/ppx/react/expected/topLevel.res.txt
@@ -22,10 +22,7 @@ module V3 = {
 @@jsxConfig({version: 4, mode: "classic"})
 
 module V4C = {
-  type props<'a, 'b> = {
-    a: 'a,
-    b: 'b,
-  }
+  type props<'a, 'b> = {a: 'a, b: 'b}
 
   @react.component
   let make = ({a, b, _}: props<'a, 'b>) => {
@@ -42,10 +39,7 @@ module V4C = {
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module V4A = {
-  type props<'a, 'b> = {
-    a: 'a,
-    b: 'b,
-  }
+  type props<'a, 'b> = {a: 'a, b: 'b}
 
   @react.component
   let make = ({a, b, _}: props<'a, 'b>) => {

--- a/res_syntax/tests/ppx/react/expected/typeConstraint.res.txt
+++ b/res_syntax/tests/ppx/react/expected/typeConstraint.res.txt
@@ -17,10 +17,7 @@ module V3 = {
 @@jsxConfig({version: 4, mode: "classic"})
 
 module V4C = {
-  type props<'a, 'b> = {
-    a: 'a,
-    b: 'b,
-  }
+  type props<'a, 'b> = {a: 'a, b: 'b}
 
   @react.component
   let make = ({a, b, _}: props<'\"type-a", '\"type-a">) =>
@@ -35,10 +32,7 @@ module V4C = {
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module V4A = {
-  type props<'a, 'b> = {
-    a: 'a,
-    b: 'b,
-  }
+  type props<'a, 'b> = {a: 'a, b: 'b}
 
   @react.component let make = ({a, b, _}: props<'\"type-a", '\"type-a">) => ReactDOM.jsx("div", {})
   let make = {

--- a/res_syntax/tests/ppx/react/expected/v4.res.txt
+++ b/res_syntax/tests/ppx/react/expected/v4.res.txt
@@ -1,7 +1,4 @@
-type props<'x, 'y> = { // Component with type constraint
-  x: 'x,
-  y: 'y,
-}
+type props<'x, 'y> = {x: 'x, y: 'y} // Component with type constraint
 @react.component let make = ({x, y, _}: props<string, string>) => React.string(x ++ y)
 let make = {
   let \"V4" = (props: props<_>) => make(props)
@@ -10,9 +7,7 @@ let make = {
 
 module AnotherName = {
   type // Component with another name than "make"
-  props<'x> = {
-    x: 'x,
-  }
+  props<'x> = {x: 'x}
 
   @react.component let anotherName = ({x, _}: props<'x>) => React.string(x)
   let anotherName = {
@@ -23,9 +18,7 @@ module AnotherName = {
 }
 
 module Uncurried = {
-  type props<'x> = {
-    x: 'x,
-  }
+  type props<'x> = {x: 'x}
 
   @react.component let make = ({x, _}: props<'x>) => React.string(x)
   let make = {
@@ -36,25 +29,19 @@ module Uncurried = {
 }
 
 module type TUncurried = {
-  type props<'x> = {
-    x: 'x,
-  }
+  type props<'x> = {x: 'x}
 
   let make: React.componentLike<props<string>, React.element>
 }
 
 module E = {
-  type props<'x> = {
-    x: 'x,
-  }
+  type props<'x> = {x: 'x}
 
   external make: React.componentLike<props<string>, React.element> = "default"
 }
 
 module EUncurried = {
-  type props<'x> = {
-    x: 'x,
-  }
+  type props<'x> = {x: 'x}
 
   external make: React.componentLike<props<string>, React.element> = "default"
 }


### PR DESCRIPTION
This PR fixes the #5936. Now it shows the error with loc.
<img width="658" alt="image" src="https://user-images.githubusercontent.com/36963424/211505459-71baaaf7-b147-46aa-9cf8-c871aba1de96.png">
The message is not a bit kind yet, but the typechecker would not distinguish whether it is a type parameter of props type or not.