### PR TITLE
Fix CI-build on macos-latest

### DIFF
--- a/scripts/test_syntax.sh
+++ b/scripts/test_syntax.sh
@@ -6,7 +6,9 @@
 #    Therefore we need to use find + temp files for the file lists.
 
 scriptDir=`dirname $0`
-DUNE_BIN_DIR=`realpath $scriptDir/../_build/install/default/bin`
+# macOS 12 does not have the realpath utility,
+# so let's use this workaround instead.
+DUNE_BIN_DIR=`cd "$scriptDir/../_build/install/default/bin"; pwd -P`
 
 $DUNE_BIN_DIR/syntax_tests
 


### PR DESCRIPTION
Github Actions is starting to use macOS 12 for `macos-latest` by default, see https://github.com/actions/runner-images/issues/6384.

However, macOS 12 does not have the `realpath` utility. This was causing builds to fail. This PR adds a workaround for that. 