### PR TITLE
Add support for toplevel await.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ subset of the arguments, and return a curried type with the remaining ones https
 - Parser/Printer: unify uncurried functions of arity 0, and of arity 1 taking unit. There's now only arity 1 in the source language. https://github.com/rescript-lang/rescript-compiler/pull/5825
 - Add support for default arguments in uncurried functions https://github.com/rescript-lang/rescript-compiler/pull/5835
 - Inline uncurried application when it is safe https://github.com/rescript-lang/rescript-compiler/pull/5847
+- Add support for toplevel `await` https://github.com/rescript-lang/rescript-compiler/pull/5940
 
 #### :boom: Breaking Change
 

--- a/jscomp/build_tests/super_errors/expected/await.res.expected
+++ b/jscomp/build_tests/super_errors/expected/await.res.expected
@@ -1,0 +1,11 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/await.res[0m:[2m4:9-17[0m
+
+  2 [2m│[0m let foo = async () => {
+  3 [2m│[0m   let _ = ()
+  [1;31m4[0m [2m│[0m   () => [1;31mawait a()[0m
+  5 [2m│[0m }
+  6 [2m│[0m 
+
+  Await on expression not in an async context

--- a/jscomp/build_tests/super_errors/fixtures/await.res
+++ b/jscomp/build_tests/super_errors/fixtures/await.res
@@ -1,0 +1,5 @@
+let a = async () => 3
+let foo = async () => {
+  let _ = ()
+  () => await a()
+}

--- a/jscomp/frontend/bs_builtin_ppx.ml
+++ b/jscomp/frontend/bs_builtin_ppx.ml
@@ -502,7 +502,7 @@ let rec structure_mapper (self : mapper) (stru : Ast_structure.t) =
 let mapper : mapper =
   {
     default_mapper with
-    expr = expr_mapper ~async_context:(ref false) ~in_function_def:(ref false);
+    expr = expr_mapper ~async_context:(ref true) ~in_function_def:(ref false);
     pat = pat_mapper;
     typ = typ_mapper;
     signature_item = signature_item_mapper;

--- a/jscomp/test/async_await.js
+++ b/jscomp/test/async_await.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var Caml_array = require("../../lib/js/caml_array.js");
 
 function next(n) {
   return n + 1 | 0;
@@ -18,7 +19,25 @@ function Make(I) {
         };
 }
 
+async function topFoo(param) {
+  return 1;
+}
+
+var arr = [
+  1,
+  2,
+  3
+];
+
+var toplevelAwait = await topFoo(undefined);
+
+var toplevelAwait2 = Caml_array.get(arr, await topFoo(undefined));
+
 exports.next = next;
 exports.useNext = useNext;
 exports.Make = Make;
-/* No side effect */
+exports.topFoo = topFoo;
+exports.arr = arr;
+exports.toplevelAwait = toplevelAwait;
+exports.toplevelAwait2 = toplevelAwait2;
+/* toplevelAwait Not a pure module */

--- a/jscomp/test/async_await.res
+++ b/jscomp/test/async_await.res
@@ -8,5 +8,11 @@ module type Impl = {
 }
 
 module Make = (I: Impl) => {
-  let get = async key => await I.get(key)
+  let get = async (key) => await I.get(key)
 }
+
+let topFoo = async () => 1
+let arr = [1, 2, 3]
+
+let toplevelAwait = await topFoo()
+let toplevelAwait2 = arr[await topFoo()]


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-compiler/issues/5925

`await` can appear anywhere unless it's under a non-async function.