### PR TITLE
Add the missing loc of jsx call expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ These are only breaking changes for unformatted code.
 - In GenType, check annotations also in module types to decide whether to produce the `.gen.tsx` file https://github.com/rescript-lang/rescript-compiler/pull/5903
 - Fix some comments disappearing in array access expressions https://github.com/rescript-lang/rescript-compiler/pull/5947
 - Parser: fix location of variable when function definition `{v => ...}` is enclosed in braces https://github.com/rescript-lang/rescript-compiler/pull/5949
-- Fixed an issue where error messages related to non-existent props were displayed without location information https://github.com/rescript-lang/rescript-compiler/pull/5960
+- Fix an issue where error messages related to non-existent props were displayed without location information https://github.com/rescript-lang/rescript-compiler/pull/5960
 
 #### :nail_care: Polish
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ These are only breaking changes for unformatted code.
 - In GenType, check annotations also in module types to decide whether to produce the `.gen.tsx` file https://github.com/rescript-lang/rescript-compiler/pull/5903
 - Fix some comments disappearing in array access expressions https://github.com/rescript-lang/rescript-compiler/pull/5947
 - Parser: fix location of variable when function definition `{v => ...}` is enclosed in braces https://github.com/rescript-lang/rescript-compiler/pull/5949
+- Fixed an issue where error messages related to non-existent props were displayed without location information https://github.com/rescript-lang/rescript-compiler/pull/5960
 
 #### :nail_care: Polish
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ These are only breaking changes for unformatted code.
 - In GenType, check annotations also in module types to decide whether to produce the `.gen.tsx` file https://github.com/rescript-lang/rescript-compiler/pull/5903
 - Fix some comments disappearing in array access expressions https://github.com/rescript-lang/rescript-compiler/pull/5947
 - Parser: fix location of variable when function definition `{v => ...}` is enclosed in braces https://github.com/rescript-lang/rescript-compiler/pull/5949
-- Fix an issue where error messages related to non-existent props were displayed without location information https://github.com/rescript-lang/rescript-compiler/pull/5960
+- Fix issue where error messages related to non-existent props were displayed without location information https://github.com/rescript-lang/rescript-compiler/pull/5960
 
 #### :nail_care: Polish
 

--- a/res_syntax/src/reactjs_jsx_v4.ml
+++ b/res_syntax/src/reactjs_jsx_v4.ml
@@ -437,11 +437,12 @@ let transformUppercaseCall3 ~config modulePath mapper jsxExprLoc callExprLoc
         ( Exp.ident {loc = Location.none; txt = Ldot (Lident "React", "jsxs")},
           [] )
     in
-    Exp.apply ~attrs jsxExpr ([(nolabel, makeID); (nolabel, props)] @ keyAndUnit)
+    Exp.apply ~loc:jsxExprLoc ~attrs jsxExpr
+      ([(nolabel, makeID); (nolabel, props)] @ keyAndUnit)
   | _ -> (
     match (!childrenArg, keyProp) with
     | None, key :: _ ->
-      Exp.apply ~attrs
+      Exp.apply ~loc:jsxExprLoc ~attrs
         (Exp.ident
            {
              loc = Location.none;
@@ -449,12 +450,12 @@ let transformUppercaseCall3 ~config modulePath mapper jsxExprLoc callExprLoc
            })
         [key; (nolabel, makeID); (nolabel, props)]
     | None, [] ->
-      Exp.apply ~attrs
+      Exp.apply ~loc:jsxExprLoc ~attrs
         (Exp.ident
            {loc = Location.none; txt = Ldot (Lident "React", "createElement")})
         [(nolabel, makeID); (nolabel, props)]
     | Some children, key :: _ ->
-      Exp.apply ~attrs
+      Exp.apply ~loc:jsxExprLoc ~attrs
         (Exp.ident
            {
              loc = Location.none;
@@ -463,7 +464,7 @@ let transformUppercaseCall3 ~config modulePath mapper jsxExprLoc callExprLoc
            })
         [key; (nolabel, makeID); (nolabel, props); (nolabel, children)]
     | Some children, [] ->
-      Exp.apply ~attrs
+      Exp.apply ~loc:jsxExprLoc ~attrs
         (Exp.ident
            {
              loc = Location.none;
@@ -544,7 +545,7 @@ let transformLowercaseCall3 ~config mapper jsxExprLoc callExprLoc attrs
         ( Exp.ident {loc = Location.none; txt = Ldot (Lident "ReactDOM", "jsxs")},
           [] )
     in
-    Exp.apply ~attrs jsxExpr
+    Exp.apply ~loc:jsxExprLoc ~attrs jsxExpr
       ([(nolabel, componentNameExpr); (nolabel, props)] @ keyAndUnit)
   | _ ->
     let children, nonChildrenProps =

--- a/res_syntax/tests/ppx/react/expected/forwardRef.res.txt
+++ b/res_syntax/tests/ppx/react/expected/forwardRef.res.txt
@@ -223,6 +223,7 @@ module V4A = {
   @react.component
   let make = (_: props) => {
     let input = React.useRef(Js.Nullable.null)
+
     ReactDOM.jsx(
       "div",
       {
@@ -279,6 +280,7 @@ module V4AUncurried = {
   @react.component
   let make = (_: props) => {
     let input = React.useRef(Js.Nullable.null)
+
     ReactDOM.jsx(
       "div",
       {


### PR DESCRIPTION
This PR fixes https://github.com/rescript-lang/rescript-compiler/issues/5957. The only case of the lowercase & classic mode keeps the loc and others are missing. This PR add the missing the loc of JSX call expression into all cases.