### PR TITLE
Update/fix changelog for 10.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master, 10.1_release]
+    branches: [master, 10.1.2_release]
   pull_request:
-    branches: [master, 10.1_release]
+    branches: [master, 10.1.2_release]
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 > - :house: [Internal]
 > - :nail_care: [Polish]
 
+# 10.1.2
+
+- Fix an issue where error messages related to duplicate props were displayed without a loc and were unclear https://github.com/rescript-lang/syntax/pull/728
+
 # 10.1.1
 
 #### :boom: Breaking Change
@@ -29,7 +33,6 @@
 - Fix build error where aliasing arguments to `_` in the make function with JSX V4. https://github.com/rescript-lang/syntax/pull/720
 - Fix parsing of spread props as an expression in JSX V4 https://github.com/rescript-lang/syntax/pull/721
 - Fix dropping attributes from props in make function in JSX V4 https://github.com/rescript-lang/syntax/pull/723
-- Fix an issue where error messages related to duplicate props were displayed without a loc and were unclear https://github.com/rescript-lang/syntax/pull/728
 
 # 10.1.0
 


### PR DESCRIPTION
Changelog entry belongs to 10.1.2, not 10.1.1.

Merging this into a new branch 10.1.2_release as work has already continued on 10.1_release.