### PR TITLE
Fix type inference issue with uncurried functions applied to a single…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ These are only breaking changes for unformatted code.
 - Fix some comments disappearing in array access expressions https://github.com/rescript-lang/rescript-compiler/pull/5947
 - Parser: fix location of variable when function definition `{v => ...}` is enclosed in braces https://github.com/rescript-lang/rescript-compiler/pull/5949
 - Fix issue where error messages related to non-existent props were displayed without location information https://github.com/rescript-lang/rescript-compiler/pull/5960
+- Fix type inference issue with uncurried functions applied to a single unit argument. The issue was introduced in https://github.com/rescript-lang/rescript-compiler/pull/5907 when adding support to `foo()` when `foo` has only optional arguments. https://github.com/rescript-lang/rescript-compiler/pull/5970
 
 #### :nail_care: Polish
 

--- a/jscomp/ml/typecore.ml
+++ b/jscomp/ml/typecore.ml
@@ -3047,7 +3047,7 @@ and type_application uncurried env funct (sargs : sargs) : targs * Types.type_ex
         else
           collect_args ()
     | [(Nolabel, {pexp_desc = Pexp_construct ({txt = Lident "()"}, None)})]
-      when uncurried && omitted = [] && List.length args = List.length !ignored ->
+      when uncurried && omitted = [] && args <> [] && List.length args = List.length !ignored ->
       (* foo(. ) treated as empty application if all args are optional (hence ignored) *)
         type_unknown_args max_arity args omitted ty_fun []
     | (l1, sarg1) :: sargl ->

--- a/jscomp/test/uncurried_default.args.js
+++ b/jscomp/test/uncurried_default.args.js
@@ -101,6 +101,14 @@ function foo3$1(xOpt, yOpt) {
 
 var r3$1 = foo3$1(undefined, undefined);
 
+function foo(func) {
+  return func(undefined) + 1 | 0;
+}
+
+var M = {
+  foo: foo
+};
+
 exports.StandardNotation = StandardNotation;
 exports.withOpt = withOpt$1;
 exports.testWithOpt = testWithOpt$1;
@@ -112,4 +120,5 @@ exports.foo2 = foo2$1;
 exports.r2 = r2$1;
 exports.foo3 = foo3$1;
 exports.r3 = r3$1;
+exports.M = M;
 /* testWithOpt Not a pure module */

--- a/jscomp/test/uncurried_default.args.res
+++ b/jscomp/test/uncurried_default.args.res
@@ -31,3 +31,9 @@ let r2 = foo2(~y=11)
 
 let foo3 = (~x=3, ~y=4) => x+y
 let r3 = foo3()
+
+module M: {
+  let foo: (unit => int) => int
+} = {
+  let foo = func => func() + 1
+}


### PR DESCRIPTION
… unit argument.

In the example

```res
@@uncurried

let foo = func => func() + 1
```
the type inferred for `func` was the return type `int` instead of the type `unit => int` because the application `()` was omitted, as the heuristic for application of a function with only optional args would mistakenly fire.