### PR TITLE
JSX4: Fix missing attributes from props type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ These are only breaking changes for unformatted code.
 - Parser: fix location of variable when function definition `{v => ...}` is enclosed in braces https://github.com/rescript-lang/rescript-compiler/pull/5949
 - Fix issue where error messages related to non-existent props were displayed without location information https://github.com/rescript-lang/rescript-compiler/pull/5960
 - Fix type inference issue with uncurried functions applied to a single unit argument. The issue was introduced in https://github.com/rescript-lang/rescript-compiler/pull/5907 when adding support to `foo()` when `foo` has only optional arguments. https://github.com/rescript-lang/rescript-compiler/pull/5970
+- Fix issue where uncurried functions were incorrectly converting the type of a prop given as a default value to curried https://github.com/rescript-lang/rescript-compiler/pull/5971
 
 #### :nail_care: Polish
 

--- a/res_syntax/src/reactjs_jsx_v4.ml
+++ b/res_syntax/src/reactjs_jsx_v4.ml
@@ -719,19 +719,10 @@ let argToType ~newtypes ~(typeConstraints : core_type option) types
   in
   match (type_, name, default) with
   | Some type_, name, _ when isOptional name ->
-    ( true,
-      getLabel name,
-      attrs,
-      loc,
-      {type_ with ptyp_attributes = optionalAttrs} )
-    :: types
+    (true, getLabel name, attrs, loc, type_) :: types
   | Some type_, name, _ -> (false, getLabel name, attrs, loc, type_) :: types
   | None, name, _ when isOptional name ->
-    ( true,
-      getLabel name,
-      attrs,
-      loc,
-      Typ.var ~loc ~attrs:optionalAttrs (safeTypeFromValue name) )
+    (true, getLabel name, attrs, loc, Typ.var ~loc (safeTypeFromValue name))
     :: types
   | None, name, _ when isLabelled name ->
     (false, getLabel name, attrs, loc, Typ.var ~loc (safeTypeFromValue name))

--- a/res_syntax/tests/ppx/react/expected/uncurriedProps.res.txt
+++ b/res_syntax/tests/ppx/react/expected/uncurriedProps.res.txt
@@ -1,0 +1,59 @@
+@@jsxConfig({version: 4})
+type props<'a> = {a?: 'a}
+
+@react.component
+let make = ({?a, _}: props<(. unit) => unit>) => {
+  let a = switch a {
+  | Some(a) => a
+  | None => (. ()) => ()
+  }
+
+  React.null
+}
+let make = {
+  let \"UncurriedProps" = (props: props<_>) => make(props)
+
+  \"UncurriedProps"
+}
+
+let func = (~callback: (. string, bool, bool) => unit=(. _, _, _) => (), ()) => {
+  let _ = callback
+}
+
+func(~callback=(. str, a, b) => {
+  let _ = str
+  let _ = a
+  let _ = b
+}, ())
+
+module Foo = {
+  type props<'callback> = {callback?: 'callback}
+
+  @react.component
+  let make = ({?callback, _}: props<(. string, bool, bool) => unit>) => {
+    let callback = switch callback {
+    | Some(callback) => callback
+    | None => (. _, _, _) => ()
+    }
+
+    {
+      React.null
+    }
+  }
+  let make = {
+    let \"UncurriedProps$Foo" = (props: props<_>) => make(props)
+
+    \"UncurriedProps$Foo"
+  }
+}
+
+module Bar = {
+  type props = {}
+
+  @react.component let make = (_: props) => React.jsx(Foo.make, {callback: (. _, _, _) => ()})
+  let make = {
+    let \"UncurriedProps$Bar" = props => make(props)
+
+    \"UncurriedProps$Bar"
+  }
+}

--- a/res_syntax/tests/ppx/react/uncurriedProps.res
+++ b/res_syntax/tests/ppx/react/uncurriedProps.res
@@ -1,0 +1,26 @@
+@@jsxConfig({ version: 4 })
+
+@react.component
+let make = (~a: (. unit) => unit=(. ) => ()) => React.null
+
+let func = (~callback: (. string, bool, bool) => unit=(. _, _, _) => (), ()) => {
+  let _ = callback
+}
+
+func(~callback=(. str, a, b) => {
+  let _ = str
+  let _ = a
+  let _ = b
+}, ())
+
+module Foo = {
+  @react.component
+  let make = (~callback: (. string, bool, bool) => unit=(. _, _, _) => ()) => {
+    React.null
+  }
+}
+
+module Bar = {
+  @react.component
+  let make = () => <Foo callback={(. _, _, _) => ()} />
+}


### PR DESCRIPTION
This PR fixes #5969 
This change keeps the attributes of the argument in the make function and removes the unnecessary optional attr from the core_type as the type parameter. So it prevents that uncurried functions were incorrectly converting the type of a prop given as a default value. The test has no diff with this PR, because the current master branch doesn't have an issue with it due to works regarding the uncurried as default