### PR TITLE
Fix issue with error messages for uncurried functions where expected …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ These are only breaking changes for unformatted code.
 - Fix issue where error messages related to non-existent props were displayed without location information https://github.com/rescript-lang/rescript-compiler/pull/5960
 - Fix type inference issue with uncurried functions applied to a single unit argument. The issue was introduced in https://github.com/rescript-lang/rescript-compiler/pull/5907 when adding support to `foo()` when `foo` has only optional arguments. https://github.com/rescript-lang/rescript-compiler/pull/5970
 - Fix issue where uncurried functions were incorrectly converting the type of a prop given as a default value to curried https://github.com/rescript-lang/rescript-compiler/pull/5971
+- Fix issue with error messages for uncurried functions where expected and given type were swapped https://github.com/rescript-lang/rescript-compiler/pull/5973
 
 #### :nail_care: Polish
 

--- a/jscomp/build_tests/super_errors/expected/curried_expected.res.expected
+++ b/jscomp/build_tests/super_errors/expected/curried_expected.res.expected
@@ -1,0 +1,10 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/curried_expected.res[0m:[2m3:24-38[0m
+
+  1 [2m│[0m let expectCurried = f => f(1) + 2
+  2 [2m│[0m 
+  [1;31m3[0m [2m│[0m let z1 = expectCurried([1;31m(. x, y) => x+y[0m)
+  4 [2m│[0m 
+
+  This function is an uncurried function where a curried function is expected

--- a/jscomp/build_tests/super_errors/fixtures/curried_expected.res
+++ b/jscomp/build_tests/super_errors/fixtures/curried_expected.res
@@ -1,0 +1,3 @@
+let expectCurried = f => f(1) + 2
+
+let z1 = expectCurried((. x, y) => x+y)

--- a/jscomp/ml/typecore.ml
+++ b/jscomp/ml/typecore.ml
@@ -2107,7 +2107,7 @@ and type_expect_ ?in_function ?(recarg=Rejected) env sexp ty_expected =
       let state = Warnings.backup () in
       let arity = Ast_uncurried.attributes_to_arity sexp.pexp_attributes in
       let uncurried_typ = Ast_uncurried.make_uncurried_type ~env ~arity (newvar()) in
-      unify_exp_types loc env ty_expected uncurried_typ;
+      unify_exp_types loc env uncurried_typ ty_expected;
       (* Disable Unerasable_optional_argument for uncurried functions *)
       let unerasable_optional_argument = Warnings.number Unerasable_optional_argument in
       Warnings.parse_options false ("-" ^ string_of_int unerasable_optional_argument);

--- a/jscomp/super_errors/super_typecore.ml
+++ b/jscomp/super_errors/super_typecore.ml
@@ -121,9 +121,9 @@ end
 
 let reportArityMismatch ~arityA ~arityB ppf =
   fprintf ppf "This function expected @{<info>%s@} %s, but got @{<error>%s@}"
-    arityA
-    (if arityA = "1" then "argument" else "arguments")
     arityB
+    (if arityB = "1" then "argument" else "arguments")
+    arityA
 
 (* Pasted from typecore.ml. Needed for some cases in report_error below *)
 (* Records *)
@@ -169,6 +169,11 @@ let report_error env ppf = function
     (_, {desc = Tconstr (Pident {name = "function$"},_,_)}) :: _
    ) -> 
     fprintf ppf "This function is a curried function where an uncurried function is expected"
+  | Expr_type_clash ( 
+    (_, {desc = Tconstr (Pident {name = "function$"}, [{desc=Tvar _}; _],_)}) ::
+    (_, {desc = Tarrow _}) :: _
+   ) -> 
+    fprintf ppf "This function is an uncurried function where a curried function is expected"
   | Expr_type_clash (
       (_, {desc = Tconstr (Pident {name = "function$"},[_; tA],_)}) ::
       (_, {desc = Tconstr (Pident {name = "function$"},[_; tB],_)}) :: _


### PR DESCRIPTION
…and given type were swapped

The logic for unification for `Function$`, which unifies with a generic uncurried type, was swapped. The error message for arity mismatch was also swapped, so those errors were showing correctly. However, in the case of expected curried function, when given an uncurried function whose type is begin inferred, the error message was swapped.
Also added a specialized error message when the uncurried type only contains a type variable, so `$function<'a, ...>` does not leak in the output. This happens as unification fails early, and the type of the function has not been determined yet.