### PR TITLE
Fix issue with async and locally abstract types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ These are only breaking changes for unformatted code.
 - Fix issue where uncurried functions were incorrectly converting the type of a prop given as a default value to curried https://github.com/rescript-lang/rescript-compiler/pull/5971
 - Fix issue with error messages for uncurried functions where expected and given type were swapped https://github.com/rescript-lang/rescript-compiler/pull/5973
 - Fix issue with nested async functions, where the inner function would be emitted without `async` https://github.com/rescript-lang/rescript-compiler/pull/5983
+- Fix issue with async context check, and printer, for async functions with locally abstract type https://github.com/rescript-lang/rescript-compiler/pull/5982
 
 #### :nail_care: Polish
 

--- a/jscomp/frontend/bs_builtin_ppx.ml
+++ b/jscomp/frontend/bs_builtin_ppx.ml
@@ -127,6 +127,11 @@ let expr_mapper ~async_context ~in_function_def (self : mapper)
       (* Treat @this (. x, y, z) => ... just like @this (x, y, z) => ... *)
       let fun_expr = Ast_uncurried.exprExtractUncurriedFun e in
       self.expr self fun_expr
+  | Pexp_newtype (s, body) ->
+    let async = Ast_attributes.has_async_payload e.pexp_attributes <> None in
+    let body = Ast_async.add_async_attribute ~async body in
+    let res = self.expr self body in
+    {e with pexp_desc = Pexp_newtype(s, res)}
   | Pexp_fun (label, _, pat, body) -> (
       let async = Ast_attributes.has_async_payload e.pexp_attributes <> None in
       match Ast_attributes.process_attributes_rev e.pexp_attributes with

--- a/res_syntax/src/res_parsetree_viewer.ml
+++ b/res_syntax/src/res_parsetree_viewer.ml
@@ -182,7 +182,7 @@ let funExpr expr =
     | expr -> (uncurried, attrsBefore, List.rev acc, expr)
   in
   match expr with
-  | {pexp_desc = Pexp_fun _} ->
+  | {pexp_desc = Pexp_fun _ | Pexp_newtype _} ->
     collect ~uncurried:false ~nFun:0 expr.pexp_attributes []
       {expr with pexp_attributes = []}
   | _ when Ast_uncurried.exprIsUncurriedFun expr ->

--- a/res_syntax/tests/printer/expr/asyncAwait.res
+++ b/res_syntax/tests/printer/expr/asyncAwait.res
@@ -120,3 +120,7 @@ let c3 = (. x) => @foo y => x+y
 
 type t1 = (. int) => string => bool
 type t2 = (. int, string) => bool
+
+let f = async (type a, ()) => {
+  await Js.Promise.resolve(())
+}

--- a/res_syntax/tests/printer/expr/expected/asyncAwait.res.txt
+++ b/res_syntax/tests/printer/expr/expected/asyncAwait.res.txt
@@ -142,3 +142,7 @@ let c3 = (. x) => {@foo y => x + y}
 
 type t1 = (. int) => string => bool
 type t2 = (. int, string) => bool
+
+let f = async (type a, ()) => {
+  await Js.Promise.resolve()
+}

--- a/res_syntax/tests/printer/expr/expected/newtype.res.txt
+++ b/res_syntax/tests/printer/expr/expected/newtype.res.txt
@@ -1,19 +1,13 @@
 let f = (type t, xs: list<t>) => ()
-let f = (@attr type t, xs: list<t>) => ()
+let f = @attr (type t, xs: list<t>) => ()
 let f = (type t, xs: list<t>, type s, ys: list<s>) => ()
-let f = (@attr type t, xs: list<t>, @attr2 type s, ys: list<s>) => ()
+let f = @attr (type t, xs: list<t>, @attr2 type s, ys: list<s>) => ()
 let f = (type t u v, xs: list<(t, u, v)>) => ()
-let f = (@attr type t u v, xs: list<(t, u, v)>) => ()
+let f = @attr (type t u v, xs: list<(t, u, v)>) => ()
 let f = (type t u v, xs: list<(t, u, v)>, type s w z, ys: list<(s, w, z)>) => ()
-let f = (@attr type t u v, xs: list<(t, u, v)>, @attr2 type s w z, ys: list<(s, w, z)>) => ()
-let f = (
-  @attr type t,
-  @attr type s,
-  xs: list<(t, s)>,
-  @attr type u,
-  @attr type v w,
-  ys: list<(u, v, w)>,
-) => ()
+let f = @attr (type t u v, xs: list<(t, u, v)>, @attr2 type s w z, ys: list<(s, w, z)>) => ()
+let f = @attr
+(type t, @attr type s, xs: list<(t, s)>, @attr type u, @attr type v w, ys: list<(u, v, w)>) => ()
 
 let mk_formatting_gen:
   type a b c d e f. formatting_gen<a, b, c, d, e, f> => Parsetree.expression =


### PR DESCRIPTION
To fix the printer, the async internal representation via an attribute needs to be preserved on functions starting with a locally abstract type. For this reason, annotations cannot be placed individually on the first locally abstract type, if that's how the function starts. Some printer tests of functions starting with an abstract type have changed because of this.

Fixes https://github.com/rescript-lang/rescript-compiler/issues/5974