### PR TITLE
Fix issue with nested async functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ These are only breaking changes for unformatted code.
 - Fix type inference issue with uncurried functions applied to a single unit argument. The issue was introduced in https://github.com/rescript-lang/rescript-compiler/pull/5907 when adding support to `foo()` when `foo` has only optional arguments. https://github.com/rescript-lang/rescript-compiler/pull/5970
 - Fix issue where uncurried functions were incorrectly converting the type of a prop given as a default value to curried https://github.com/rescript-lang/rescript-compiler/pull/5971
 - Fix issue with error messages for uncurried functions where expected and given type were swapped https://github.com/rescript-lang/rescript-compiler/pull/5973
+- Fix issue with nested async functions, where the inner function would be emitted without `async` https://github.com/rescript-lang/rescript-compiler/pull/5983
 
 #### :nail_care: Polish
 

--- a/jscomp/ml/translcore.ml
+++ b/jscomp/ml/translcore.ml
@@ -681,6 +681,8 @@ let rec cut n l =
 
 let try_ids = Hashtbl.create 8
 
+let has_async_attribute exp = exp.exp_attributes |> List.exists (fun ({txt}, _payload) -> txt = "res.async")
+
 let rec transl_exp e =
   List.iter (Translattribute.check_attribute e) e.exp_attributes;
   transl_exp0 e
@@ -695,7 +697,7 @@ and transl_exp0 (e : Typedtree.expression) : Lambda.lambda =
   | Texp_let (rec_flag, pat_expr_list, body) ->
       transl_let rec_flag pat_expr_list (transl_exp body)
   | Texp_function { arg_label = _; param; cases; partial } ->
-      let async = e.exp_attributes |> List.exists (fun ({txt}, _payload) -> txt = "res.async") in
+      let async = has_async_attribute e in
       let params, body, return_unit =
         let pl = push_defaults e.exp_loc [] cases partial in
         transl_function e.exp_loc partial param pl
@@ -1036,7 +1038,7 @@ and transl_function loc partial param cases =
        } as exp;
    };
   ]
-    when Parmatch.inactive ~partial pat ->
+    when Parmatch.inactive ~partial pat && not (exp |> has_async_attribute) ->
       let params, body, return_unit =
         transl_function exp.exp_loc partial' param' cases
       in

--- a/jscomp/test/async_inline.js
+++ b/jscomp/test/async_inline.js
@@ -60,6 +60,18 @@ var tui = 3;
 
 var tuia = uncurriedIdAsync(3);
 
+function nested1(param) {
+  return async function (y) {
+    return await y;
+  };
+}
+
+async function nested2(param) {
+  return async function (y) {
+    return await y;
+  };
+}
+
 var tci = 3;
 
 exports.willBeInlined = willBeInlined;
@@ -76,4 +88,6 @@ exports.tci = tci;
 exports.tcia = tcia;
 exports.tui = tui;
 exports.tuia = tuia;
+exports.nested1 = nested1;
+exports.nested2 = nested2;
 /* inlined Not a pure module */

--- a/jscomp/test/async_inline.res
+++ b/jscomp/test/async_inline.res
@@ -46,3 +46,7 @@ let tci = curriedId(3)
 let tcia = curriedIdAsync(3)
 let tui = uncurriedId(. 3)
 let tuia = uncurriedIdAsync(. 3)
+
+let nested1 = () => async (y) => await y
+
+let nested2 = async () => async (y) => await y


### PR DESCRIPTION
Nested curried functions are combined into one, and the async inner function is not generated. This PR Avoids combining nested functions when they are async.

Fixes https://github.com/rescript-lang/rescript-compiler/issues/5980