### PR TITLE
Add missing HTML attribute capture to JsxDOM.res

### DIFF
--- a/jscomp/others/jsxDOM.res
+++ b/jscomp/others/jsxDOM.res
@@ -136,6 +136,7 @@ type domProps = {
   defaultValue?: string,
   /* global html attributes */
   accessKey?: string,
+  capture?: [#user | #environment]
   className?: string /* substitute for "class" */,
   contentEditable?: bool,
   contextMenu?: string,


### PR DESCRIPTION
Adding the `capture` attribute to JsxDOM.res

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/capture