### PR TITLE
Fix formatting of props spread for multiline JSX expression

### DIFF
--- a/res_syntax/src/res_printer.ml
+++ b/res_syntax/src/res_printer.ml
@@ -4264,7 +4264,7 @@ and printJsxProp ~state arg cmtTbl =
     | Optional _lbl -> Doc.concat [Doc.question; printIdentLike ident])
   | Asttypes.Labelled "_spreadProps", expr ->
     let doc = printExpressionWithComments ~state expr cmtTbl in
-    Doc.concat [Doc.lbrace; Doc.dotdotdot; Doc.softLine; doc; Doc.rbrace]
+    Doc.concat [Doc.lbrace; Doc.dotdotdot; doc; Doc.rbrace]
   | lbl, expr ->
     let argLoc, expr =
       match expr.pexp_attributes with

--- a/res_syntax/tests/printer/expr/expected/jsx.res.txt
+++ b/res_syntax/tests/printer/expr/expected/jsx.res.txt
@@ -410,3 +410,9 @@ let v =
   </A>
 
 let x = <A x="y" {...str} />
+// https://github.com/rescript-lang/rescript-compiler/issues/6002
+let x = props =>
+  <A
+    {...props}
+    className="inline-block px-6 py-2.5 bg-blue-600 text-white font-medium text-xs leading-tight"
+  />

--- a/res_syntax/tests/printer/expr/expected/jsx.res.txt
+++ b/res_syntax/tests/printer/expr/expected/jsx.res.txt
@@ -410,6 +410,7 @@ let v =
   </A>
 
 let x = <A x="y" {...str} />
+
 // https://github.com/rescript-lang/rescript-compiler/issues/6002
 let x = props =>
   <A

--- a/res_syntax/tests/printer/expr/jsx.res
+++ b/res_syntax/tests/printer/expr/jsx.res
@@ -403,6 +403,7 @@ let v =
   </A>
 
 let x = <A x="y" {...str} />
+
 // https://github.com/rescript-lang/rescript-compiler/issues/6002
 let x = props =>
   <A

--- a/res_syntax/tests/printer/expr/jsx.res
+++ b/res_syntax/tests/printer/expr/jsx.res
@@ -403,3 +403,9 @@ let v =
   </A>
 
 let x = <A x="y" {...str} />
+// https://github.com/rescript-lang/rescript-compiler/issues/6002
+let x = props =>
+  <A
+    {...props}
+    className="inline-block px-6 py-2.5 bg-blue-600 text-white font-medium text-xs leading-tight"
+  />


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-compiler/issues/6002