### PR TITLE
Fix:  Inline auto curried async functions produce invalid javascript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ These are only breaking changes for unformatted code.
 - GenType: fix issue with V3 compatibility mode (see https://github.com/rescript-lang/rescript-compiler/issues/5990) https://github.com/rescript-lang/rescript-compiler/pull/5991
 - Fix issue in `Js.Promise2` where `then` and `catch` were returning `undefined` https://github.com/rescript-lang/rescript-compiler/pull/5997
 - Fix formatting of props spread for multiline JSX expression https://github.com/rescript-lang/rescript-compiler/pull/6006
+- Fix issue in the compiler back-end where async functions passed to an `@uncurry` external would be inlined and transformed in a way that loses async https://github.com/rescript-lang/rescript-compiler/pull/6010
 
 #### :nail_care: Polish
 

--- a/jscomp/test/async_inline.js
+++ b/jscomp/test/async_inline.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Curry = require("../../lib/js/curry.js");
+var React = require("react");
 
 async function willBeInlined(param) {
   return 3;
@@ -72,6 +73,12 @@ async function nested2(param) {
   };
 }
 
+function onSubmit(param) {
+  return React.useCallback(async function (_a, b) {
+              return await b;
+            });
+}
+
 var tci = 3;
 
 exports.willBeInlined = willBeInlined;
@@ -90,4 +97,5 @@ exports.tui = tui;
 exports.tuia = tuia;
 exports.nested1 = nested1;
 exports.nested2 = nested2;
+exports.onSubmit = onSubmit;
 /* inlined Not a pure module */

--- a/jscomp/test/async_inline.res
+++ b/jscomp/test/async_inline.res
@@ -50,3 +50,13 @@ let tuia = uncurriedIdAsync(. 3)
 let nested1 = () => async (y) => await y
 
 let nested2 = async () => async (y) => await y
+
+type callback<'input, 'output> = 'input => 'output
+
+@module("react")
+external useCallback: (@uncurry ('input => 'output)) => callback<'input, 'output> = "useCallback"
+
+let onSubmit = () =>
+  useCallback(async (_a, b) => {
+    await b
+  })


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-compiler/issues/6007