### PR TITLE
Fix formatting of `switch` expressions that contain brace `cases` inside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ These are only breaking changes for unformatted code.
 - Fix formatting of props spread for multiline JSX expression https://github.com/rescript-lang/rescript-compiler/pull/6006
 - Fix issue in the compiler back-end where async functions passed to an `@uncurry` external would be inlined and transformed in a way that loses async https://github.com/rescript-lang/rescript-compiler/pull/6010
 - Fix location issue for the treatment of `async` functions where hovering on the body with a type error would show `'a => promise<'a>` everywhere https://github.com/rescript-lang/rescript-compiler/pull/6012
+- Fix formatting of `switch` expressions that contain brace `cases` inside https://github.com/rescript-lang/rescript-compiler/pull/6015
 
 #### :nail_care: Polish
 

--- a/res_syntax/src/res_comments_table.ml
+++ b/res_syntax/src/res_comments_table.ml
@@ -345,7 +345,13 @@ let getLoc node =
   let open Parsetree in
   match node with
   | Case case ->
-    {case.pc_lhs.ppat_loc with loc_end = case.pc_rhs.pexp_loc.loc_end}
+    {
+      case.pc_lhs.ppat_loc with
+      loc_end =
+        (match ParsetreeViewer.processBracesAttr case.pc_rhs with
+        | None, _ -> case.pc_rhs.pexp_loc.loc_end
+        | Some ({loc}, _), _ -> loc.Location.loc_end);
+    }
   | CoreType ct -> ct.ptyp_loc
   | ExprArgument expr -> (
     match expr.Parsetree.pexp_attributes with

--- a/res_syntax/src/res_printer.ml
+++ b/res_syntax/src/res_printer.ml
@@ -4659,7 +4659,10 @@ and printCases ~state (cases : Parsetree.case list) cmtTbl =
                ~getLoc:(fun n ->
                  {
                    n.Parsetree.pc_lhs.ppat_loc with
-                   loc_end = n.pc_rhs.pexp_loc.loc_end;
+                   loc_end =
+                     (match ParsetreeViewer.processBracesAttr n.pc_rhs with
+                     | None, _ -> n.pc_rhs.pexp_loc.loc_end
+                     | Some ({loc}, _), _ -> loc.Location.loc_end);
                  })
                ~print:(printCase ~state) ~nodes:cases cmtTbl;
            ];

--- a/res_syntax/tests/printer/expr/expected/switch.res.txt
+++ b/res_syntax/tests/printer/expr/expected/switch.res.txt
@@ -55,3 +55,11 @@ switch route {
     <div> {React.string("Second B div")} </div>
   </>
 }
+
+switch x {
+| A => {
+    let _ = 1
+    let _ = 2
+  } // no blank line below
+| B => ()
+}

--- a/res_syntax/tests/printer/expr/switch.res
+++ b/res_syntax/tests/printer/expr/switch.res
@@ -49,3 +49,11 @@ switch route {
     <div> {React.string("Second B div")} </div>
   </>
 }
+
+switch x {
+| A => {
+    let _ = 1
+    let _ = 2
+  } // no blank line below
+| B => ()
+}


### PR DESCRIPTION
Formatter adds a blank line after braced `case`, which seems to be a regression introduced in v10
```res
switch foo {                             
| 1 => {
    Js.log(1)
    Js.log(2)
  } 

| 2 => Js.log(3)
}
```