### PR TITLE
Fix issue with JSX V4 when components are nested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ These are only breaking changes for unformatted code.
 - Support `@gentype.import` as an alias to `@genType.import` in the compiler https://github.com/rescript-lang/rescript-compiler/pull/6020
 - Fix issue with integer overflow check https://github.com/rescript-lang/rescript-compiler/pull/6028
 - Fix issue with JSX V4 and newtype https://github.com/rescript-lang/rescript-compiler/pull/6029
+- Fix issue with JSX V4 when components are nested https://github.com/rescript-lang/rescript-compiler/pull/6031
 
 #### :nail_care: Polish
 

--- a/res_syntax/src/reactjs_jsx_ppx.ml
+++ b/res_syntax/src/reactjs_jsx_ppx.ml
@@ -127,8 +127,8 @@ let getMapper ~config =
           | Pstr_attribute attr -> processConfigAttribute attr config
           | _ -> ());
           let item = default_mapper.structure_item mapper item in
-          if config.version = 3 then transformStructureItem3 mapper item
-          else if config.version = 4 then transformStructureItem4 mapper item
+          if config.version = 3 then transformStructureItem3 item
+          else if config.version = 4 then transformStructureItem4 item
           else [item])
         items
       |> List.flatten

--- a/res_syntax/src/reactjs_jsx_v3.ml
+++ b/res_syntax/src/reactjs_jsx_v3.ml
@@ -446,8 +446,7 @@ let jsxMapper ~config =
       args
   in
 
-  let rec recursivelyTransformNamedArgsForMake mapper expr args newtypes =
-    let expr = mapper.expr mapper expr in
+  let rec recursivelyTransformNamedArgsForMake expr args newtypes =
     match expr.pexp_desc with
     (* TODO: make this show up with a loc. *)
     | Pexp_fun (Labelled "key", _, _, _) | Pexp_fun (Optional "key", _, _, _) ->
@@ -494,7 +493,7 @@ let jsxMapper ~config =
         | _ -> None
       in
 
-      recursivelyTransformNamedArgsForMake mapper expression
+      recursivelyTransformNamedArgsForMake expression
         ((arg, default, pattern, alias, pattern.ppat_loc, type_) :: args)
         newtypes
     | Pexp_fun
@@ -517,10 +516,9 @@ let jsxMapper ~config =
         "React: react.component refs only support plain arguments and type \
          annotations."
     | Pexp_newtype (label, expression) ->
-      recursivelyTransformNamedArgsForMake mapper expression args
-        (label :: newtypes)
+      recursivelyTransformNamedArgsForMake expression args (label :: newtypes)
     | Pexp_constraint (expression, _typ) ->
-      recursivelyTransformNamedArgsForMake mapper expression args newtypes
+      recursivelyTransformNamedArgsForMake expression args newtypes
     | _ -> (args, newtypes, None)
   in
 
@@ -586,7 +584,7 @@ let jsxMapper ~config =
   in
 
   let nestedModules = ref [] in
-  let transformStructureItem mapper item =
+  let transformStructureItem item =
     match item with
     (* external *)
     | {
@@ -825,7 +823,7 @@ let jsxMapper ~config =
           let props = getPropsAttr payload in
           (* do stuff here! *)
           let namedArgList, newtypes, forwardRef =
-            recursivelyTransformNamedArgsForMake mapper
+            recursivelyTransformNamedArgsForMake
               (modifiedBindingOld binding)
               [] []
           in

--- a/res_syntax/tests/ppx/react/expected/aliasProps.res.txt
+++ b/res_syntax/tests/ppx/react/expected/aliasProps.res.txt
@@ -3,7 +3,6 @@
 module C0 = {
   type props<'priority, 'text> = {priority: 'priority, text?: 'text}
 
-  @react.component
   let make = (props: props<_, _>) => {
     let _ = props.priority
     let text = switch props.text {
@@ -23,7 +22,6 @@ module C0 = {
 module C1 = {
   type props<'priority, 'text> = {priority: 'priority, text?: 'text}
 
-  @react.component
   let make = (props: props<_, _>) => {
     let p = props.priority
     let text = switch props.text {
@@ -43,7 +41,6 @@ module C1 = {
 module C2 = {
   type props<'foo> = {foo?: 'foo}
 
-  @react.component
   let make = (props: props<_>) => {
     let bar = switch props.foo {
     | Some(foo) => foo

--- a/res_syntax/tests/ppx/react/expected/commentAtTop.res.txt
+++ b/res_syntax/tests/ppx/react/expected/commentAtTop.res.txt
@@ -1,6 +1,5 @@
 type props<'msg> = {msg: 'msg} // test React JSX file
 
-@react.component
 let make = ({msg, _}: props<_>) => {
   ReactDOM.jsx("div", {children: ?ReactDOM.someElement({msg->React.string})})
 }

--- a/res_syntax/tests/ppx/react/expected/defaultValueProp.res.txt
+++ b/res_syntax/tests/ppx/react/expected/defaultValueProp.res.txt
@@ -1,6 +1,5 @@
 module C0 = {
   type props<'a, 'b> = {a?: 'a, b?: 'b}
-  @react.component
   let make = (props: props<_, _>) => {
     let a = switch props.a {
     | Some(a) => a
@@ -22,7 +21,6 @@ module C0 = {
 module C1 = {
   type props<'a, 'b> = {a?: 'a, b: 'b}
 
-  @react.component
   let make = (props: props<_, _>) => {
     let a = switch props.a {
     | Some(a) => a

--- a/res_syntax/tests/ppx/react/expected/fileLevelConfig.res.txt
+++ b/res_syntax/tests/ppx/react/expected/fileLevelConfig.res.txt
@@ -20,7 +20,6 @@ module V3 = {
 module V4C = {
   type props<'msg> = {msg: 'msg}
 
-  @react.component
   let make = ({msg, _}: props<_>) => {
     ReactDOM.createDOMElementVariadic("div", [{msg->React.string}])
   }
@@ -36,7 +35,6 @@ module V4C = {
 module V4A = {
   type props<'msg> = {msg: 'msg}
 
-  @react.component
   let make = ({msg, _}: props<_>) => {
     ReactDOM.jsx("div", {children: ?ReactDOM.someElement({msg->React.string})})
   }

--- a/res_syntax/tests/ppx/react/expected/firstClassModules.res.txt
+++ b/res_syntax/tests/ppx/react/expected/firstClassModules.res.txt
@@ -64,7 +64,6 @@ module Select = {
     items: 'items,
   }
 
-  @react.component
   let make = (
     type a key,
     {model, selected, onChange, items, _}: props<

--- a/res_syntax/tests/ppx/react/expected/forwardRef.res.txt
+++ b/res_syntax/tests/ppx/react/expected/forwardRef.res.txt
@@ -75,7 +75,6 @@ module V4C = {
       ref?: 'ref,
     }
 
-    @react.component
     let make = (
       {?className, children, _}: props<_, _, ReactRef.currentDomRef>,
       ref: Js.Nullable.t<ReactRef.currentDomRef>,
@@ -103,7 +102,6 @@ module V4C = {
   }
   type props = {}
 
-  @react.component
   let make = (_: props) => {
     let input = React.useRef(Js.Nullable.null)
 
@@ -132,7 +130,6 @@ module V4CUncurried = {
       ref?: 'ref,
     }
 
-    @react.component
     let make = (
       {?className, children, _}: props<_, _, ReactRef.currentDomRef>,
       ref: Js.Nullable.t<ReactRef.currentDomRef>,
@@ -160,7 +157,6 @@ module V4CUncurried = {
   }
   type props = {}
 
-  @react.component
   let make = (_: props) => {
     let input = React.useRef(Js.Nullable.null)
 
@@ -191,7 +187,6 @@ module V4A = {
       ref?: 'ref,
     }
 
-    @react.component
     let make = ({?className, children, _}: props<_, _, ReactDOM.Ref.currentDomRef>, ref) =>
       ReactDOM.jsxs(
         "div",
@@ -217,7 +212,6 @@ module V4A = {
   }
   type props = {}
 
-  @react.component
   let make = (_: props) => {
     let input = React.useRef(Js.Nullable.null)
 
@@ -245,7 +239,6 @@ module V4AUncurried = {
       ref?: 'ref,
     }
 
-    @react.component
     let make = ({?className, children, _}: props<_, _, ReactDOM.Ref.currentDomRef>, ref) =>
       ReactDOM.jsxs(
         "div",
@@ -271,7 +264,6 @@ module V4AUncurried = {
   }
   type props = {}
 
-  @react.component
   let make = (_: props) => {
     let input = React.useRef(Js.Nullable.null)
 

--- a/res_syntax/tests/ppx/react/expected/interface.res.txt
+++ b/res_syntax/tests/ppx/react/expected/interface.res.txt
@@ -1,6 +1,6 @@
 module A = {
   type props<'x> = {x: 'x}
-  @react.component let make = ({x, _}: props<_>) => React.string(x)
+  let make = ({x, _}: props<_>) => React.string(x)
   let make = {
     let \"Interface$A" = (props: props<_>) => make(props)
     \"Interface$A"
@@ -10,7 +10,7 @@ module A = {
 module NoProps = {
   type props = {}
 
-  @react.component let make = (_: props) => ReactDOM.jsx("div", {})
+  let make = (_: props) => ReactDOM.jsx("div", {})
   let make = {
     let \"Interface$NoProps" = props => make(props)
 

--- a/res_syntax/tests/ppx/react/expected/interfaceWithRef.res.txt
+++ b/res_syntax/tests/ppx/react/expected/interfaceWithRef.res.txt
@@ -1,5 +1,4 @@
 type props<'x, 'ref> = {x: 'x, ref?: 'ref}
-@react.component
 let make = (
   {x, _}: props<string, ReactDOM.Ref.currentDomRef>,
   ref: Js.Nullable.t<ReactDOM.Ref.currentDomRef>,

--- a/res_syntax/tests/ppx/react/expected/mangleKeyword.res.txt
+++ b/res_syntax/tests/ppx/react/expected/mangleKeyword.res.txt
@@ -22,7 +22,6 @@ let c31 = React.createElement(C31.make, C31.makeProps(~_open="x", ()))
 module C4C0 = {
   type props<'T_open, 'T_type> = {@as("open") _open: 'T_open, @as("type") _type: 'T_type}
 
-  @react.component
   let make = ({@as("open") _open, @as("type") _type, _}: props<_, string>) => React.string(_open)
   let make = {
     let \"MangleKeyword$C4C0" = (props: props<_>) => make(props)
@@ -44,7 +43,6 @@ let c4c1 = React.createElement(C4C1.make, {_open: "x", _type: "t"})
 module C4A0 = {
   type props<'T_open, 'T_type> = {@as("open") _open: 'T_open, @as("type") _type: 'T_type}
 
-  @react.component
   let make = ({@as("open") _open, @as("type") _type, _}: props<_, string>) => React.string(_open)
   let make = {
     let \"MangleKeyword$C4A0" = (props: props<_>) => make(props)

--- a/res_syntax/tests/ppx/react/expected/nested.res.txt
+++ b/res_syntax/tests/ppx/react/expected/nested.res.txt
@@ -1,0 +1,21 @@
+module Outer = {
+  type props = {}
+  let make = (_: props) => {
+    module Inner = {
+      type props = {}
+
+      let make = (_: props) => ReactDOM.jsx("div", {})
+      let make = {
+        let \"Nested$Outer" = props => make(props)
+
+        \"Nested$Outer"
+      }
+    }
+
+    React.jsx(Inner.make, {})
+  }
+  let make = {
+    let \"Nested$Outer" = props => make(props)
+    \"Nested$Outer"
+  }
+}

--- a/res_syntax/tests/ppx/react/expected/newtype.res.txt
+++ b/res_syntax/tests/ppx/react/expected/newtype.res.txt
@@ -26,7 +26,6 @@ module V3 = {
 module V4C = {
   type props<'a, 'b, 'c> = {a: 'a, b: 'b, c: 'c}
 
-  @react.component
   let make = (type a, {a, b, c, _}: props<a, array<option<[#Foo(a)]>>, 'a>) =>
     ReactDOM.createDOMElementVariadic("div", [])
   let make = {
@@ -41,7 +40,6 @@ module V4C = {
 module V4A = {
   type props<'a, 'b, 'c> = {a: 'a, b: 'b, c: 'c}
 
-  @react.component
   let make = (type a, {a, b, c, _}: props<a, array<option<[#Foo(a)]>>, 'a>) =>
     ReactDOM.jsx("div", {})
   let make = {
@@ -54,7 +52,6 @@ module V4A = {
 module V4A1 = {
   type props<'a, 'b, 'c> = {a: 'a, b: 'b, c: 'c}
 
-  @react.component
   let make = (type x y, {a, b, c, _}: props<x, array<y>, 'a>) => ReactDOM.jsx("div", {})
   let make = {
     let \"Newtype$V4A1" = (props: props<_>) => make(props)
@@ -70,7 +67,6 @@ module type T = {
 module V4A2 = {
   type props<'foo> = {foo: 'foo}
 
-  @react.component
   let make = (type a, {foo, _}: props<module(T with type t = a)>) => {
     module T = unpack(foo)
     ReactDOM.jsx("div", {})
@@ -85,7 +81,6 @@ module V4A2 = {
 module V4A3 = {
   type props<'foo> = {foo: 'foo}
 
-  @react.component
   let make = (type a, {foo, _}: props<_>) => {
     module T = unpack(foo: T with type t = a)
     foo

--- a/res_syntax/tests/ppx/react/expected/noPropsWithKey.res.txt
+++ b/res_syntax/tests/ppx/react/expected/noPropsWithKey.res.txt
@@ -3,7 +3,7 @@
 module V4CA = {
   type props = {}
 
-  @react.component let make = (_: props) => ReactDOM.createDOMElementVariadic("div", [])
+  let make = (_: props) => ReactDOM.createDOMElementVariadic("div", [])
   let make = {
     let \"NoPropsWithKey$V4CA" = props => make(props)
 
@@ -21,7 +21,6 @@ module V4CB = {
 module V4C = {
   type props = {}
 
-  @react.component
   let make = (_: props) =>
     ReactDOM.createElement(
       React.fragment,
@@ -42,7 +41,7 @@ module V4C = {
 module V4CA = {
   type props = {}
 
-  @react.component let make = (_: props) => ReactDOM.jsx("div", {})
+  let make = (_: props) => ReactDOM.jsx("div", {})
   let make = {
     let \"NoPropsWithKey$V4CA" = props => make(props)
 
@@ -60,7 +59,6 @@ module V4CB = {
 module V4C = {
   type props = {}
 
-  @react.component
   let make = (_: props) =>
     React.jsxs(
       React.jsxFragment,

--- a/res_syntax/tests/ppx/react/expected/optimizeAutomaticMode.res.txt
+++ b/res_syntax/tests/ppx/react/expected/optimizeAutomaticMode.res.txt
@@ -6,7 +6,6 @@ module User = {
   let format = user => "Dr." ++ user.lastName
   type props<'doctor> = {doctor: 'doctor}
 
-  @react.component
   let make = ({doctor, _}: props<_>) => {
     ReactDOM.jsx("h1", {id: "h1", children: ?ReactDOM.someElement({React.string(format(doctor))})})
   }

--- a/res_syntax/tests/ppx/react/expected/removedKeyProp.res.txt
+++ b/res_syntax/tests/ppx/react/expected/removedKeyProp.res.txt
@@ -3,7 +3,7 @@
 module Foo = {
   type props<'x, 'y> = {x: 'x, y: 'y}
 
-  @react.component let make = ({x, y, _}: props<_, _>) => React.string(x ++ y)
+  let make = ({x, y, _}: props<_, _>) => React.string(x ++ y)
   let make = {
     let \"RemovedKeyProp$Foo" = (props: props<_>) => make(props)
 
@@ -14,7 +14,6 @@ module Foo = {
 module HasChildren = {
   type props<'children> = {children: 'children}
 
-  @react.component
   let make = ({children, _}: props<_>) => ReactDOM.createElement(React.fragment, [children])
   let make = {
     let \"RemovedKeyProp$HasChildren" = (props: props<_>) => make(props)
@@ -24,7 +23,6 @@ module HasChildren = {
 }
 type props = {}
 
-@react.component
 let make = (_: props) =>
   ReactDOM.createElement(
     React.fragment,

--- a/res_syntax/tests/ppx/react/expected/sharedProps.res.txt
+++ b/res_syntax/tests/ppx/react/expected/sharedProps.res.txt
@@ -3,7 +3,7 @@
 module V4C1 = {
   type props = sharedProps<string>
 
-  @react.component(: sharedProps<string>) let make = ({x, y, _}: props) => React.string(x ++ y)
+  let make = ({x, y, _}: props) => React.string(x ++ y)
   let make = {
     let \"SharedProps$V4C1" = props => make(props)
 
@@ -14,7 +14,7 @@ module V4C1 = {
 module V4C2 = {
   type props<'a> = sharedProps<'a>
 
-  @react.component(: sharedProps<'a>) let make = ({x, y, _}: props<_>) => React.string(x ++ y)
+  let make = ({x, y, _}: props<_>) => React.string(x ++ y)
   let make = {
     let \"SharedProps$V4C2" = (props: props<_>) => make(props)
 
@@ -25,7 +25,6 @@ module V4C2 = {
 module V4C3 = {
   type props<'a> = sharedProps<string, 'a>
 
-  @react.component(: sharedProps<string, 'a>)
   let make = ({x, y, _}: props<_>) => React.string(x ++ y)
   let make = {
     let \"SharedProps$V4C3" = (props: props<_>) => make(props)
@@ -37,7 +36,7 @@ module V4C3 = {
 module V4C4 = {
   type props = sharedProps
 
-  @react.component(: sharedProps) let make = ({x, y, _}: props) => React.string(x ++ y)
+  let make = ({x, y, _}: props) => React.string(x ++ y)
   let make = {
     let \"SharedProps$V4C4" = props => make(props)
 
@@ -74,7 +73,7 @@ module V4C8 = {
 module V4A1 = {
   type props = sharedProps<string>
 
-  @react.component(: sharedProps<string>) let make = ({x, y, _}: props) => React.string(x ++ y)
+  let make = ({x, y, _}: props) => React.string(x ++ y)
   let make = {
     let \"SharedProps$V4A1" = props => make(props)
 
@@ -85,7 +84,7 @@ module V4A1 = {
 module V4A2 = {
   type props<'a> = sharedProps<'a>
 
-  @react.component(: sharedProps<'a>) let make = ({x, y, _}: props<_>) => React.string(x ++ y)
+  let make = ({x, y, _}: props<_>) => React.string(x ++ y)
   let make = {
     let \"SharedProps$V4A2" = (props: props<_>) => make(props)
 
@@ -96,7 +95,6 @@ module V4A2 = {
 module V4A3 = {
   type props<'a> = sharedProps<string, 'a>
 
-  @react.component(: sharedProps<string, 'a>)
   let make = ({x, y, _}: props<_>) => React.string(x ++ y)
   let make = {
     let \"SharedProps$V4A3" = (props: props<_>) => make(props)
@@ -108,7 +106,7 @@ module V4A3 = {
 module V4A4 = {
   type props = sharedProps
 
-  @react.component(: sharedProps) let make = ({x, y, _}: props) => React.string(x ++ y)
+  let make = ({x, y, _}: props) => React.string(x ++ y)
   let make = {
     let \"SharedProps$V4A4" = props => make(props)
 

--- a/res_syntax/tests/ppx/react/expected/topLevel.res.txt
+++ b/res_syntax/tests/ppx/react/expected/topLevel.res.txt
@@ -24,7 +24,6 @@ module V3 = {
 module V4C = {
   type props<'a, 'b> = {a: 'a, b: 'b}
 
-  @react.component
   let make = ({a, b, _}: props<_, _>) => {
     Js.log("This function should be named 'TopLevel.react'")
     ReactDOM.createDOMElementVariadic("div", [])
@@ -41,7 +40,6 @@ module V4C = {
 module V4A = {
   type props<'a, 'b> = {a: 'a, b: 'b}
 
-  @react.component
   let make = ({a, b, _}: props<_, _>) => {
     Js.log("This function should be named 'TopLevel.react'")
     ReactDOM.jsx("div", {})

--- a/res_syntax/tests/ppx/react/expected/typeConstraint.res.txt
+++ b/res_syntax/tests/ppx/react/expected/typeConstraint.res.txt
@@ -19,7 +19,6 @@ module V3 = {
 module V4C = {
   type props<'a, 'b> = {a: 'a, b: 'b}
 
-  @react.component
   let make = (type a, {a, b, _}: props<_, _>) => ReactDOM.createDOMElementVariadic("div", [])
   let make = {
     let \"TypeConstraint$V4C" = (props: props<_>) => make(props)
@@ -33,7 +32,7 @@ module V4C = {
 module V4A = {
   type props<'a, 'b> = {a: 'a, b: 'b}
 
-  @react.component let make = (type a, {a, b, _}: props<_, _>) => ReactDOM.jsx("div", {})
+  let make = (type a, {a, b, _}: props<_, _>) => ReactDOM.jsx("div", {})
   let make = {
     let \"TypeConstraint$V4A" = (props: props<_>) => make(props)
 

--- a/res_syntax/tests/ppx/react/expected/uncurriedProps.res.txt
+++ b/res_syntax/tests/ppx/react/expected/uncurriedProps.res.txt
@@ -1,7 +1,6 @@
 @@jsxConfig({version: 4})
 type props<'a> = {a?: 'a}
 
-@react.component
 let make = (props: props<(. unit) => unit>) => {
   let a = switch props.a {
   | Some(a) => a
@@ -29,7 +28,6 @@ func(~callback=(. str, a, b) => {
 module Foo = {
   type props<'callback> = {callback?: 'callback}
 
-  @react.component
   let make = (props: props<(. string, bool, bool) => unit>) => {
     let callback = switch props.callback {
     | Some(callback) => callback
@@ -50,7 +48,7 @@ module Foo = {
 module Bar = {
   type props = {}
 
-  @react.component let make = (_: props) => React.jsx(Foo.make, {callback: (. _, _, _) => ()})
+  let make = (_: props) => React.jsx(Foo.make, {callback: (. _, _, _) => ()})
   let make = {
     let \"UncurriedProps$Bar" = props => make(props)
 

--- a/res_syntax/tests/ppx/react/expected/v4.res.txt
+++ b/res_syntax/tests/ppx/react/expected/v4.res.txt
@@ -1,5 +1,5 @@
 type props<'x, 'y> = {x: 'x, y: 'y} // Component with type constraint
-@react.component let make = ({x, y, _}: props<string, string>) => React.string(x ++ y)
+let make = ({x, y, _}: props<string, string>) => React.string(x ++ y)
 let make = {
   let \"V4" = (props: props<_>) => make(props)
   \"V4"
@@ -9,7 +9,7 @@ module AnotherName = {
   type // Component with another name than "make"
   props<'x> = {x: 'x}
 
-  @react.component let anotherName = ({x, _}: props<_>) => React.string(x)
+  let anotherName = ({x, _}: props<_>) => React.string(x)
   let anotherName = {
     let \"V4$AnotherName$anotherName" = (props: props<_>) => anotherName(props)
 
@@ -20,7 +20,7 @@ module AnotherName = {
 module Uncurried = {
   type props<'x> = {x: 'x}
 
-  @react.component let make = ({x, _}: props<_>) => React.string(x)
+  let make = ({x, _}: props<_>) => React.string(x)
   let make = {
     let \"V4$Uncurried" = (props: props<_>) => make(props)
 

--- a/res_syntax/tests/ppx/react/nested.res
+++ b/res_syntax/tests/ppx/react/nested.res
@@ -1,0 +1,11 @@
+module Outer = {
+  @react.component
+  let make = () => {
+    module Inner = {
+      @react.component
+      let make = () => <div />
+    }
+
+    <Inner />
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-compiler/issues/5975

The issue is due to a combination of:
1) when a component let make = body is transformed, first the body is transformed, then when transformStructureItem4 is called, the body is transformed again
2) @react.component is left after the PPX transformation

Because of this, in the case of nested components, the transformed inner components is transformed again by transformStructureItem4, but it should not as it's been desugared already.

It would be enough to change either one, to avoid the error with nested components, but this PR handles both aspects.