### PR TITLE
Downgrade setup-ocaml to fix Windows CI issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           submodules: true
 
       - name: Use OCaml ${{matrix.ocaml_compiler}}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v2.0.10
         with:
           ocaml-compiler: ${{matrix.ocaml_compiler}}
           opam-pin: false


### PR DESCRIPTION
[setup-ocaml 2.0.11](https://github.com/ocaml/setup-ocaml/releases/tag/v2.0.11) contains the following change:

> Don't install Cygwin's git or mercurial packages (reduces cache by ~90MB).

(see also https://github.com/ocaml/setup-ocaml/pull/648)

In our CI script, we are setting up the git config as follows for Windows:

```
git config --global core.autocrlf false
git config --global core.eol lf
```

With the Git Windows client (already installed in the runner image) used instead of Cygwin's git, this causes the following error when running `git diff` later on in the CI process:

```
Run git diff --exit-code lib/js lib/es6
fatal: bad boolean config value 'false
' for 'core.autocrlf'
```

I am therefore pinning the setup-ocaml version to 2.0.10 for now.