### PR TITLE
Improve code generated for default arguments in JSX V4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ These are only breaking changes for unformatted code.
 - Fix issue with JSX V4 and newtype https://github.com/rescript-lang/rescript-compiler/pull/6029
 - Fix issue with JSX V4 when components are nested https://github.com/rescript-lang/rescript-compiler/pull/6031
 - Fix issue where generic compare on `float` values would be different from the compare for type `float` https://github.com/rescript-lang/rescript-compiler/pull/6042
+- Improve code generated for default arguments in JSX V4 https://github.com/rescript-lang/rescript-compiler/pull/6041
 
 #### :nail_care: Polish
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ These are only breaking changes for unformatted code.
 - Fix issue with JSX V4 when components are nested https://github.com/rescript-lang/rescript-compiler/pull/6031
 - Fix issue where generic compare on `float` values would be different from the compare for type `float` https://github.com/rescript-lang/rescript-compiler/pull/6042
 - Improve code generated for default arguments in JSX V4 https://github.com/rescript-lang/rescript-compiler/pull/6041
+- Fix issue with JSX V4 props of the form `~p as module(...)` https://github.com/rescript-lang/rescript-compiler/pull/6041
 
 #### :nail_care: Polish
 

--- a/docs/JSXV4.md
+++ b/docs/JSXV4.md
@@ -273,12 +273,10 @@ is transformed to
 type props<'x, 'y, 'z> = {x: 'x, y?: 'y, z?: 'z}
 
 ({x, ?y, ?z}: props<_, _, _>) => {
-  let x = x
   let y = switch y {
   | None => 3 + x
   | Some(y) => y
   }
-  let z = z
   body
 }
 ```

--- a/docs/JSXV4.md
+++ b/docs/JSXV4.md
@@ -264,7 +264,7 @@ let make = React.forwardRef({
 ### Transformation for Component Definition
 
 ```rescript
-@react.component (~x, ~y=3+x, ?z) => body
+@react.component (~x, ~y=3+x, ~z=?) => body
 ```
 
 is transformed to
@@ -272,11 +272,13 @@ is transformed to
 ```rescript
 type props<'x, 'y, 'z> = {x: 'x, y?: 'y, z?: 'z}
 
-({x, y, z}: props<_>) => {
-  let y = switch props.y {
+({x, ?y, ?z}: props<_, _, _>) => {
+  let x = x
+  let y = switch y {
   | None => 3 + x
   | Some(y) => y
   }
+  let z = z
   body
 }
 ```

--- a/jscomp/test/alias_default_value_test.js
+++ b/jscomp/test/alias_default_value_test.js
@@ -2,9 +2,9 @@
 
 
 function Alias_default_value_test$C0(props) {
+  var b = props.b;
   var a = props.a;
   var a$1 = a !== undefined ? a : 2;
-  var b = props.b;
   var b$1 = b !== undefined ? b : (a$1 << 1);
   return a$1 + b$1 | 0;
 }
@@ -14,9 +14,9 @@ var C0 = {
 };
 
 function Alias_default_value_test$C1(props) {
-  var foo = props.foo;
-  if (foo !== undefined) {
-    return foo;
+  var bar = props.foo;
+  if (bar !== undefined) {
+    return bar;
   } else {
     return "";
   }
@@ -26,6 +26,19 @@ var C1 = {
   make: Alias_default_value_test$C1
 };
 
+function Alias_default_value_test$C2(props) {
+  var a = props.a;
+  var bar = props.foo;
+  var bar$1 = bar !== undefined ? bar : "";
+  var a$1 = a !== undefined ? a : bar$1;
+  return bar$1 + a$1 + props.b;
+}
+
+var C2 = {
+  make: Alias_default_value_test$C2
+};
+
 exports.C0 = C0;
 exports.C1 = C1;
+exports.C2 = C2;
 /* No side effect */

--- a/jscomp/test/alias_default_value_test.js
+++ b/jscomp/test/alias_default_value_test.js
@@ -59,9 +59,18 @@ var C4 = {
   make: Alias_default_value_test$C4
 };
 
+function Alias_default_value_test$C6(props) {
+  return props.comp.xx;
+}
+
+var C6 = {
+  make: Alias_default_value_test$C6
+};
+
 exports.C0 = C0;
 exports.C1 = C1;
 exports.C2 = C2;
 exports.C3 = C3;
 exports.C4 = C4;
+exports.C6 = C6;
 /* No side effect */

--- a/jscomp/test/alias_default_value_test.js
+++ b/jscomp/test/alias_default_value_test.js
@@ -38,7 +38,30 @@ var C2 = {
   make: Alias_default_value_test$C2
 };
 
+function Alias_default_value_test$C3(props) {
+  var text = props.text;
+  if (text !== undefined) {
+    return text;
+  } else {
+    return "Test";
+  }
+}
+
+var C3 = {
+  make: Alias_default_value_test$C3
+};
+
+function Alias_default_value_test$C4(props) {
+  return props.a;
+}
+
+var C4 = {
+  make: Alias_default_value_test$C4
+};
+
 exports.C0 = C0;
 exports.C1 = C1;
 exports.C2 = C2;
+exports.C3 = C3;
+exports.C4 = C4;
 /* No side effect */

--- a/jscomp/test/alias_default_value_test.res
+++ b/jscomp/test/alias_default_value_test.res
@@ -32,3 +32,14 @@ module C4 = {
   @react.component
   let make = (~a as b, ~x=true) => b
 }
+
+module C6 = {
+  module type Comp = {
+    let xx : int
+    @react.component
+    let make: unit => React.element
+  }
+
+  @react.component
+  let make = (~comp as module(Comp: Comp), ~x as (a, b)) => Comp.xx
+}

--- a/jscomp/test/alias_default_value_test.res
+++ b/jscomp/test/alias_default_value_test.res
@@ -15,3 +15,10 @@ module C1 = {
     React.string(bar)
   }
 }
+
+module C2 = {
+  @react.component
+  let make = (~foo as bar="", ~a=bar, ~b) => {
+    React.string(bar ++ a ++ b)
+  }
+}

--- a/jscomp/test/alias_default_value_test.res
+++ b/jscomp/test/alias_default_value_test.res
@@ -22,3 +22,13 @@ module C2 = {
     React.string(bar ++ a ++ b)
   }
 }
+
+module C3 = {
+  @react.component
+  let make = (~priority as _, ~text="Test") => React.string(text)
+}
+
+module C4 = {
+  @react.component
+  let make = (~a as b, ~x=true) => b
+}

--- a/res_syntax/src/reactjs_jsx_v4.ml
+++ b/res_syntax/src/reactjs_jsx_v4.ml
@@ -850,9 +850,7 @@ let vbMatch (name, default, _, alias, loc, _) =
     Vb.mk
       (Pat.var (Location.mkloc alias loc))
       (Exp.match_
-         (Exp.field
-            (Exp.ident {txt = Lident "props"; loc = Location.none})
-            (Location.mknoloc @@ Lident label))
+         (Exp.ident {txt = Lident alias; loc = Location.none})
          [
            Exp.case
              (Pat.construct
@@ -866,9 +864,7 @@ let vbMatch (name, default, _, alias, loc, _) =
   | None ->
     Vb.mk
       (Pat.var (Location.mkloc alias loc))
-      (Exp.field
-         (Exp.ident {txt = Lident "props"; loc = Location.none})
-         (Location.mknoloc @@ Lident label))
+      (Exp.ident {txt = Lident label; loc = Location.none})
 
 let vbMatchExpr namedArgList expr =
   let rec aux namedArgList =
@@ -1042,11 +1038,6 @@ let mapBinding ~config ~emptyLoc ~pstr_loc ~fileName ~recFlag binding =
       match patternsWithLabel with
       | [] -> Pat.any ()
       | _ -> Pat.record (List.rev patternsWithLabel) Open
-    in
-    let recordPattern =
-      if hasDefaultValue namedArgList then
-        Pat.var {txt = "props"; loc = emptyLoc}
-      else recordPattern
     in
     let expression =
       Exp.fun_ Nolabel None

--- a/res_syntax/src/reactjs_jsx_v4.ml
+++ b/res_syntax/src/reactjs_jsx_v4.ml
@@ -640,6 +640,7 @@ let rec recursivelyTransformNamedArgsForMake expr args newtypes coreType =
     in
     let type_ =
       match pattern with
+      | {ppat_desc = Ppat_constraint (_, {ptyp_desc = Ptyp_package _})} -> None
       | {ppat_desc = Ppat_constraint (_, type_)} -> Some type_
       | _ -> None
     in
@@ -965,11 +966,10 @@ let mapBinding ~config ~emptyLoc ~pstr_loc ~fileName ~recFlag binding =
     in
     let rec stripConstraintUnpack ~label pattern =
       match pattern with
+      | {ppat_desc = Ppat_constraint (_, {ptyp_desc = Ptyp_package _})} ->
+        pattern
       | {ppat_desc = Ppat_constraint (pattern, _)} ->
         stripConstraintUnpack ~label pattern
-      | {ppat_desc = Ppat_unpack _; ppat_loc} ->
-        (* remove unpack e.g. model: module(T) *)
-        Pat.var ~loc:ppat_loc {txt = label; loc = ppat_loc}
       | _ -> pattern
     in
     let rec returnedExpression patternsWithLabel patternsWithNolabel

--- a/res_syntax/tests/ppx/react/aliasProps.res
+++ b/res_syntax/tests/ppx/react/aliasProps.res
@@ -14,3 +14,10 @@ module C2 = {
   @react.component
   let make = (~foo as bar="") => React.string(bar)
 }
+
+module C3 = {
+  @react.component
+  let make = (~foo as bar="", ~a=bar, ~b) => {
+    React.string(bar ++ a ++ b)
+  }
+}

--- a/res_syntax/tests/ppx/react/aliasProps.res
+++ b/res_syntax/tests/ppx/react/aliasProps.res
@@ -21,3 +21,15 @@ module C3 = {
     React.string(bar ++ a ++ b)
   }
 }
+
+module C4 = {
+  @react.component
+  let make = (~a as b, ~x=true) => <div> b </div>
+}
+
+module C5 = {
+  @react.component
+  let make = (~a as (x,y), ~z=3) => x+y+z
+}
+
+

--- a/res_syntax/tests/ppx/react/aliasProps.res
+++ b/res_syntax/tests/ppx/react/aliasProps.res
@@ -29,7 +29,15 @@ module C4 = {
 
 module C5 = {
   @react.component
-  let make = (~a as (x,y), ~z=3) => x+y+z
+  let make = (~a as (x, y), ~z=3) => x + y + z
 }
 
+module C6 = {
+  module type Comp = {
+    @react.component
+    let make: unit => React.element
+  }
 
+  @react.component
+  let make = (~comp as module(Comp: Comp), ~x as (a, b)) => <Comp />
+}

--- a/res_syntax/tests/ppx/react/expected/aliasProps.res.txt
+++ b/res_syntax/tests/ppx/react/expected/aliasProps.res.txt
@@ -3,9 +3,9 @@
 module C0 = {
   type props<'priority, 'text> = {priority: 'priority, text?: 'text}
 
-  let make = (props: props<_, _>) => {
-    let _ = props.priority
-    let text = switch props.text {
+  let make = ({priority: _, ?text, _}: props<_, _>) => {
+    let _ = priority
+    let text = switch text {
     | Some(text) => text
     | None => "Test"
     }
@@ -22,9 +22,9 @@ module C0 = {
 module C1 = {
   type props<'priority, 'text> = {priority: 'priority, text?: 'text}
 
-  let make = (props: props<_, _>) => {
-    let p = props.priority
-    let text = switch props.text {
+  let make = ({priority: p, ?text, _}: props<_, _>) => {
+    let p = priority
+    let text = switch text {
     | Some(text) => text
     | None => "Test"
     }
@@ -41,8 +41,8 @@ module C1 = {
 module C2 = {
   type props<'foo> = {foo?: 'foo}
 
-  let make = (props: props<_>) => {
-    let bar = switch props.foo {
+  let make = ({foo: ?bar, _}: props<_>) => {
+    let bar = switch bar {
     | Some(foo) => foo
     | None => ""
     }
@@ -53,5 +53,30 @@ module C2 = {
     let \"AliasProps$C2" = (props: props<_>) => make(props)
 
     \"AliasProps$C2"
+  }
+}
+
+module C3 = {
+  type props<'foo, 'a, 'b> = {foo?: 'foo, a?: 'a, b: 'b}
+
+  let make = ({foo: ?bar, ?a, b, _}: props<_, _, _>) => {
+    let bar = switch bar {
+    | Some(foo) => foo
+    | None => ""
+    }
+    let a = switch a {
+    | Some(a) => a
+    | None => bar
+    }
+    let b = b
+
+    {
+      React.string(bar ++ a ++ b)
+    }
+  }
+  let make = {
+    let \"AliasProps$C3" = (props: props<_>) => make(props)
+
+    \"AliasProps$C3"
   }
 }

--- a/res_syntax/tests/ppx/react/expected/aliasProps.res.txt
+++ b/res_syntax/tests/ppx/react/expected/aliasProps.res.txt
@@ -4,7 +4,6 @@ module C0 = {
   type props<'priority, 'text> = {priority: 'priority, text?: 'text}
 
   let make = ({priority: _, ?text, _}: props<_, _>) => {
-    let _ = priority
     let text = switch text {
     | Some(text) => text
     | None => "Test"
@@ -23,7 +22,6 @@ module C1 = {
   type props<'priority, 'text> = {priority: 'priority, text?: 'text}
 
   let make = ({priority: p, ?text, _}: props<_, _>) => {
-    let p = priority
     let text = switch text {
     | Some(text) => text
     | None => "Test"
@@ -68,7 +66,6 @@ module C3 = {
     | Some(a) => a
     | None => bar
     }
-    let b = b
 
     {
       React.string(bar ++ a ++ b)
@@ -78,5 +75,41 @@ module C3 = {
     let \"AliasProps$C3" = (props: props<_>) => make(props)
 
     \"AliasProps$C3"
+  }
+}
+
+module C4 = {
+  type props<'a, 'x> = {a: 'a, x?: 'x}
+
+  let make = ({a: b, ?x, _}: props<_, _>) => {
+    let x = switch x {
+    | Some(x) => x
+    | None => true
+    }
+
+    ReactDOM.jsx("div", {children: ?ReactDOM.someElement(b)})
+  }
+  let make = {
+    let \"AliasProps$C4" = (props: props<_>) => make(props)
+
+    \"AliasProps$C4"
+  }
+}
+
+module C5 = {
+  type props<'a, 'z> = {a: 'a, z?: 'z}
+
+  let make = ({a: (x, y), ?z, _}: props<_, _>) => {
+    let z = switch z {
+    | Some(z) => z
+    | None => 3
+    }
+
+    x + y + z
+  }
+  let make = {
+    let \"AliasProps$C5" = (props: props<_>) => make(props)
+
+    \"AliasProps$C5"
   }
 }

--- a/res_syntax/tests/ppx/react/expected/aliasProps.res.txt
+++ b/res_syntax/tests/ppx/react/expected/aliasProps.res.txt
@@ -113,3 +113,19 @@ module C5 = {
     \"AliasProps$C5"
   }
 }
+
+module C6 = {
+  module type Comp = {
+    type props = {}
+
+    let make: React.componentLike<props, React.element>
+  }
+  type props<'comp, 'x> = {comp: 'comp, x: 'x}
+
+  let make = ({comp: module(Comp: Comp), x: (a, b), _}: props<_, _>) => React.jsx(Comp.make, {})
+  let make = {
+    let \"AliasProps$C6" = (props: props<_>) => make(props)
+
+    \"AliasProps$C6"
+  }
+}

--- a/res_syntax/tests/ppx/react/expected/defaultValueProp.res.txt
+++ b/res_syntax/tests/ppx/react/expected/defaultValueProp.res.txt
@@ -1,11 +1,11 @@
 module C0 = {
   type props<'a, 'b> = {a?: 'a, b?: 'b}
-  let make = (props: props<_, _>) => {
-    let a = switch props.a {
+  let make = ({?a, ?b, _}: props<_, _>) => {
+    let a = switch a {
     | Some(a) => a
     | None => 2
     }
-    let b = switch props.b {
+    let b = switch b {
     | Some(b) => b
     | None => a * 2
     }
@@ -21,12 +21,12 @@ module C0 = {
 module C1 = {
   type props<'a, 'b> = {a?: 'a, b: 'b}
 
-  let make = (props: props<_, _>) => {
-    let a = switch props.a {
+  let make = ({?a, b, _}: props<_, _>) => {
+    let a = switch a {
     | Some(a) => a
     | None => 2
     }
-    let b = props.b
+    let b = b
 
     React.int(a + b)
   }

--- a/res_syntax/tests/ppx/react/expected/defaultValueProp.res.txt
+++ b/res_syntax/tests/ppx/react/expected/defaultValueProp.res.txt
@@ -26,7 +26,6 @@ module C1 = {
     | Some(a) => a
     | None => 2
     }
-    let b = b
 
     React.int(a + b)
   }

--- a/res_syntax/tests/ppx/react/expected/firstClassModules.res.txt
+++ b/res_syntax/tests/ppx/react/expected/firstClassModules.res.txt
@@ -66,8 +66,8 @@ module Select = {
 
   let make = (
     type a key,
-    {model, selected, onChange, items, _}: props<
-      module(T with type t = a and type key = key),
+    {model: module(T: T with type t = a and type key = key), selected, onChange, items, _}: props<
+      _,
       option<key>,
       option<key> => unit,
       array<a>,

--- a/res_syntax/tests/ppx/react/expected/newtype.res.txt
+++ b/res_syntax/tests/ppx/react/expected/newtype.res.txt
@@ -67,7 +67,7 @@ module type T = {
 module V4A2 = {
   type props<'foo> = {foo: 'foo}
 
-  let make = (type a, {foo, _}: props<module(T with type t = a)>) => {
+  let make = (type a, {foo: (foo: module(T with type t = a)), _}: props<_>) => {
     module T = unpack(foo)
     ReactDOM.jsx("div", {})
   }
@@ -90,4 +90,12 @@ module V4A3 = {
 
     \"Newtype$V4A3"
   }
+}
+type props<'x, 'q> = {x: 'x, q: 'q}
+
+let make = ({x, q, _}: props<('a, 'b), 'a>) => [fst(x), q]
+let make = {
+  let \"Newtype" = (props: props<_>) => make(props)
+
+  \"Newtype"
 }

--- a/res_syntax/tests/ppx/react/expected/uncurriedProps.res.txt
+++ b/res_syntax/tests/ppx/react/expected/uncurriedProps.res.txt
@@ -1,8 +1,8 @@
 @@jsxConfig({version: 4})
 type props<'a> = {a?: 'a}
 
-let make = (props: props<(. unit) => unit>) => {
-  let a = switch props.a {
+let make = ({?a, _}: props<(. unit) => unit>) => {
+  let a = switch a {
   | Some(a) => a
   | None => (. ()) => ()
   }
@@ -28,8 +28,8 @@ func(~callback=(. str, a, b) => {
 module Foo = {
   type props<'callback> = {callback?: 'callback}
 
-  let make = (props: props<(. string, bool, bool) => unit>) => {
-    let callback = switch props.callback {
+  let make = ({?callback, _}: props<(. string, bool, bool) => unit>) => {
+    let callback = switch callback {
     | Some(callback) => callback
     | None => (. _, _, _) => ()
     }

--- a/res_syntax/tests/ppx/react/newtype.res
+++ b/res_syntax/tests/ppx/react/newtype.res
@@ -43,3 +43,6 @@ module V4A3 = {
     foo
   }
 }
+
+@react.component
+let make =(~x : ('a,'b), ~q:'a ) => [fst(x), q]


### PR DESCRIPTION
This
```res
@react.component
let foo = (~x, ~y=3+x, ?z) => ...
```

was generating

```res
({props: props<_, _, _>) => {
  let x = props.x
  let y = switch props.y {
  | None => 3 + x
  | Some(y) => y
  }
  let z = props.z
...
```

now it generates instead
```res
({x, ?y, ?z}: props<_, _, _>) => {
  let x = x
  let y = switch y {
  | None => 3 + x
  | Some(y) => y
  }
  let z = z
...
```

the different in generated code is that bindings such as `let x = props.x` are not present in the `js` output.