### PR TITLE
Use latest setup-ocaml again as Windows git config issue is fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           chmod +x _build/install/default/bin/*
 
       - name: Use OCaml ${{matrix.ocaml_compiler}}
-        uses: ocaml/setup-ocaml@v2.0.10
+        uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{matrix.ocaml_compiler}}
           opam-pin: false


### PR DESCRIPTION
This reverts commit e9b20aeae707b57f7ca5d9f3b351cc18990ce2e3.

We want to be on the latest setup-ocaml version, as the new [ocaml-setup 2.0.12](https://github.com/ocaml/setup-ocaml/releases/tag/v2.0.12) now also uses the official OPAM mingw repo instead of the deprecated and outdated fork fdopen/opam-repository-mingw.



