### PR TITLE
Add internal bsc option `ignore-parse-errors`

### DIFF
--- a/jscomp/bsc/rescript_compiler_main.ml
+++ b/jscomp/bsc/rescript_compiler_main.ml
@@ -72,13 +72,13 @@ let process_file sourcefile ?(kind ) ppf =
     let sourcefile = set_abs_input_name  sourcefile in     
     setup_compiler_printer `rescript;
     Js_implementation.implementation 
-      ~parser:Res_driver.parse_implementation
+      ~parser:(Res_driver.parse_implementation ~ignoreParseErrors:!Clflags.ignore_parse_errors)
       ppf sourcefile 
   | Resi ->   
     let sourcefile = set_abs_input_name  sourcefile in 
     setup_compiler_printer `rescript;
     Js_implementation.interface 
-      ~parser:Res_driver.parse_interface
+      ~parser:(Res_driver.parse_interface ~ignoreParseErrors:!Clflags.ignore_parse_errors)
       ppf sourcefile      
   | Intf_ast 
     ->     
@@ -153,7 +153,7 @@ let format_file input =
     | Ml | Mli -> `ml
     | Res | Resi -> `res 
     | _ -> Bsc_args.bad_arg ("don't know what to do with " ^ input) in   
-  let formatted =   Res_multi_printer.print syntax ~input in 
+  let formatted = Res_multi_printer.print ~ignoreParseErrors:!Clflags.ignore_parse_errors syntax ~input in 
   match !Clflags.output_name with 
   | None ->
     output_string stdout formatted
@@ -391,6 +391,9 @@ let buckle_script_flags : (string * Bsc_args.spec * string) array =
 
     "-only-parse", set Clflags.only_parse, 
     "*internal* stop after parsing";
+
+    "-ignore-parse-errors", set Clflags.ignore_parse_errors, 
+    "*internal* continue after parse errors";
 
     "-where", unit_call print_standard_library, 
     "*internal* Print location of standard library and exit";

--- a/jscomp/ml/clflags.ml
+++ b/jscomp/ml/clflags.ml
@@ -25,7 +25,8 @@ let dump_parsetree = ref false          (* -dparsetree *)
 and dump_typedtree = ref false          (* -dtypedtree *)
 and dump_rawlambda = ref false          (* -drawlambda *)
 and dump_lambda = ref false             (* -dlambda *)
-and only_parse = ref false             (* -only-parse *)
+and only_parse = ref false              (* -only-parse *)
+and ignore_parse_errors = ref false     (* -ignore-parse-errors *)
 
 let dont_write_files = ref false        (* set to true under ocamldoc *)
 

--- a/jscomp/ml/clflags.mli
+++ b/jscomp/ml/clflags.mli
@@ -25,6 +25,7 @@ val dont_write_files : bool ref
 val keep_docs : bool ref
 val keep_locs : bool ref
 val only_parse : bool ref
+val ignore_parse_errors: bool ref
 
 
 val parse_color_setting : string -> Misc.Color.setting option

--- a/res_syntax/src/res_driver.ml
+++ b/res_syntax/src/res_driver.ml
@@ -131,24 +131,31 @@ let printEngine =
         print_string (Res_printer.printInterface ~width signature ~comments));
   }
 
-let parse_implementation sourcefile =
+let parse_implementation ?(ignoreParseErrors = false) sourcefile =
   Location.input_name := sourcefile;
   let parseResult =
     parsingEngine.parseImplementation ~forPrinter:false ~filename:sourcefile
   in
   if parseResult.invalid then (
     Res_diagnostics.printReport parseResult.diagnostics parseResult.source;
-    exit 1);
+    if not ignoreParseErrors then exit 1);
   parseResult.parsetree
   [@@raises exit]
 
-let parse_interface sourcefile =
+let parse_interface ?(ignoreParseErrors = false) sourcefile =
   Location.input_name := sourcefile;
   let parseResult =
     parsingEngine.parseInterface ~forPrinter:false ~filename:sourcefile
   in
   if parseResult.invalid then (
     Res_diagnostics.printReport parseResult.diagnostics parseResult.source;
-    exit 1);
+    if not ignoreParseErrors then exit 1);
   parseResult.parsetree
   [@@raises exit]
+
+(* suppress unused optional arg *)
+let _ =
+ fun s ->
+  ( parse_implementation ~ignoreParseErrors:false s,
+    parse_interface ~ignoreParseErrors:false s )
+ [@@raises exit]

--- a/res_syntax/src/res_driver.mli
+++ b/res_syntax/src/res_driver.mli
@@ -53,9 +53,10 @@ val parsingEngine : Res_diagnostics.t list parsingEngine
 val printEngine : printEngine
 
 (* ReScript implementation parsing compatible with ocaml pparse driver. Used by the compiler. *)
-val parse_implementation : string -> Parsetree.structure
+val parse_implementation :
+  ?ignoreParseErrors:bool -> string -> Parsetree.structure
   [@@live] [@@raises Location.Error]
 
 (* ReScript interface parsing compatible with ocaml pparse driver. Used by the compiler *)
-val parse_interface : string -> Parsetree.signature
+val parse_interface : ?ignoreParseErrors:bool -> string -> Parsetree.signature
   [@@live] [@@raises Location.Error]

--- a/res_syntax/src/res_multi_printer.ml
+++ b/res_syntax/src/res_multi_printer.ml
@@ -1,27 +1,25 @@
 let defaultPrintWidth = 100
 
 (* print res files to res syntax *)
-let printRes ~isInterface ~filename =
-  if isInterface then
+let printRes ~ignoreParseErrors ~isInterface ~filename =
+  if isInterface then (
     let parseResult =
       Res_driver.parsingEngine.parseInterface ~forPrinter:true ~filename
     in
     if parseResult.invalid then (
       Res_diagnostics.printReport parseResult.diagnostics parseResult.source;
-      exit 1)
-    else
-      Res_printer.printInterface ~width:defaultPrintWidth
-        ~comments:parseResult.comments parseResult.parsetree
+      if not ignoreParseErrors then exit 1);
+    Res_printer.printInterface ~width:defaultPrintWidth
+      ~comments:parseResult.comments parseResult.parsetree)
   else
     let parseResult =
       Res_driver.parsingEngine.parseImplementation ~forPrinter:true ~filename
     in
     if parseResult.invalid then (
       Res_diagnostics.printReport parseResult.diagnostics parseResult.source;
-      exit 1)
-    else
-      Res_printer.printImplementation ~width:defaultPrintWidth
-        ~comments:parseResult.comments parseResult.parsetree
+      if not ignoreParseErrors then exit 1);
+    Res_printer.printImplementation ~width:defaultPrintWidth
+      ~comments:parseResult.comments parseResult.parsetree
   [@@raises exit]
 
 (* print ocaml files to res syntax *)
@@ -42,12 +40,15 @@ let printMl ~isInterface ~filename =
       ~comments:parseResult.comments parseResult.parsetree
 
 (* print the given file named input to from "language" to res, general interface exposed by the compiler *)
-let print language ~input =
+let print ?(ignoreParseErrors = false) language ~input =
   let isInterface =
     let len = String.length input in
     len > 0 && String.unsafe_get input (len - 1) = 'i'
   in
   match language with
-  | `res -> printRes ~isInterface ~filename:input
+  | `res -> printRes ~ignoreParseErrors ~isInterface ~filename:input
   | `ml -> printMl ~isInterface ~filename:input
   [@@raises exit]
+
+(* suppress unused optional arg *)
+let _ = fun s -> print ~ignoreParseErrors:false s [@@raises exit]

--- a/res_syntax/src/res_multi_printer.mli
+++ b/res_syntax/src/res_multi_printer.mli
@@ -1,3 +1,3 @@
 (* Interface to print source code from different languages to res.
  * Takes a filename called "input" and returns the corresponding formatted res syntax *)
-val print : [`ml | `res] -> input:string -> string
+val print : ?ignoreParseErrors:bool -> [`ml | `res] -> input:string -> string


### PR DESCRIPTION
For debugging purposes, don't stop the compiler after parse errors are encountered. This lets you take a look at the parse tree produced after parse errors, or format in the presence of errors.