### PR TITLE
Make internal encoding of locations aware of unicode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ These are only breaking changes for unformatted code.
 - Parser: fix location of variable when function definition `{v => ...}` is enclosed in braces https://github.com/rescript-lang/rescript-compiler/pull/5949
 - Fix issue with error messages for uncurried functions where expected and given type were swapped https://github.com/rescript-lang/rescript-compiler/pull/5973
 - Fix issue with integer overflow check https://github.com/rescript-lang/rescript-compiler/pull/6028
+- Make internal encoding of locations aware of unicode https://github.com/rescript-lang/rescript-compiler/pull/6073
 
 #### :nail_care: Polish
 

--- a/jscomp/build_tests/super_errors/expected/unicode_location.res.expected
+++ b/jscomp/build_tests/super_errors/expected/unicode_location.res.expected
@@ -1,0 +1,12 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/unicode_location.res[0m:[2m1:43[0m
+
+  [1;31m1[0m [2m│[0m let q = "💩💩💩💩💩💩💩💩�[1;31m�[0m��💩" ++ ("a" ++ 3 ++ "b")
+  2 [2m│[0m //                                         ^ character position 33 + 10 
+    [2m│[0m (unicode symbols of length 2)
+
+  This has type: [1;31mint[0m
+  Somewhere wanted: [1;33mstring[0m
+  
+  You can convert [1;33mint[0m to [1;33mstring[0m with [1;33mBelt.Int.toString[0m.

--- a/jscomp/build_tests/super_errors/fixtures/unicode_location.res
+++ b/jscomp/build_tests/super_errors/fixtures/unicode_location.res
@@ -1,0 +1,2 @@
+let q = "💩💩💩💩💩💩💩💩💩💩" ++ ("a" ++ 3 ++ "b")
+//                                         ^ character position 33 + 10 (unicode symbols of length 2)

--- a/res_syntax/src/res_core.ml
+++ b/res_syntax/src/res_core.ml
@@ -2469,6 +2469,7 @@ and parseAttributesAndBinding (p : Parser.t) =
   let err = p.scanner.err in
   let ch = p.scanner.ch in
   let offset = p.scanner.offset in
+  let offset16 = p.scanner.offset16 in
   let lineOffset = p.scanner.lineOffset in
   let lnum = p.scanner.lnum in
   let mode = p.scanner.mode in
@@ -2490,6 +2491,7 @@ and parseAttributesAndBinding (p : Parser.t) =
       p.scanner.err <- err;
       p.scanner.ch <- ch;
       p.scanner.offset <- offset;
+      p.scanner.offset16 <- offset16;
       p.scanner.lineOffset <- lineOffset;
       p.scanner.lnum <- lnum;
       p.scanner.mode <- mode;

--- a/res_syntax/src/res_parser.ml
+++ b/res_syntax/src/res_parser.ml
@@ -159,6 +159,7 @@ let lookahead p callback =
   let err = p.scanner.err in
   let ch = p.scanner.ch in
   let offset = p.scanner.offset in
+  let offset16 = p.scanner.offset16 in
   let lineOffset = p.scanner.lineOffset in
   let lnum = p.scanner.lnum in
   let mode = p.scanner.mode in
@@ -177,6 +178,7 @@ let lookahead p callback =
   p.scanner.err <- err;
   p.scanner.ch <- ch;
   p.scanner.offset <- offset;
+  p.scanner.offset16 <- offset16;
   p.scanner.lineOffset <- lineOffset;
   p.scanner.lnum <- lnum;
   p.scanner.mode <- mode;

--- a/res_syntax/src/res_scanner.mli
+++ b/res_syntax/src/res_scanner.mli
@@ -11,7 +11,9 @@ type t = {
     Res_diagnostics.category ->
     unit;
   mutable ch: charEncoding; (* current character *)
-  mutable offset: int; (* character offset *)
+  mutable offset: int; (* current byte offset *)
+  mutable offset16: int;
+      (* current number of utf16 code units since line start *)
   mutable lineOffset: int; (* current line offset *)
   mutable lnum: int; (* current line number *)
   mutable mode: mode list;


### PR DESCRIPTION
When some unicode characters are present on a line, the existing encoding of positions, based on number of bytes since line start, is incorrect. This can be seen in e.g. error messages picked up in the editor (or on the command-line).

This PR takes unicode into account. Even though the ocaml locations are byte-based, one can trick the system by encoding as `pos_cnum`:
```  (number of bytes from file start to line start) + (number of utf16 code units since line start) ```
Since the compiler's printer performs a subtraction, the utf16 character position is shown. Notice that editors, vscode in particular, show you something in "Col", but its internal commands expect correct utf16 character which is different.