### PR TITLE
Build compiler binaries with release profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: "Build compiler"
         if: runner.os != 'Linux'
-        run: opam exec -- dune build
+        run: opam exec -- dune build --profile release
 
       - name: Use Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
It seems the compiler binaries (other than the statically linked Linux binary) were built with the "dev" profile, i.e. without the `-O3 -unbox-closures` flags.