### PR TITLE
jsoo build with "dune build --profile browser"

### DIFF
--- a/jscomp/bsb_exe/dune
+++ b/jscomp/bsb_exe/dune
@@ -6,6 +6,8 @@
 (executable
  (name rescript_main)
  (public_name rescript)
+ (enabled_if
+  (<> %{profile} browser))
  (flags
   (:standard -w +a-4-9-40-41-42-70))
  (libraries bsb common ext str unix))

--- a/jscomp/bsb_helper_exe/dune
+++ b/jscomp/bsb_helper_exe/dune
@@ -6,6 +6,8 @@
 (executable
  (name bsb_helper_main)
  (public_name bsb_helper)
+ (enabled_if
+  (<> %{profile} browser))
  (flags
   (:standard -w +a-9-40-42))
  (libraries bsb_helper))

--- a/jscomp/dune
+++ b/jscomp/dune
@@ -15,4 +15,9 @@
   (env-vars
    (CPPO_FLAGS -D=RELEASE))
   (ocamlopt_flags
+   (:standard -O3 -unbox-closures)))
+ (browser
+  (env-vars
+   (CPPO_FLAGS -D=BROWSER))
+  (ocamlopt_flags
    (:standard -O3 -unbox-closures))))

--- a/jscomp/jsoo/dune
+++ b/jscomp/jsoo/dune
@@ -1,8 +1,10 @@
 ; Don't build the JS compiler by default as it slows down CI considerably.
 
-; (executables
-;  (names jsoo_main jsoo_playground_main)
-;  (modes js)
-;  (flags
-;   (:standard -w +a-4-9-40-42-44-45))
-;  (libraries core ml super_errors))
+(executables
+ (names jsoo_main jsoo_playground_main)
+ (modes js)
+ (enabled_if
+  (= %{profile} browser))
+ (flags
+  (:standard -w +a-4-9-40-42-44-45))
+ (libraries core ml super_errors))

--- a/jscomp/ounit_tests/dune
+++ b/jscomp/ounit_tests/dune
@@ -6,6 +6,8 @@
 (executable
  (name ounit_tests_main)
  (public_name ounit_tests)
+ (enabled_if
+  (<> %{profile} browser))
  (flags
   (:standard -w +a-4-9-30-40-41-42-48-70))
  (libraries bsb bsb_helper core ounit2))

--- a/res_syntax/benchmarks/dune
+++ b/res_syntax/benchmarks/dune
@@ -7,14 +7,16 @@
  (name benchmark)
  (public_name syntax_benchmarks)
  (enabled_if
-  (or
-   (= %{system} macosx)
-   ; or one of Linuxes (see https://github.com/ocaml/ocaml/issues/10613)
-   (= %{system} linux)
-   (= %{system} linux_elf)
-   (= %{system} elf)
-   (= %{system} linux_eabihf)
-   (= %{system} linux_eabi)))
+  (and
+   (<> %{profile} browser)
+   (or
+    (= %{system} macosx)
+    ; or one of Linuxes (see https://github.com/ocaml/ocaml/issues/10613)
+    (= %{system} linux)
+    (= %{system} linux_elf)
+    (= %{system} elf)
+    (= %{system} linux_eabihf)
+    (= %{system} linux_eabi))))
  (flags
   (:standard -w +a-4-40-42-70))
  (foreign_stubs

--- a/res_syntax/cli/dune
+++ b/res_syntax/cli/dune
@@ -6,6 +6,8 @@
 (executable
  (name res_cli)
  (public_name res_parser)
+ (enabled_if
+  (<> %{profile} browser))
  (flags
   (:standard -w +a-4-42-40-9-48-70))
  (libraries syntax))

--- a/res_syntax/testrunner/dune
+++ b/res_syntax/testrunner/dune
@@ -6,6 +6,8 @@
 (executable
  (name res_test)
  (public_name syntax_tests)
+ (enabled_if
+  (<> %{profile} browser))
  (flags
   (:standard -w +a-40-42-70))
  (libraries syntax core))


### PR DESCRIPTION
Enable building the playground compiler using

```sh
dune build --profile browser
```

When trying to use it following the instructions in https://github.com/rescript-lang/rescript-compiler/blob/master/CONTRIBUTING.md#playground-js-bundle-api, it currently gives `The module or file Pervasives can't be found.` This is because of the missing cmij cache, will address that in a separate PR at a later time.