### PR TITLE
Proof of Concept: explore per-module custom infix operators.

### DIFF
--- a/res_syntax/src/res_custom_infix.ml
+++ b/res_syntax/src/res_custom_infix.ml
@@ -1,0 +1,20 @@
+type t = (string * string) list
+
+let addSymbol ~name ~alias x =
+  (* Put "++" before "+" *)
+  let cmp (n1, _) (n2, _) = String.length n2 - String.length n1 in
+  List.stable_sort cmp ((name, alias) :: x)
+
+let findAlias ~alias x = x |> List.find_opt (fun (_, a) -> alias = a)
+
+let lookupName ~name ~src ~srcLen ~offset =
+  let nameLen = String.length name in
+  let restLen = srcLen - offset in
+  if nameLen <= restLen then (
+    let found = ref true in
+    for i = 0 to nameLen - 1 do
+      if (name.[i] [@doesNotRaise]) <> (src.[offset + i] [@doesNotRaise]) then
+        found := false
+    done;
+    !found)
+  else false

--- a/res_syntax/src/res_parens.mli
+++ b/res_syntax/src/res_parens.mli
@@ -3,17 +3,21 @@ type kind = Parenthesized | Braced of Location.t | Nothing
 val expr : Parsetree.expression -> kind
 val structureExpr : Parsetree.expression -> kind
 
-val unaryExprOperand : Parsetree.expression -> kind
+val unaryExprOperand : state:Res_printer_state.t -> Parsetree.expression -> kind
 
-val binaryExprOperand : isLhs:bool -> Parsetree.expression -> kind
+val binaryExprOperand :
+  isLhs:bool -> state:Res_printer_state.t -> Parsetree.expression -> kind
 val subBinaryExprOperand : string -> string -> bool
-val rhsBinaryExprOperand : string -> Parsetree.expression -> bool
-val flattenOperandRhs : string -> Parsetree.expression -> bool
+val rhsBinaryExprOperand :
+  state:Res_printer_state.t -> string -> Parsetree.expression -> bool
+val flattenOperandRhs :
+  state:Res_printer_state.t -> string -> Parsetree.expression -> bool
 
 val binaryOperatorInsideAwaitNeedsParens : string -> bool
-val lazyOrAssertOrAwaitExprRhs : ?inAwait:bool -> Parsetree.expression -> kind
+val lazyOrAssertOrAwaitExprRhs :
+  ?inAwait:bool -> state:Res_printer_state.t -> Parsetree.expression -> kind
 
-val fieldExpr : Parsetree.expression -> kind
+val fieldExpr : state:Res_printer_state.t -> Parsetree.expression -> kind
 
 val setFieldExprRhs : Parsetree.expression -> kind
 
@@ -22,13 +26,13 @@ val ternaryOperand : Parsetree.expression -> kind
 val jsxPropExpr : Parsetree.expression -> kind
 val jsxChildExpr : Parsetree.expression -> kind
 
-val binaryExpr : Parsetree.expression -> kind
+val binaryExpr : state:Res_printer_state.t -> Parsetree.expression -> kind
 val modTypeFunctorReturn : Parsetree.module_type -> bool
 val modTypeWithOperand : Parsetree.module_type -> bool
 val modExprFunctorConstraint : Parsetree.module_type -> bool
 
 val bracedExpr : Parsetree.expression -> bool
-val callExpr : Parsetree.expression -> kind
+val callExpr : state:Res_printer_state.t -> Parsetree.expression -> kind
 
 val includeModExpr : Parsetree.module_expr -> bool
 

--- a/res_syntax/src/res_parser.ml
+++ b/res_syntax/src/res_parser.ml
@@ -161,6 +161,7 @@ let lookahead p callback =
   let offset = p.scanner.offset in
   let offset16 = p.scanner.offset16 in
   let lineOffset = p.scanner.lineOffset in
+  let customInfix = p.scanner.customInfix in
   let lnum = p.scanner.lnum in
   let mode = p.scanner.mode in
   let token = p.token in
@@ -182,6 +183,7 @@ let lookahead p callback =
   p.scanner.lineOffset <- lineOffset;
   p.scanner.lnum <- lnum;
   p.scanner.mode <- mode;
+  p.scanner.customInfix <- customInfix;
   p.token <- token;
   p.startPos <- startPos;
   p.endPos <- endPos;

--- a/res_syntax/src/res_parsetree_viewer.mli
+++ b/res_syntax/src/res_parsetree_viewer.mli
@@ -75,8 +75,9 @@ val isHuggableRhs : Parsetree.expression -> bool
 val operatorPrecedence : string -> int
 
 val isUnaryExpression : Parsetree.expression -> bool
-val isBinaryOperator : string -> bool
-val isBinaryExpression : Parsetree.expression -> bool
+val isBinaryOperator : state:Res_printer_state.t -> string -> bool
+val isBinaryExpression :
+  state:Res_printer_state.t -> Parsetree.expression -> bool
 val isRhsBinaryOperator : string -> bool
 
 val flattenableOperators : string -> string -> bool
@@ -100,7 +101,8 @@ val isJsxExpression : Parsetree.expression -> bool
 val hasJsxAttribute : Parsetree.attributes -> bool
 val hasOptionalAttribute : Parsetree.attributes -> bool
 
-val shouldIndentBinaryExpr : Parsetree.expression -> bool
+val shouldIndentBinaryExpr :
+  state:Res_printer_state.t -> Parsetree.expression -> bool
 val shouldInlineRhsBinaryExpr : Parsetree.expression -> bool
 val hasPrintableAttributes : Parsetree.attributes -> bool
 val filterPrintableAttributes : Parsetree.attributes -> Parsetree.attributes

--- a/res_syntax/src/res_printer_state.ml
+++ b/res_syntax/src/res_printer_state.ml
@@ -1,0 +1,21 @@
+let customLayoutThreshold = 2
+
+type t = {
+  customLayout: int;
+  mutable uncurried_config: Res_uncurried.config;
+  mutable customInfix: Res_custom_infix.t;
+}
+
+let copy t =
+  {
+    customLayout = t.customLayout;
+    uncurried_config = t.uncurried_config;
+    customInfix = t.customInfix;
+  }
+
+let init =
+  {customLayout = 0; uncurried_config = Res_uncurried.init; customInfix = []}
+
+let nextCustomLayout t = {t with customLayout = t.customLayout + 1}
+
+let shouldBreakCallback t = t.customLayout > customLayoutThreshold

--- a/res_syntax/src/res_scanner.mli
+++ b/res_syntax/src/res_scanner.mli
@@ -5,6 +5,7 @@ type charEncoding
 type t = {
   filename: string;
   src: string;
+  srcLen: int;
   mutable err:
     startPos:Lexing.position ->
     endPos:Lexing.position ->
@@ -17,6 +18,7 @@ type t = {
   mutable lineOffset: int; (* current line offset *)
   mutable lnum: int; (* current line number *)
   mutable mode: mode list;
+  mutable customInfix: Res_custom_infix.t;
 }
 
 val make : filename:string -> string -> t

--- a/res_syntax/src/res_token.ml
+++ b/res_syntax/src/res_token.ml
@@ -96,6 +96,7 @@ type t =
   | Try
   | DocComment of Location.t * string
   | ModuleComment of Location.t * string
+  | CustomInfix of string
 
 let precedence = function
   | HashEqual | ColonEqual -> 1
@@ -104,7 +105,7 @@ let precedence = function
   | Equal | EqualEqual | EqualEqualEqual | LessThan | GreaterThan | BangEqual
   | BangEqualEqual | LessEqual | GreaterEqual | BarGreater ->
     4
-  | Plus | PlusDot | Minus | MinusDot | PlusPlus -> 5
+  | Plus | PlusDot | Minus | MinusDot | PlusPlus | CustomInfix _ -> 5
   | Asterisk | AsteriskDot | Forwardslash | ForwardslashDot -> 6
   | Exponentiation -> 7
   | MinusGreater -> 8
@@ -207,6 +208,7 @@ let toString = function
   | Try -> "try"
   | DocComment (_loc, s) -> "DocComment " ^ s
   | ModuleComment (_loc, s) -> "ModuleComment " ^ s
+  | CustomInfix s -> s
 
 let keywordTable = function
   | "and" -> And

--- a/res_syntax/tests/printer/expr/expected/infix.res.txt
+++ b/res_syntax/tests/printer/expr/expected/infix.res.txt
@@ -1,0 +1,7 @@
+let plus = (x, y) => x + y
+let minus = (x, y) => x - y
+
+@@infix(("😀", "plus"))
+@@infix(("💩💩", "minus"))
+
+let q = 3 😀 4 💩💩 5

--- a/res_syntax/tests/printer/expr/infix.res
+++ b/res_syntax/tests/printer/expr/infix.res
@@ -1,0 +1,7 @@
+let plus = (x, y) => x + y
+let minus = (x, y) => x - y
+
+@@infix(("😀", "plus"))
+@@infix(("💩💩", "minus"))
+
+let q = 3 😀 4 💩💩 5


### PR DESCRIPTION
Add local support for custom infix operators.

Properties:
- Per-file, not dependent on project settings.
- Opt-in by the user, not mandated (by e.g. a library).
- No semantic change, just local view of the same ast.
- Supports hover, and jump to definition. Or just scan the file visually to find the definition of symbols (no search codebase for e.g. "!" defined in some far away file)
- No effect on parsing and printing performance on normal use.

Example:
```res
let plus = (x, y) => x + y
let minus = (x, y) => x - y

@@infix(("😀", "plus"))
@@infix(("💩💩", "minus"))

let q = 3 😀 4 💩💩 5
```

The scope of `@@infix` is from where it appears until the end of the module (or file if at toplevel).
There's currently no restriction on what can be used as a symbol: any string including keywords. Restrictions can be placed later on, but the core mechanism is well defined regardless (just as with a macro mechanism).