### PR TITLE
Add support for `|>` in uncurried mode by desugaring it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ These are only breaking changes for unformatted code.
 - Treat uncurried application of primitives like curried application, which produces better output https://github.com/rescript-lang/rescript-compiler/pull/5851
 - New internal representation for uncurried functions using built-in type `function$<fun_type, arity>` this avoids having to declare all the possible arities ahead of time https://github.com/rescript-lang/rescript-compiler/pull/5870
 - PPX V3: allow uncurried `make` function and treat it like a curried one https://github.com/rescript-lang/rescript-compiler/pull/6081
+- Add support for `|>` in uncurried mode by desugaring it https://github.com/rescript-lang/rescript-compiler/pull/6083
 
 # 10.1.4
 

--- a/res_syntax/tests/printer/expr/Uncurried.res
+++ b/res_syntax/tests/printer/expr/Uncurried.res
@@ -1,0 +1,7 @@
+@@uncurried
+
+let add3 = (x,y,z) => x+y+z
+
+let triangle = 3 |> add3(1,2) |> add3(4,5)
+
+let () = 3 |> ignore

--- a/res_syntax/tests/printer/expr/expected/Uncurried.res.txt
+++ b/res_syntax/tests/printer/expr/expected/Uncurried.res.txt
@@ -1,0 +1,7 @@
+@@uncurried
+
+let add3 = (x, y, z) => x + y + z
+
+let triangle = add3(4, 5, add3(1, 2, 3))
+
+let () = ignore(3)


### PR DESCRIPTION
Desugar the semantics of `|>` in uncurried mode so existing curried code still compiles. But the code will stop using `|>` after formatting.

For example: `3 |> add3(1,2)` would not compile when `add3` has 3 arguments. But after desugaring, the third argument is added.