### PR TITLE
Make subtyping in uncurried mode work past type definitions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,9 @@ subset of the arguments, and return a curried type with the remaining ones https
 - Support optional named arguments without a final unit in uncurried functions https://github.com/rescript-lang/rescript-compiler/pull/5907
 - Add support for uncurried mode: a mode where everything is considered uncurried, whether with or without the `.`. This can be turned on with `@@uncurried` locally in a file. For project-level configuration in `bsconfig.json`, there's a boolean config `"uncurried"`, which propagates to dependencies, to turn on uncurried mode.
 Since there's no syntax for partial application in this new mode, introduce `@res.partial foo(x)` to express partial application. This is temporary and will later have some surface syntax.
+Make uncurried functions a subtype of curried functions, and allow application for uncurried functions.
 Use best effort to determine the config when formatting a file.
-https://github.com/rescript-lang/rescript-compiler/pull/5968 https://github.com/rescript-lang/rescript-compiler/pull/6080
+https://github.com/rescript-lang/rescript-compiler/pull/5968 https://github.com/rescript-lang/rescript-compiler/pull/6080 https://github.com/rescript-lang/rescript-compiler/pull/6086
 
 #### :boom: Breaking Change
 

--- a/jscomp/ml/ctype.ml
+++ b/jscomp/ml/ctype.ml
@@ -2341,9 +2341,6 @@ let rec unify (env:Env.t ref) t1 t2 =
         with Cannot_expand ->
           unify2 env t1 t2
         end
-    | (Tconstr (Pident {name="function$"}, [tFun; _], _), Tarrow _) when !Config.uncurried = Uncurried ->
-        (* subtype: an uncurried function is cast to a curried one *)
-        unify2 env tFun t2
     | _ ->
         unify2 env t1 t2
     end;
@@ -2399,6 +2396,9 @@ and unify3 env t1 t1' t2 t2' =
       link_type t2' t1;
   | (Tfield _, Tfield _) -> (* special case for GADTs *)
       unify_fields env t1' t2'
+  | (Tconstr (Pident {name="function$"}, [tFun; _], _), Tarrow _) when !Config.uncurried = Uncurried ->
+      (* subtype: an uncurried function is cast to a curried one *)
+      unify2 env tFun t2
   | _ ->
     begin match !umode with
     | Expression ->

--- a/jscomp/test/UncurriedAlways.js
+++ b/jscomp/test/UncurriedAlways.js
@@ -43,6 +43,10 @@ function bar3(__x) {
   return foo3(__x, 3, 4);
 }
 
+function q(param) {
+  return null;
+}
+
 exports.foo = foo;
 exports.z = z;
 exports.bar = bar;
@@ -54,4 +58,5 @@ exports.foo2 = foo2;
 exports.bar2 = bar2;
 exports.foo3 = foo3;
 exports.bar3 = bar3;
+exports.q = q;
 /*  Not a pure module */

--- a/jscomp/test/UncurriedAlways.res
+++ b/jscomp/test/UncurriedAlways.res
@@ -14,12 +14,15 @@ let a = 3->foo(. 4)
 
 Js.log(a) // Test automatic uncurried application
 
-let _ = Js.Array2.map([1], (. x) => x+1)
+let _ = Js.Array2.map([1], (. x) => x + 1)
 
 let ptl = @res.partial foo(10) // force partial application
 
-let foo2 = (x,y) => x+y
+let foo2 = (x, y) => x + y
 let bar2: _ => _ = foo2(_, 3)
 
-let foo3 = (x,y,z) => x+y+z
-let bar3 : _ => _ = foo3(_, 3, 4)
+let foo3 = (x, y, z) => x + y + z
+let bar3: _ => _ = foo3(_, 3, 4)
+
+type cmp = Jsx.component<int>
+let q: cmp = _ => Jsx.null // Check that subtyping works past type definitions


### PR DESCRIPTION
Subtyping from uncurried to curried functions was not working when the expected curried function was under a type definition. This would give type errors on components that take a component type as prop.