### PR TITLE
Improve code generated for template literals.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ These are only breaking changes for unformatted code.
 - PPX V3: allow uncurried `make` function and treat it like a curried one https://github.com/rescript-lang/rescript-compiler/pull/6081
 - Add support for `|>` in uncurried mode by desugaring it https://github.com/rescript-lang/rescript-compiler/pull/6083
 - Change the compilation of pattern matching for variants so it does not depends on variats being integers https://github.com/rescript-lang/rescript-compiler/pull/6085
+- Improve code generated for string templates https://github.com/rescript-lang/rescript-compiler/pull/6090
 
 # 10.1.4
 

--- a/jscomp/core/js_exp_make.ml
+++ b/jscomp/core/js_exp_make.ml
@@ -515,6 +515,8 @@ let rec string_append ?comment (e : t) (el : t) : t =
     { e with expression_desc = Str { txt = a ^ b; delim } }
   in
   match (e.expression_desc, el.expression_desc) with
+  | Str { txt = ""}, _ -> el
+  | _, Str { txt = ""} -> e
   | ( Str { txt = a; delim },
       String_append ({ expression_desc = Str { txt = b; delim = delim_ } }, c) )
     when delim = delim_ ->

--- a/jscomp/test/caml_format_test.js
+++ b/jscomp/test/caml_format_test.js
@@ -88,7 +88,7 @@ function from_of_string(xs) {
                     var b = param[1];
                     var a = param[0];
                     return [
-                            "of_string " + String(i) + "",
+                            "of_string " + String(i),
                             (function (param) {
                                 return {
                                         TAG: /* Eq */0,
@@ -156,7 +156,7 @@ var suites = Pervasives.$at(from_of_string(of_string), Pervasives.$at({
                         var b = param[1];
                         var a = param[0];
                         return [
-                                "infinity_of_string " + String(i) + "",
+                                "infinity_of_string " + String(i),
                                 (function (param) {
                                     return {
                                             TAG: /* Eq */0,
@@ -194,7 +194,7 @@ var suites = Pervasives.$at(from_of_string(of_string), Pervasives.$at({
                             var b = param[1];
                             var a = param[0];
                             return [
-                                    "normal_float_of_string " + String(i) + "",
+                                    "normal_float_of_string " + String(i),
                                     (function (param) {
                                         return {
                                                 TAG: /* Eq */0,
@@ -427,7 +427,7 @@ Mt.from_pair_suites("Caml_format_test", Pervasives.$at(suites, Pervasives.$at($$
                         var f = param[1];
                         var fmt = param[0];
                         return [
-                                "loat_format " + String(i) + "",
+                                "loat_format " + String(i),
                                 (function (param) {
                                     return {
                                             TAG: /* Eq */0,

--- a/jscomp/test/ext_filename_test.js
+++ b/jscomp/test/ext_filename_test.js
@@ -181,7 +181,7 @@ function find_root_filename(_cwd, filename) {
       _cwd = cwd$p;
       continue ;
     }
-    var s = "" + filename + " not found from " + cwd;
+    var s = filename + " not found from " + cwd;
     throw {
           RE_EXN_ID: "Failure",
           _1: s,

--- a/jscomp/test/int64_mul_div_test.js
+++ b/jscomp/test/int64_mul_div_test.js
@@ -310,7 +310,7 @@ function from_pairs(prefix, pairs) {
                     var a = param[1];
                     var result = param[0];
                     return [
-                            "" + prefix + "_" + i,
+                            prefix + "_" + i,
                             (function (param) {
                                 return commutative_mul(result, a, b);
                               })

--- a/jscomp/test/mario_game.js
+++ b/jscomp/test/mario_game.js
@@ -3331,7 +3331,7 @@ function load(param) {
   if (el !== null) {
     canvas = el;
   } else {
-    console.log("cant find canvas " + canvas_id + "");
+    console.log("cant find canvas " + canvas_id);
     throw {
           RE_EXN_ID: "Failure",
           _1: "fail",

--- a/jscomp/test/template.js
+++ b/jscomp/test/template.js
@@ -4,7 +4,7 @@
 var bla2 = "";
 
 function concat(param) {
-  return "\n    display:\r flex;\n   " + bla2 + "";
+  return "\n    display:\r flex;\n   " + bla2;
 }
 
 exports.bla2 = bla2;

--- a/lib/es6/arg.js
+++ b/lib/es6/arg.js
@@ -120,7 +120,7 @@ function add_help(speclist) {
 }
 
 function usage_b(buf, speclist, errmsg) {
-  $$Buffer.add_string(buf, "" + errmsg + "\n");
+  $$Buffer.add_string(buf, errmsg + "\n");
   List.iter((function (param) {
           var doc = param[2];
           if (doc.length === 0) {
@@ -132,7 +132,7 @@ function usage_b(buf, speclist, errmsg) {
             return $$Buffer.add_string(buf, "  " + key + " " + doc + "\n");
           }
           var sym = make_symlist("{", "|", "}", spec._0);
-          return $$Buffer.add_string(buf, "  " + key + " " + sym + "" + doc + "\n");
+          return $$Buffer.add_string(buf, "  " + key + " " + sym + doc + "\n");
         }), add_help(speclist));
 }
 
@@ -202,17 +202,17 @@ function parse_and_expand_argv_dynamic_aux(allow_expand, current, argv, speclist
             case "-help" :
                 break;
             default:
-              $$Buffer.add_string(b, "" + progname + ": unknown option '" + s + "'.\n");
+              $$Buffer.add_string(b, progname + ": unknown option '" + s + "'.\n");
           }
           break;
       case /* Wrong */1 :
-          $$Buffer.add_string(b, "" + progname + ": wrong argument '" + error._1 + "'; option '" + error._0 + "' expects " + error._2 + ".\n");
+          $$Buffer.add_string(b, progname + ": wrong argument '" + error._1 + "'; option '" + error._0 + "' expects " + error._2 + ".\n");
           break;
       case /* Missing */2 :
-          $$Buffer.add_string(b, "" + progname + ": option '" + error._0 + "' needs an argument.\n");
+          $$Buffer.add_string(b, progname + ": option '" + error._0 + "' needs an argument.\n");
           break;
       case /* Message */3 :
-          $$Buffer.add_string(b, "" + progname + ": " + error._0 + ".\n");
+          $$Buffer.add_string(b, progname + ": " + error._0 + ".\n");
           break;
       
     }

--- a/lib/js/arg.js
+++ b/lib/js/arg.js
@@ -120,7 +120,7 @@ function add_help(speclist) {
 }
 
 function usage_b(buf, speclist, errmsg) {
-  $$Buffer.add_string(buf, "" + errmsg + "\n");
+  $$Buffer.add_string(buf, errmsg + "\n");
   List.iter((function (param) {
           var doc = param[2];
           if (doc.length === 0) {
@@ -132,7 +132,7 @@ function usage_b(buf, speclist, errmsg) {
             return $$Buffer.add_string(buf, "  " + key + " " + doc + "\n");
           }
           var sym = make_symlist("{", "|", "}", spec._0);
-          return $$Buffer.add_string(buf, "  " + key + " " + sym + "" + doc + "\n");
+          return $$Buffer.add_string(buf, "  " + key + " " + sym + doc + "\n");
         }), add_help(speclist));
 }
 
@@ -202,17 +202,17 @@ function parse_and_expand_argv_dynamic_aux(allow_expand, current, argv, speclist
             case "-help" :
                 break;
             default:
-              $$Buffer.add_string(b, "" + progname + ": unknown option '" + s + "'.\n");
+              $$Buffer.add_string(b, progname + ": unknown option '" + s + "'.\n");
           }
           break;
       case /* Wrong */1 :
-          $$Buffer.add_string(b, "" + progname + ": wrong argument '" + error._1 + "'; option '" + error._0 + "' expects " + error._2 + ".\n");
+          $$Buffer.add_string(b, progname + ": wrong argument '" + error._1 + "'; option '" + error._0 + "' expects " + error._2 + ".\n");
           break;
       case /* Missing */2 :
-          $$Buffer.add_string(b, "" + progname + ": option '" + error._0 + "' needs an argument.\n");
+          $$Buffer.add_string(b, progname + ": option '" + error._0 + "' needs an argument.\n");
           break;
       case /* Message */3 :
-          $$Buffer.add_string(b, "" + progname + ": " + error._0 + ".\n");
+          $$Buffer.add_string(b, progname + ": " + error._0 + ".\n");
           break;
       
     }


### PR DESCRIPTION
Now that `j` interpolation is gone, string append can be optimized in the back-end.

Fixes https://github.com/rescript-lang/rescript-compiler/issues/5521