### PR TITLE
CI: build statically linked Linux arm64 binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: "Build compiler"
         if: runner.os != 'Linux'
-        run: opam exec -- dune build --profile release
+        run: opam exec -- dune build --display quiet --profile release
 
       - name: Use Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,17 +21,27 @@ jobs:
   # The container already comes with all required tools pre-installed
   # (see https://github.com/rescript-lang/docker-rescript-ci-build/blob/main/Dockerfile).
   static-binaries-linux:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, buildjet-2vcpu-ubuntu-2204-arm]
+
+    runs-on: ${{matrix.os}}
 
     container:
-      image: ghcr.io/rescript-lang/rescript-ci-build:v1.0.0
+      image: ghcr.io/rescript-lang/rescript-ci-build:v1.1.0
 
     steps:
+      # See https://github.com/actions/runner/issues/801#issuecomment-1374967227.
+      - name: Workaround for Github actions runner on Alpine arm64
+        if: runner.arch	== 'ARM64'
+        run: sed -i "s:ID=alpine:ID=NotpineForGHA:" /etc/os-release
+
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Build compiler binaries
-        run: opam exec -- dune build --profile static
+        run: opam exec -- dune build --display quiet --profile static
 
       - name: Build ninja binary
         working-directory: ninja
@@ -42,10 +52,51 @@ jobs:
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v3
         with:
-          name: static-binaries-linux
+          name: static-binaries-linux-${{runner.arch}}
           path: |
             _build/install/default/bin
             ninja/ninja
+
+  # The full build including tests does not work on Linux ARM because setup-ocaml fails.
+  # Therefore, only upload the binaries from the static build
+  upload-linux-arm64-binaries:
+    needs:
+      - static-binaries-linux
+
+    runs-on: buildjet-2vcpu-ubuntu-2204-arm
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Download static linux binaries
+        if: runner.os == 'Linux'
+        uses: actions/download-artifact@v3
+        with:
+          name: static-binaries-linux-${{ runner.arch }}
+
+      - name: Make static linux binaries executable
+        if: runner.os == 'Linux'
+        run: |
+          chmod +x ninja/ninja
+          chmod +x _build/install/default/bin/*
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Copy exes to platform bin dirs
+        run: node ./scripts/copyExes.js
+
+      - name: Prepare artifact upload
+        run: node .github/workflows/get_artifact_info.js
+
+      - name: "Upload artifacts: binaries"
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.artifact_name }}
+          path: ${{ env.artifact_path }}
 
   build:
     needs: static-binaries-linux
@@ -77,7 +128,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: actions/download-artifact@v3
         with:
-          name: static-binaries-linux
+          name: static-binaries-linux-${{ runner.arch }}
 
       - name: Make static linux binaries executable
         if: runner.os == 'Linux'
@@ -236,7 +287,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest, macos-arm]
+        os:
+          [
+            macos-latest,
+            macos-arm,
+            ubuntu-latest,
+            buildjet-2vcpu-ubuntu-2204-arm,
+            windows-latest,
+          ]
 
     runs-on: ${{matrix.os}}
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "darwin",
     "darwinarm64",
     "linux",
+    "linuxarm64",
     "win32",
     "docs/docson/build-schema.json",
     "lib",

--- a/packages/artifacts.txt
+++ b/packages/artifacts.txt
@@ -965,6 +965,10 @@ linux/bsb_helper.exe
 linux/bsc.exe
 linux/ninja.exe
 linux/rescript.exe
+linuxarm64/bsb_helper.exe
+linuxarm64/bsc.exe
+linuxarm64/ninja.exe
+linuxarm64/rescript.exe
 ninja.COPYING
 package.json
 rescript

--- a/scripts/moveArtifacts.sh
+++ b/scripts/moveArtifacts.sh
@@ -6,6 +6,7 @@ chmod +x binaries-*/*.exe
 mv binaries-darwin darwin
 mv binaries-darwinarm64 darwinarm64
 mv binaries-linux linux
+mv binaries-linuxarm64 linuxarm64
 mv binaries-win32 win32
 
 mv cmij-cache/*.bin lib


### PR DESCRIPTION
This PR adds building Linux arm64 binaries to the CI process. Like the Linux x64 binaries, these are statically linked and therefore need to be built in an Alpine-based Docker container. For this, I extended the Docker image used for CI (https://github.com/rescript-lang/docker-rescript-ci-build) to be multi-platform (x64 + arm64).

As GitHub Actions currently does not provide an ARM-based Linux runner and running in QEMU is too slow, the Linux arm64 builds are performed on a [BuildJet](https://buildjet.com/for-github-actions) ARM 2 vCPU runner. The costs for that runner are covered  by the ReScript Association as set up by @ryyppy.

This extends the list of supported platforms for which pre-built binaries are included in the `rescript` npm package to

* macOS x64
* macOS arm64
* Linux x64 (statically linked)
* Linux arm64 (statically linked)
* Windows x64

For the moment, only the final "installation tests" with the finished npm package are run for Linux arm64. To get the other tests to run, too, further refactoring of the build process will be needed because following the same process as for the other platforms currently fails due to an error in `setup-ocaml`.

I think this is good enough for now though. I am still planning further refactoring of the build process, but I would like to wait with that until the runtime and test sources are fully converted to .res syntax as that should simplify a lot of things.