### PR TITLE
CI: reactivate macos-arm builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: [macos-latest, ubuntu-latest, windows-latest, macos-arm]
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest, macos-arm]
         ocaml_compiler: [4.14.0]
 
     runs-on: ${{matrix.os}}
@@ -288,9 +287,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [
+        os:
+          [
             macos-latest,
-            # macos-arm,
+            macos-arm,
             ubuntu-latest,
             buildjet-2vcpu-ubuntu-2204-arm,
             windows-latest,

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "bsc",
     "rescript",
     "darwin",
+    "darwinarm64",
     "linux",
     "linuxarm64",
     "win32",

--- a/packages/artifacts.txt
+++ b/packages/artifacts.txt
@@ -9,6 +9,10 @@ darwin/bsb_helper.exe
 darwin/bsc.exe
 darwin/ninja.exe
 darwin/rescript.exe
+darwinarm64/bsb_helper.exe
+darwinarm64/bsc.exe
+darwinarm64/ninja.exe
+darwinarm64/rescript.exe
 docs/docson/build-schema.json
 lib/bstracing
 lib/cmi_cache.bin

--- a/scripts/bin_path.js
+++ b/scripts/bin_path.js
@@ -12,11 +12,6 @@ var path = require("path");
 var binDirName =
   process.arch === "x64" ? process.platform : process.platform + process.arch;
 
-// Deactivate support for macos-arm for now
-if (binDirName === "darwinarm64") {
-  binDirName = "darwin";
-}
-
 /**
  *
  * @type{string}

--- a/scripts/makeArtifactList.js
+++ b/scripts/makeArtifactList.js
@@ -46,8 +46,7 @@ if (isCheckMode) {
 }
 
 function getFilesAddedByCI() {
-  // const platforms = ["darwin", "darwinarm64", "linux", "win32"];
-  const platforms = ["darwin", "linux", "win32"];
+  const platforms = ["darwin", "darwinarm64", "linux", "win32"];
   const exes = ["bsb_helper.exe", "bsc.exe", "ninja.exe", "rescript.exe"];
 
   const files = ["ninja.COPYING"];

--- a/scripts/moveArtifacts.sh
+++ b/scripts/moveArtifacts.sh
@@ -4,7 +4,7 @@ set -e
 chmod +x binaries-*/*.exe
 
 mv binaries-darwin darwin
-# mv binaries-darwinarm64 darwinarm64
+mv binaries-darwinarm64 darwinarm64
 mv binaries-linux linux
 mv binaries-linuxarm64 linuxarm64
 mv binaries-win32 win32


### PR DESCRIPTION
macos-arm build were deactivated temporarily because our self-hosted Github actions runner was out of order.

We now have a new one, so we can reenable macos-arm builds.