### PR TITLE
Untagged variants: fix pm with overlap.

### DIFF
--- a/jscomp/core/js_exp_make.ml
+++ b/jscomp/core/js_exp_make.ml
@@ -780,15 +780,25 @@ let rec is_a_literal_case ~(literal_cases : Lambda.literal list) ~block_cases (e
     Ext_list.exists literal_cases (function
       | String _ -> true
       | l -> false ) in
+  let literals_overlaps_with_number () = 
+    Ext_list.exists literal_cases (function
+      | Int _ | Float _ -> true
+      | l -> false ) in
   let is_literal_case (l:Lambda.literal) : t = bin EqEqEq e (literal l) in
   let is_block_case (c:Lambda.block_type) : t = match c with
   | StringType when literals_overlaps_with_string () = false  (* No overlap *) -> 
     bin NotEqEq (typeof e) (str "string")
-  | IntType -> bin NotEqEq (typeof e) (str "number")
-  | FloatType -> bin NotEqEq (typeof e) (str "number")
-  | Array ->  not (bin InstanceOf e (str "Array" ~delim:DNoQuotes))
-  | Object ->  { expression_desc = Bin (NotEqEq, typeof e, str "object"); comment=None }
-  | StringType
+  | IntType when literals_overlaps_with_number () = false ->
+    bin NotEqEq (typeof e) (str "number")
+  | FloatType when literals_overlaps_with_number () = false ->
+    bin NotEqEq (typeof e) (str "number")
+  | Array -> 
+    not (bin InstanceOf e (str "Array" ~delim:DNoQuotes))
+  | Object ->
+    { expression_desc = Bin (NotEqEq, typeof e, str "object"); comment=None }
+  | StringType (* overlap *)
+  | IntType (* overlap *)
+  | FloatType (* overlap*)
   | Unknown ->
     (* We don't know the type of unknown, so we need to express:
        this is not one of the literals *)

--- a/jscomp/core/js_exp_make.ml
+++ b/jscomp/core/js_exp_make.ml
@@ -784,6 +784,10 @@ let rec is_a_literal_case ~(literal_cases : Lambda.literal list) ~block_cases (e
     Ext_list.exists literal_cases (function
       | Int _ | Float _ -> true
       | l -> false ) in
+  let literals_overlaps_with_object () = 
+    Ext_list.exists literal_cases (function
+      | Null -> true
+      | l -> false ) in
   let is_literal_case (l:Lambda.literal) : t = bin EqEqEq e (literal l) in
   let is_block_case (c:Lambda.block_type) : t = match c with
   | StringType when literals_overlaps_with_string () = false  (* No overlap *) -> 
@@ -794,11 +798,12 @@ let rec is_a_literal_case ~(literal_cases : Lambda.literal list) ~block_cases (e
     bin NotEqEq (typeof e) (str "number")
   | Array -> 
     not (bin InstanceOf e (str "Array" ~delim:DNoQuotes))
-  | Object ->
+  | Object when literals_overlaps_with_object () = false ->
     { expression_desc = Bin (NotEqEq, typeof e, str "object"); comment=None }
   | StringType (* overlap *)
   | IntType (* overlap *)
-  | FloatType (* overlap*)
+  | FloatType (* overlap *)
+  | Object (* overlap *)
   | Unknown ->
     (* We don't know the type of unknown, so we need to express:
        this is not one of the literals *)

--- a/jscomp/core/js_exp_make.ml
+++ b/jscomp/core/js_exp_make.ml
@@ -797,7 +797,7 @@ let rec is_a_literal_case ~(literal_cases : Lambda.literal list) ~block_cases (e
   | FloatType when literals_overlaps_with_number () = false ->
     bin NotEqEq (typeof e) (str "number")
   | Array -> 
-    not (bin InstanceOf e (str "Array" ~delim:DNoQuotes))
+    not (is_array e)
   | Object when literals_overlaps_with_object () = false ->
     { expression_desc = Bin (NotEqEq, typeof e, str "object"); comment=None }
   | StringType (* overlap *)

--- a/jscomp/core/js_exp_make.ml
+++ b/jscomp/core/js_exp_make.ml
@@ -804,10 +804,11 @@ let rec is_a_literal_case ~(literal_cases : Lambda.literal list) ~block_cases (e
     not (is_array e)
   | Object when literals_overlaps_with_object () = false ->
     (typeof e) != (str "object")
+  | Object (* overlap *) ->
+    e == nil || (typeof e) != (str "object")
   | StringType (* overlap *)
   | IntType (* overlap *)
   | FloatType (* overlap *)
-  | Object (* overlap *)
   | Unknown ->
     (* We don't know the type of unknown, so we need to express:
        this is not one of the literals *)

--- a/jscomp/core/js_exp_make.ml
+++ b/jscomp/core/js_exp_make.ml
@@ -793,7 +793,7 @@ let rec is_a_literal_case ~(literal_cases : Lambda.literal list) ~block_cases (e
   let (||) x y = bin Or x y in
   let (&&) x y = bin And x y in
   let is_literal_case (l:Lambda.literal) : t =  e == (literal l) in
-  let is_block_case (c:Lambda.block_type) : t = match c with
+  let is_not_block_case (c:Lambda.block_type) : t = match c with
   | StringType when literals_overlaps_with_string () = false  (* No overlap *) -> 
     (typeof e) != (str "string")
   | IntType when literals_overlaps_with_number () = false ->
@@ -824,9 +824,9 @@ let rec is_a_literal_case ~(literal_cases : Lambda.literal list) ~block_cases (e
     )
   in
   match block_cases with
-  | [c] -> is_block_case c
+  | [c] -> is_not_block_case c
   | c1 :: (_::_ as rest) ->
-    (is_block_case c1) && (is_a_literal_case ~literal_cases ~block_cases:rest e)
+    (is_not_block_case c1) && (is_a_literal_case ~literal_cases ~block_cases:rest e)
   | [] -> assert false
 
 let is_int_tag ?(has_null_undefined_other=(false, false, false)) (e : t) : t =

--- a/jscomp/test/UntaggedVariants.js
+++ b/jscomp/test/UntaggedVariants.js
@@ -76,7 +76,7 @@ var Truthy = {
 };
 
 function classify$1(x) {
-  if (typeof x !== "object") {
+  if (x === null || x === undefined) {
     if (x === null) {
       return "null";
     } else {
@@ -173,7 +173,7 @@ var WithArray = {
 };
 
 function classify$6(x) {
-  if (!(x instanceof Array) && typeof x !== "object" && typeof x !== "number" && typeof x !== "string") {
+  if (!(x instanceof Array) && (x === true || x === false || x === null) && typeof x !== "number" && typeof x !== "string") {
     switch (x) {
       case false :
           return "JSONFalse";
@@ -274,7 +274,7 @@ var OverlapNumber = {
 };
 
 function checkEnum$2(e) {
-  if (typeof e === "object") {
+  if (!(e === "Two" || e === null || e === "Three")) {
     return "Object...";
   }
   switch (e) {

--- a/jscomp/test/UntaggedVariants.js
+++ b/jscomp/test/UntaggedVariants.js
@@ -250,8 +250,27 @@ function checkEnum(e) {
   }
 }
 
-var Overlap = {
+var OverlapString = {
   checkEnum: checkEnum
+};
+
+function checkEnum$1(e) {
+  if (!(e === "Two" || e === 1.0 || e === "Three")) {
+    return "Something else...";
+  }
+  switch (e) {
+    case 1.0 :
+        return "One!";
+    case "Two" :
+        return "Two";
+    case "Three" :
+        return "Threeeee";
+    
+  }
+}
+
+var OverlapNumber = {
+  checkEnum: checkEnum$1
 };
 
 var i = 42;
@@ -288,5 +307,6 @@ exports.OnlyBlocks = OnlyBlocks;
 exports.WithArray = WithArray;
 exports.Json = Json;
 exports.TrickyNested = TrickyNested;
-exports.Overlap = Overlap;
+exports.OverlapString = OverlapString;
+exports.OverlapNumber = OverlapNumber;
 /* l2 Not a pure module */

--- a/jscomp/test/UntaggedVariants.js
+++ b/jscomp/test/UntaggedVariants.js
@@ -173,7 +173,7 @@ var WithArray = {
 };
 
 function classify$6(x) {
-  if (!(x instanceof Array) && (x === true || x === false || x === null) && typeof x !== "number" && typeof x !== "string") {
+  if (!Array.isArray(x) && (x === true || x === false || x === null) && typeof x !== "number" && typeof x !== "string") {
     switch (x) {
       case false :
           return "JSONFalse";

--- a/jscomp/test/UntaggedVariants.js
+++ b/jscomp/test/UntaggedVariants.js
@@ -76,7 +76,7 @@ var Truthy = {
 };
 
 function classify$1(x) {
-  if (x === null || x === undefined) {
+  if (x === null || typeof x !== "object") {
     if (x === null) {
       return "null";
     } else {
@@ -173,7 +173,7 @@ var WithArray = {
 };
 
 function classify$6(x) {
-  if (!Array.isArray(x) && (x === true || x === false || x === null) && typeof x !== "number" && typeof x !== "string") {
+  if (!Array.isArray(x) && (x === null || typeof x !== "object") && typeof x !== "number" && typeof x !== "string") {
     switch (x) {
       case false :
           return "JSONFalse";
@@ -274,7 +274,7 @@ var OverlapNumber = {
 };
 
 function checkEnum$2(e) {
-  if (!(e === "Two" || e === null || e === "Three")) {
+  if (!(e === null || typeof e !== "object")) {
     return "Object...";
   }
   switch (e) {

--- a/jscomp/test/UntaggedVariants.js
+++ b/jscomp/test/UntaggedVariants.js
@@ -273,6 +273,25 @@ var OverlapNumber = {
   checkEnum: checkEnum$1
 };
 
+function checkEnum$2(e) {
+  if (typeof e === "object") {
+    return "Object...";
+  }
+  switch (e) {
+    case null :
+        return "One!";
+    case "Two" :
+        return "Two";
+    case "Three" :
+        return "Threeeee";
+    
+  }
+}
+
+var OverlapObject = {
+  checkEnum: checkEnum$2
+};
+
 var i = 42;
 
 var i2 = 42.5;
@@ -309,4 +328,5 @@ exports.Json = Json;
 exports.TrickyNested = TrickyNested;
 exports.OverlapString = OverlapString;
 exports.OverlapNumber = OverlapNumber;
+exports.OverlapObject = OverlapObject;
 /* l2 Not a pure module */

--- a/jscomp/test/UntaggedVariants.js
+++ b/jscomp/test/UntaggedVariants.js
@@ -2,7 +2,7 @@
 
 
 function classify(x) {
-  if (typeof x !== "string" && typeof x !== "number") {
+  if (x === "A" && typeof x !== "number") {
     return "A";
   } else if (typeof x === "number") {
     return "An integer";
@@ -108,7 +108,7 @@ var Unknown = {
 };
 
 function classify$3(x) {
-  if (typeof x !== "object" && typeof x !== "number" && typeof x !== "string") {
+  if (typeof x !== "object" && typeof x !== "number" && (x === "C" || x === "B" || x === "A" || x === "D")) {
     switch (x) {
       case "A" :
           return "a";
@@ -235,6 +235,25 @@ var TrickyNested = {
   check: check
 };
 
+function checkEnum(e) {
+  if (!(e === "Two" || e === "One" || e === "Three")) {
+    return "Something else..." + e;
+  }
+  switch (e) {
+    case "One" :
+        return "One!";
+    case "Two" :
+        return "Two";
+    case "Three" :
+        return "Threeeee";
+    
+  }
+}
+
+var Overlap = {
+  checkEnum: checkEnum
+};
+
 var i = 42;
 
 var i2 = 42.5;
@@ -269,4 +288,5 @@ exports.OnlyBlocks = OnlyBlocks;
 exports.WithArray = WithArray;
 exports.Json = Json;
 exports.TrickyNested = TrickyNested;
+exports.Overlap = Overlap;
 /* l2 Not a pure module */

--- a/jscomp/test/UntaggedVariants.res
+++ b/jscomp/test/UntaggedVariants.res
@@ -222,3 +222,16 @@ module OverlapNumber = {
     | FutureAddedValue(_) => "Something else..."
     }
 }
+
+module OverlapObject = {
+  @unboxed
+  type enum = | @as(null) One | Two | Three | Object({x: int})
+
+  let checkEnum = e =>
+    switch e {
+    | One => "One!"
+    | Two => "Two"
+    | Three => "Threeeee"
+    | Object(_) => "Object..."
+    }
+}

--- a/jscomp/test/UntaggedVariants.res
+++ b/jscomp/test/UntaggedVariants.res
@@ -196,3 +196,16 @@ module TrickyNested = {
     | _ => 42
     }
 }
+
+module Overlap = {
+  @unboxed
+  type enum = One | Two | Three | FutureAddedValue(string)
+
+  let checkEnum = e =>
+    switch e {
+    | One => "One!"
+    | Two => "Two"
+    | Three => "Threeeee"
+    | FutureAddedValue(s) => "Something else..." ++ s
+    }
+}

--- a/jscomp/test/UntaggedVariants.res
+++ b/jscomp/test/UntaggedVariants.res
@@ -197,7 +197,7 @@ module TrickyNested = {
     }
 }
 
-module Overlap = {
+module OverlapString = {
   @unboxed
   type enum = One | Two | Three | FutureAddedValue(string)
 
@@ -207,5 +207,18 @@ module Overlap = {
     | Two => "Two"
     | Three => "Threeeee"
     | FutureAddedValue(s) => "Something else..." ++ s
+    }
+}
+
+module OverlapNumber = {
+  @unboxed
+  type enum = | @as(1.0) One | Two | Three | FutureAddedValue(float)
+
+  let checkEnum = e =>
+    switch e {
+    | One => "One!"
+    | Two => "Two"
+    | Three => "Threeeee"
+    | FutureAddedValue(_) => "Something else..."
     }
 }


### PR DESCRIPTION
There are cases where literals can overlap with blocks.
e.g. string literals with type string, or null with type object

Fixes: https://github.com/rescript-lang/rescript-compiler/issues/6123