### PR TITLE
Fix formatting of uncurried function with constraint on return type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 - Add support for extensible records (e.g. `type t = {...t1, x:int, ...t2}`) https://github.com/rescript-lang/rescript-compiler/pull/5715
 
+#### :bug: Bug Fix
+
+- Fix formatting and parentheses placement in uncurried functions with constraints. https://github.com/rescript-lang/rescript-compiler/pull/6143
+
 # 11.0.0-alpha.2
 
 #### :rocket: Main New Feature

--- a/res_syntax/src/res_parens.ml
+++ b/res_syntax/src/res_parens.ml
@@ -132,6 +132,7 @@ let binaryExprOperand ~isLhs expr =
        Pexp_constraint _ | Pexp_fun _ | Pexp_function _ | Pexp_newtype _;
     } ->
       Parenthesized
+    | _ when Ast_uncurried.exprIsUncurriedFun expr -> Parenthesized
     | expr when ParsetreeViewer.isBinaryExpression expr -> Parenthesized
     | expr when ParsetreeViewer.isTernaryExpr expr -> Parenthesized
     | {pexp_desc = Pexp_lazy _ | Pexp_assert _} when isLhs -> Parenthesized

--- a/res_syntax/src/res_parens.ml
+++ b/res_syntax/src/res_parens.ml
@@ -441,6 +441,7 @@ let includeModExpr modExpr =
 let arrowReturnTypExpr typExpr =
   match typExpr.Parsetree.ptyp_desc with
   | Parsetree.Ptyp_arrow _ -> true
+  | _ when Ast_uncurried.typeIsUncurriedFun typExpr -> true
   | _ -> false
 
 let patternRecordRowRhs (pattern : Parsetree.pattern) =

--- a/res_syntax/tests/printer/expr/UncurriedByDefault.res
+++ b/res_syntax/tests/printer/expr/UncurriedByDefault.res
@@ -76,6 +76,9 @@ let fn = (_x): ((. unit) => unit) => foo
 let fooC = () => ()
 let fnC = (_x): ((unit) => unit) => fooC
 
+let a = ((. ()) => "foo")->Ok
+let aC = (() => "foo")->Ok
+
 @@uncurried.swap
 
 let cApp = foo(. 3)

--- a/res_syntax/tests/printer/expr/UncurriedByDefault.res
+++ b/res_syntax/tests/printer/expr/UncurriedByDefault.res
@@ -71,6 +71,11 @@ type callback4 = (. ReactEvent.Mouse.t) => unit as 'callback
 type callback5 = (. ReactEvent.Mouse.t) => (unit as 'u)
 type callback6 = ((. ReactEvent.Mouse.t) => unit) as 'callback
 
+let foo = (. ()) => ()
+let fn = (_x): ((. unit) => unit) => foo
+let fooC = () => ()
+let fnC = (_x): ((unit) => unit) => fooC
+
 @@uncurried.swap
 
 let cApp = foo(. 3)

--- a/res_syntax/tests/printer/expr/UncurriedByDefault.res
+++ b/res_syntax/tests/printer/expr/UncurriedByDefault.res
@@ -151,3 +151,7 @@ type callback3 = ((. ReactEvent.Mouse.t) => unit) as 'callback
 type callback4 = ReactEvent.Mouse.t => unit as 'callback
 type callback5 = ReactEvent.Mouse.t => (unit as 'u)
 type callback6 = (ReactEvent.Mouse.t => unit) as 'callback
+
+let fooU = () => ()
+let fnU = (_x): ((unit) => unit) => fooC
+let aU = (() => "foo")->Ok

--- a/res_syntax/tests/printer/expr/expected/UncurriedByDefault.res.txt
+++ b/res_syntax/tests/printer/expr/expected/UncurriedByDefault.res.txt
@@ -151,3 +151,7 @@ type callback3 = ((. ReactEvent.Mouse.t) => unit) as 'callback
 type callback4 = (ReactEvent.Mouse.t => unit) as 'callback
 type callback5 = ReactEvent.Mouse.t => (unit as 'u)
 type callback6 = (ReactEvent.Mouse.t => unit) as 'callback
+
+let fooU = () => ()
+let fnU = (_x): (unit => unit) => fooC
+let aU = (() => "foo")->Ok

--- a/res_syntax/tests/printer/expr/expected/UncurriedByDefault.res.txt
+++ b/res_syntax/tests/printer/expr/expected/UncurriedByDefault.res.txt
@@ -71,6 +71,11 @@ type callback4 = ((. ReactEvent.Mouse.t) => unit) as 'callback
 type callback5 = (. ReactEvent.Mouse.t) => (unit as 'u)
 type callback6 = ((. ReactEvent.Mouse.t) => unit) as 'callback
 
+let foo = (. ()) => ()
+let fn = (_x): ((. unit) => unit) => foo
+let fooC = () => ()
+let fnC = (_x): (unit => unit) => fooC
+
 @@uncurried.swap
 
 let cApp = foo(. 3)

--- a/res_syntax/tests/printer/expr/expected/UncurriedByDefault.res.txt
+++ b/res_syntax/tests/printer/expr/expected/UncurriedByDefault.res.txt
@@ -76,6 +76,9 @@ let fn = (_x): ((. unit) => unit) => foo
 let fooC = () => ()
 let fnC = (_x): (unit => unit) => fooC
 
+let a = ((. ()) => "foo")->Ok
+let aC = (() => "foo")->Ok
+
 @@uncurried.swap
 
 let cApp = foo(. 3)


### PR DESCRIPTION
See https://github.com/rescript-lang/rescript-compiler/issues/6141