### PR TITLE
Example of broken formatting for foo(a,_) in uncurried mode.

### DIFF
--- a/res_syntax/tests/printer/expr/UncurriedByDefault.res
+++ b/res_syntax/tests/printer/expr/UncurriedByDefault.res
@@ -155,3 +155,5 @@ type callback6 = (ReactEvent.Mouse.t => unit) as 'callback
 let fooU = () => ()
 let fnU = (_x): ((unit) => unit) => fooC
 let aU = (() => "foo")->Ok
+
+let toIgnoredName = concatStrings("abc", _)

--- a/res_syntax/tests/printer/expr/expected/UncurriedByDefault.res.txt
+++ b/res_syntax/tests/printer/expr/expected/UncurriedByDefault.res.txt
@@ -155,3 +155,5 @@ type callback6 = (ReactEvent.Mouse.t => unit) as 'callback
 let fooU = () => ()
 let fnU = (_x): (unit => unit) => fooC
 let aU = (() => "foo")->Ok
+
+let toIgnoredName = () => concatStrings("abc", _)


### PR DESCRIPTION
See https://github.com/rescript-lang/rescript-compiler/issues/6146