### PR TITLE
Record definition spread issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### :bug: Bug Fix
 
 - Fix broken formatting in uncurried mode for functions with _ placeholder args. https://github.com/rescript-lang/rescript-compiler/pull/6148
+- Fix issue where spreading record types with optional labels would not have their labels preserved as optional. https://github.com/rescript-lang/rescript-compiler/pull/6154
 
 # 11.0.0-alpha.3
 

--- a/jscomp/ml/typedecl.ml
+++ b/jscomp/ml/typedecl.ml
@@ -476,9 +476,11 @@ let transl_declaration ~typeRecordAsObject env sdecl id =
               Ext_list.filter_map lbls (fun lbl ->
                   if has_optional lbl.ld_attributes then Some lbl.ld_name.txt else None)
             in
-            Ttype_record lbls, Type_record(lbls', if unbox then Record_unboxed false
-            else if optionalLabels <> [] then Record_optional_labels optionalLabels
-            else Record_regular), sdecl
+            Ttype_record lbls, Type_record(lbls', if unbox then 
+                Record_unboxed false
+              else if optionalLabels <> [] then 
+                Record_optional_labels optionalLabels
+              else Record_regular), sdecl
           | None ->
              (* Could not find record type decl for ...t: assume t is an object type and this is syntax ambiguity *)
              typeRecordAsObject := true;

--- a/jscomp/ml/typedecl.ml
+++ b/jscomp/ml/typedecl.ml
@@ -455,13 +455,7 @@ let transl_declaration ~typeRecordAsObject env sdecl id =
                 | {ld_name = {txt = "..."}; ld_type} :: rest, _ :: rest' ->
                   (match Ctype.extract_concrete_typedecl env (extract ld_type.ctyp_type) with
                     (_p0, _p, {type_kind=Type_record (fields, _repr)}) ->
-                      process_lbls (fst acc @ (fields |> List.map(fun (lbl: Types.label_declaration) ->
-                        let typ = lbl.ld_type in
-                        let typ =
-                          if has_optional lbl.ld_attributes then
-                            (Ctype.newconstr (Path.Pident (Ident.create "option")) [typ])
-                          else typ in
-                        {lbl with ld_type = typ }) |> List.map mkLbl), snd acc @ fields) rest rest'
+                      process_lbls (fst acc @ (fields |> List.map mkLbl), snd acc @ fields) rest rest'
                     | _ -> assert false
                     | exception _ -> None)
                 | lbl::rest, lbl'::rest' -> process_lbls (fst acc @ [lbl], snd acc @ [lbl']) rest rest'

--- a/jscomp/ml/typedecl.ml
+++ b/jscomp/ml/typedecl.ml
@@ -425,20 +425,20 @@ let transl_declaration ~typeRecordAsObject env sdecl id =
         Ast_untagged_variants.check_well_formed ~isUntaggedDef cstrs;
         Ttype_variant tcstrs, Type_variant cstrs, sdecl
       | Ptype_record lbls_ ->
-        let has_optional attrs = Ext_list.exists attrs (fun ({txt },_) -> txt = "res.optional") in
-        let optionalLabels =
-            Ext_list.filter_map lbls_
-            (fun lbl -> if has_optional lbl.pld_attributes then Some lbl.pld_name.txt else None) in
-        let lbls =
-          if optionalLabels = [] then lbls_
-          else Ext_list.map lbls_ (fun lbl ->
-            let typ = lbl.pld_type in
-            let typ =
-              if has_optional lbl.pld_attributes then
-                {typ with ptyp_desc = Ptyp_constr ({txt = Lident "option"; loc=typ.ptyp_loc}, [typ])}
-              else typ in
-            {lbl with  pld_type = typ }) in
-        let lbls, lbls' = transl_labels env true lbls in
+          let has_optional attrs = Ext_list.exists attrs (fun ({txt },_) -> txt = "res.optional") in
+          let optionalLabels =
+              Ext_list.filter_map lbls_
+              (fun lbl -> if has_optional lbl.pld_attributes then Some lbl.pld_name.txt else None) in
+          let lbls =
+            if optionalLabels = [] then lbls_
+            else Ext_list.map lbls_ (fun lbl ->
+              let typ = lbl.pld_type in
+              let typ =
+                if has_optional lbl.pld_attributes then
+                  {typ with ptyp_desc = Ptyp_constr ({txt = Lident "option"; loc=typ.ptyp_loc}, [typ])}
+                else typ in
+              {lbl with  pld_type = typ }) in
+          let lbls, lbls' = transl_labels env true lbls in
           let lbls_opt = match lbls, lbls' with
             | {ld_name = {txt = "..."}; ld_type} :: _, _ :: _ ->
               let rec extract t = match t.desc with

--- a/jscomp/test/DotDotDot.js
+++ b/jscomp/test/DotDotDot.js
@@ -22,7 +22,13 @@ var v2 = {
   w: 2.0
 };
 
+var x = {
+  name: "test",
+  x: "test"
+};
+
 exports.v = v;
 exports.v2 = v2;
+exports.x = x;
 exports.MultipleDotDotDots = MultipleDotDotDots;
 /* No side effect */

--- a/jscomp/test/DotDotDot.res
+++ b/jscomp/test/DotDotDot.res
@@ -35,6 +35,8 @@ type svgProps = {
   y?: string,
 }
 
+let x: svgProps = {x: "test"}
+
 module MultipleDotDotDots = {
   type t1 = {x: int}
   type t2 = {y: string}

--- a/jscomp/test/DotDotDot.res
+++ b/jscomp/test/DotDotDot.res
@@ -35,7 +35,7 @@ type svgProps = {
   y?: string,
 }
 
-let x: svgProps = {x: "test"}
+let x: svgProps = {x: "test", name: "test"}
 
 // uncomment this to reveal a parser error
 // type copiedSvgProps = {...svgProps}

--- a/jscomp/test/DotDotDot.res
+++ b/jscomp/test/DotDotDot.res
@@ -37,6 +37,9 @@ type svgProps = {
 
 let x: svgProps = {x: "test"}
 
+// uncomment this to reveal a parser error
+// type copiedSvgProps = {...svgProps}
+
 module MultipleDotDotDots = {
   type t1 = {x: int}
   type t2 = {y: string}


### PR DESCRIPTION
This does 2 things:

1. Fixes an issue where the fields being optional wasn't propagated through the new record type spread functionality. Before this, any optional field from a record that was then spread onto another record would no longer be optional.
2. Adds a commented out test for a case where the parser breaks as we're spreading a single type only, with no additional fields, as in copying the record to a new identical record. I _think_ that's supposed to work?