### PR TITLE
Fixed subtype checking for record types with "@as" attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 - Disable warning on `@inline` attibute on uncurried functions. https://github.com/rescript-lang/rescript-compiler/pull/6152
 - Support doc comments on arguments of function types. https://github.com/rescript-lang/rescript-compiler/pull/6161
 - Fix issue with record type coercion and unboxed. https://github.com/rescript-lang/rescript-compiler/issues/6158
+- Fixed subtype checking for record types with "@as" attributes: The subtype relationship now takes into account the compatibility of "@as" attributes between corresponding fields, ensuring correctness in runtime representation.
+ https://github.com/rescript-lang/rescript-compiler/issues/6158
+
 
 # 11.0.0-alpha.3
 


### PR DESCRIPTION
This commit adds the necessary checks to ensure compatibility between the "as" attributes of corresponding fields when determining subtype relationships between record types. The code now verifies that the string payloads of the "as" attributes in matching fields are equal. If they are not equal, the subtype relationship is considered invalid. This change improves the accuracy and robustness of the subtype checking mechanism when dealing with record types that utilize custom "as" attributes.

See https://github.com/rescript-lang/rescript-compiler/issues/6158