### PR TITLE
Add surface syntax for partial application of uncurried functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 # 11.0.0-alpha.4 (Unreleased)
 
 #### :rocket: Main New Feature
-- Add surface synyax for partial application of uncurried functions.
+- Add surface syntax for partial application of uncurried functions.
 
 #### :bug: Bug Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 # 11.0.0-alpha.4 (Unreleased)
 
+#### :rocket: Main New Feature
+- Add surface synyax for partial application of uncurried functions.
+
 #### :bug: Bug Fix
 
 - Fix broken formatting in uncurried mode for functions with _ placeholder args. https://github.com/rescript-lang/rescript-compiler/pull/6148

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 # 11.0.0-alpha.4 (Unreleased)
 
 #### :rocket: Main New Feature
-- Add surface syntax for partial application of uncurried functions: `foo(1, ...)`. This corresponds to curried application in the old mode. 
+- Add surface syntax for partial application of uncurried functions: `foo(1, ...)`. This corresponds to curried application in the old mode. https://github.com/rescript-lang/rescript-compiler/pull/6166
 
 #### :bug: Bug Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 # 11.0.0-alpha.4 (Unreleased)
 
 #### :rocket: Main New Feature
-- Add surface syntax for partial application of uncurried functions.
+- Add surface syntax for partial application of uncurried functions: `foo(1, ...)`. This corresponds to curried application in the old mode. 
 
 #### :bug: Bug Fix
 

--- a/res_syntax/src/res_grammar.ml
+++ b/res_syntax/src/res_grammar.ml
@@ -299,7 +299,7 @@ let isListTerminator grammar token =
   | _, Token.Eof
   | ExprList, (Rparen | Forwardslash | Rbracket)
   | ListExpr, Rparen
-  | ArgumentList, Rparen
+  | ArgumentList, (Rparen | DotDotDot)
   | TypExprList, (Rparen | Forwardslash | GreaterThan | Equal)
   | ModExprList, Rparen
   | ( (PatternList | PatternOcamlList | PatternRecord),

--- a/res_syntax/src/res_parsetree_viewer.ml
+++ b/res_syntax/src/res_parsetree_viewer.ml
@@ -72,6 +72,15 @@ let processUncurriedAppAttribute attrs =
   in
   process false [] attrs
 
+let processPartialAppAttribute attrs =
+  let rec process partialApp acc attrs =
+    match attrs with
+    | [] -> (partialApp, List.rev acc)
+    | ({Location.txt = "res.partial"}, _) :: rest -> process true acc rest
+    | attr :: rest -> process partialApp (attr :: acc) rest
+  in
+  process false [] attrs
+
 type functionAttributesInfo = {
   async: bool;
   bs: bool;

--- a/res_syntax/src/res_parsetree_viewer.mli
+++ b/res_syntax/src/res_parsetree_viewer.mli
@@ -20,6 +20,9 @@ val processBsAttribute : Parsetree.attributes -> bool * Parsetree.attributes
 val processUncurriedAppAttribute :
   Parsetree.attributes -> bool * Parsetree.attributes
 
+val processPartialAppAttribute :
+  Parsetree.attributes -> bool * Parsetree.attributes
+
 type functionAttributesInfo = {
   async: bool;
   bs: bool;

--- a/res_syntax/tests/printer/expr/UncurriedByDefault.res
+++ b/res_syntax/tests/printer/expr/UncurriedByDefault.res
@@ -157,3 +157,5 @@ let fnU = (_x): ((unit) => unit) => fooC
 let aU = (() => "foo")->Ok
 
 Ok("_")->Belt.Result.map(concatStrings(_, "foo"))
+
+let ptl1 =  add(1, ...)

--- a/res_syntax/tests/printer/expr/expected/UncurriedByDefault.res.txt
+++ b/res_syntax/tests/printer/expr/expected/UncurriedByDefault.res.txt
@@ -157,3 +157,5 @@ let fnU = (_x): (unit => unit) => fooC
 let aU = (() => "foo")->Ok
 
 Ok("_")->Belt.Result.map(concatStrings(_, "foo"))
+
+let ptl1 = add(1, ...)


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-compiler/issues/6165

This PR introduces a new surface syntax for partial application of uncurried functions in ReScript. The syntax allows developers to partially apply uncurried functions more easily and concisely using the ... token in argument lists. The implementation includes changes to the parser, grammar, and printer to handle the new syntax properly.

### Example:

```res
@@uncurried

let add = (a, b, c) => a + b + c
let ptl1 = add(1, ...)
let result = ptl1(2, 3) // result will be 6
```

This example demonstrates the new syntax for partial application of the uncurried add function.