### PR TITLE
Make "rescript format" work with node 10 again and set "engines" field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 - Parse `assert` as a regular function. `assert` is no longer a unary expression. Example: before `assert 1 == 2` is parsed as `(assert 1) == 2`, now it is parsed as `assert(1 == 2)`. https://github.com/rescript-lang/rescript-compiler/pull/6180
 
+#### :bug: Bug Fix
+
+- Make "rescript format" work with node 10 again and set minimum required node version to 10 in package.json. https://github.com/rescript-lang/rescript-compiler/pull/6186
+
 # 11.0.0-alpha.4
 
 #### :rocket: Main New Feature

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "prettier": "^2.7.1",
     "rollup": "^0.49.2"
   },
+  "engines": {
+    "node": ">=10"
+  },
   "bin": {
     "bsc": "bsc",
     "bstracing": "lib/bstracing",

--- a/scripts/rescript_format.js
+++ b/scripts/rescript_format.js
@@ -5,7 +5,7 @@ var format_usage = `Usage: rescript format <options> [files]
 \`rescript format\` formats the current directory
 `;
 var child_process = require("child_process");
-var util = require("node:util");
+var util = require("util");
 var asyncExecFile = util.promisify(child_process.execFile);
 var path = require("path");
 var fs = require("fs");


### PR DESCRIPTION
Closes #6185.