### PR TITLE
[Proof of concept] add @pure annotation for externals

### DIFF
--- a/jscomp/core/j.ml
+++ b/jscomp/core/j.ml
@@ -283,7 +283,7 @@ and statement_desc =
   | Try of block * (exception_ident * block) option * block option
   | Debugger
 
-and expression = { expression_desc : expression_desc; comment : string option }
+and expression = { expression_desc : expression_desc; comment : string option; annotate_pure : bool }
 and statement = { statement_desc : statement_desc; comment : string option }
 
 and variable_declaration = {

--- a/jscomp/core/js_dump.ml
+++ b/jscomp/core/js_dump.ml
@@ -510,6 +510,7 @@ and vident cxt f (v : J.vident) =
 (* The higher the level, the more likely that inner has to add parens *)
 and expression ~level:l cxt f (exp : J.expression) : cxt =
   pp_comment_option f exp.comment;
+  if exp.annotate_pure then P.string f "/*#__PURE__*/ ";
   expression_desc cxt ~level:l f exp.expression_desc
 
 and expression_desc cxt ~(level : int) f x : cxt =

--- a/jscomp/core/js_exp_make.mli
+++ b/jscomp/core/js_exp_make.mli
@@ -273,7 +273,7 @@ val js_comp : Lam_compat.comparison -> ?comment:string -> t -> t -> t
 
 val not : t -> t
 
-val call : ?comment:string -> info:Js_call_info.t -> t -> t list -> t
+val call : ?comment:string -> ?annotate_pure:bool -> info:Js_call_info.t -> t -> t list -> t
 
 val flat_call : ?comment:string -> t -> t -> t
 

--- a/jscomp/core/js_record_map.ml
+++ b/jscomp/core/js_record_map.ml
@@ -263,9 +263,9 @@ let statement_desc : statement_desc fn =
   | Debugger as v -> v
 
 let expression : expression fn =
- fun _self { expression_desc = _x0; comment = _x1 } ->
+ fun _self { expression_desc = _x0; comment = _x1; annotate_pure = _x2 } ->
   let _x0 = expression_desc _self _x0 in
-  { expression_desc = _x0; comment = _x1 }
+  { expression_desc = _x0; comment = _x1; annotate_pure = _x2 }
 
 let statement : statement fn =
  fun _self { statement_desc = _x0; comment = _x1 } ->

--- a/jscomp/core/lam_compile_external_call.ml
+++ b/jscomp/core/lam_compile_external_call.ml
@@ -252,17 +252,17 @@ let translate_scoped_access scopes obj =
 let translate_ffi (cxt : Lam_compile_context.t) arg_types
     (ffi : External_ffi_types.external_spec) (args : J.expression list) =
   match ffi with
-  | Js_call { external_module_name = module_name; name = fn; splice; scopes } ->
+  | Js_call { external_module_name = module_name; name = fn; splice; scopes; annotate_pure } ->
       let fn = translate_scoped_module_val module_name fn scopes in
       if splice then
         let args, eff, dynamic = assemble_args_has_splice arg_types args in
         add_eff eff
           (if dynamic then splice_apply fn args
-          else E.call ~info:{ arity = Full; call_info = Call_na } fn args)
+          else E.call ~annotate_pure ~info:{ arity = Full; call_info = Call_na } fn args)
       else
         let args, eff = assemble_args_no_splice arg_types args in
         add_eff eff
-        @@ E.call ~info:{ arity = Full; call_info = Call_na } fn args
+        @@ E.call ~annotate_pure ~info:{ arity = Full; call_info = Call_na } fn args
   | Js_module_as_fn { external_module_name; splice } ->
       let fn = external_var external_module_name in
       if splice then

--- a/jscomp/ext/ident.ml
+++ b/jscomp/ext/ident.ml
@@ -17,7 +17,7 @@ open Format
 
 type t = { stamp: int; name: string; mutable flags: int }
 
-let [@inlnie] max (x:int) y = if x >= y then x else y 
+let [@inline] max (x:int) y = if x >= y then x else y
 let global_flag = 1
 let predef_exn_flag = 2
 

--- a/jscomp/frontend/ast_attributes.ml
+++ b/jscomp/frontend/ast_attributes.ml
@@ -121,6 +121,7 @@ let external_attrs =
     "send";
     "new";
     "set_index";
+    "pure";
     Literals.gentype_import1;
     Literals.gentype_import2;
   |]

--- a/jscomp/frontend/external_ffi_types.ml
+++ b/jscomp/frontend/external_ffi_types.ml
@@ -53,6 +53,7 @@ type external_spec =
       external_module_name: external_module_name option;
       splice: bool;
       scopes: string list;
+      annotate_pure: bool;
     }
   | Js_send of {name: string; splice: bool; js_send_scopes: string list}
     (* we know it is a js send, but what will happen if you pass an ocaml objct *)
@@ -188,7 +189,8 @@ let check_ffi ?loc ffi : bool =
     upgrade (is_package_relative_path external_module_name.bundle);
     check_external_module_name external_module_name
   | Js_new {external_module_name; name; splice = _; scopes = _}
-  | Js_call {external_module_name; name; splice = _; scopes = _} ->
+  | Js_call
+      {external_module_name; name; splice = _; scopes = _; annotate_pure = _} ->
     Ext_option.iter external_module_name (fun external_module_name ->
         upgrade (is_package_relative_path external_module_name.bundle));
     Ext_option.iter external_module_name (fun name ->

--- a/jscomp/frontend/external_ffi_types.mli
+++ b/jscomp/frontend/external_ffi_types.mli
@@ -50,6 +50,7 @@ type external_spec =
       external_module_name: external_module_name option;
       splice: bool;
       scopes: string list;
+      annotate_pure: bool;
     }
   | Js_send of {name: string; splice: bool; js_send_scopes: string list}
     (* we know it is a js send, but what will happen if you pass an ocaml objct *)


### PR DESCRIPTION
### Add @pure annotation support for external JavaScript dependencies to improve tree shaking compatibility

"`#__PURE__` comments are used by bundlers, like Webpack, to improve tree shaking by identifying pure functions that can be safely removed during the optimization process. Currently, ReScript does not provide a way to add these annotations when working with external JavaScript dependencies. 

This proposal suggests adding support for the `@pure` annotation in ReScript for external JavaScript dependencies, allowing developers to explicitly mark these functions as pure and improve tree shaking compatibility. The example below demonstrates the proposed implementation:

```rescript
type t
@pure @module("example") external make: unit => t = "default"
let t = make()
```

```js
var Example = require("example").default;
var t = /*#__PURE__*/ Example();
```

I'm looking for feedback on whether this approach is correct and valuable to implement. Any insights on how the compiler processes this code and potential challenges in implementing this feature are welcome.