### PR TITLE
Fix partial application for uncurried functions with labeled args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 #### :bug: Bug Fix
 
 - Make "rescript format" work with node 10 again and set minimum required node version to 10 in package.json. https://github.com/rescript-lang/rescript-compiler/pull/6186
+- Fix partial application for uncurried functions with labeled args https://github.com/rescript-lang/rescript-compiler/pull/6198
 
 # 11.0.0-alpha.4
 

--- a/jscomp/ml/ast_uncurried.ml
+++ b/jscomp/ml/ast_uncurried.ml
@@ -106,3 +106,9 @@ let uncurried_type_get_arity ~env typ =
   | Tconstr (Pident { name = "function$" }, [ _t; tArity ], _) ->
       type_to_arity tArity
   | _ -> assert false
+
+let uncurried_type_get_arity_opt ~env typ =
+  match (Ctype.expand_head env typ).desc with
+  | Tconstr (Pident { name = "function$" }, [ _t; tArity ], _) ->
+      Some (type_to_arity tArity)
+  | _ -> None

--- a/jscomp/test/UncurriedAlways.js
+++ b/jscomp/test/UncurriedAlways.js
@@ -24,8 +24,8 @@ console.log(a);
       return x + 1 | 0;
     });
 
-function ptl(param) {
-  return foo(10, param);
+function ptl(extra) {
+  return 10 + extra | 0;
 }
 
 function foo2(x, y) {
@@ -56,6 +56,108 @@ function inl2(x, y) {
   return x + y | 0;
 }
 
+function foo$1(x, y, z) {
+  return [
+          x,
+          y,
+          z
+        ];
+}
+
+function ptl$1(none, extra) {
+  return [
+          none,
+          "y",
+          extra
+        ];
+}
+
+var a1 = [
+  "x",
+  "y",
+  "z"
+];
+
+console.log("a1:", a1);
+
+var AllLabels = {
+  foo: foo$1,
+  ptl: ptl$1,
+  a1: a1
+};
+
+function foo$2(x, y, z, dOpt) {
+  var d = dOpt !== undefined ? dOpt : "d=0";
+  return [
+          x,
+          y,
+          z,
+          d
+        ];
+}
+
+function ptl$2(none, extra, extra$1) {
+  return foo$2(none, "y", extra, extra$1);
+}
+
+var b1 = ptl$2("x", "z", undefined);
+
+console.log("b1:", b1);
+
+var b2 = ptl$2("x", "z", "d<-100");
+
+console.log("b2:", b2);
+
+var OptAtEnd = {
+  foo: foo$2,
+  ptl: ptl$2,
+  b1: b1,
+  b2: b2
+};
+
+function foo$3(d1Opt, x, d2Opt, y, d3Opt, z, d4Opt, w, d5Opt) {
+  var d1 = d1Opt !== undefined ? d1Opt : "d1=0";
+  var d2 = d2Opt !== undefined ? d2Opt : "d2=0";
+  var d3 = d3Opt !== undefined ? d3Opt : "d3=0";
+  var d4 = d4Opt !== undefined ? d4Opt : "d4=0";
+  var d5 = d5Opt !== undefined ? d5Opt : "d5=0";
+  return [
+          d1,
+          x,
+          d2,
+          y,
+          d3,
+          z,
+          d4,
+          w,
+          d5
+        ];
+}
+
+function ptl$3(none, none$1, none$2, none$3, none$4, none$5, extra) {
+  return foo$3(none, none$1, none$2, "y", none$3, none$4, none$5, "w", extra);
+}
+
+var c1 = ptl$3(undefined, "x", undefined, undefined, "z", undefined, undefined);
+
+console.log("c1:", c1);
+
+var c2 = ptl$3("d1<-100", "x", undefined, undefined, "z", undefined, undefined);
+
+console.log("c2:", c2);
+
+var c3 = ptl$3(undefined, "x", "d2<-200", undefined, "z", "d4<-400", undefined);
+
+console.log("c3:", c3);
+
+var OptMixed = {
+  foo: foo$3,
+  ptl: ptl$3,
+  c1: c1,
+  c2: c2,
+  c3: c3
+};
+
 exports.foo = foo;
 exports.z = z;
 exports.bar = bar;
@@ -70,4 +172,7 @@ exports.bar3 = bar3;
 exports.q = q;
 exports.inl = inl;
 exports.inl2 = inl2;
+exports.AllLabels = AllLabels;
+exports.OptAtEnd = OptAtEnd;
+exports.OptMixed = OptMixed;
 /*  Not a pure module */

--- a/jscomp/test/UncurriedAlways.res
+++ b/jscomp/test/UncurriedAlways.res
@@ -32,3 +32,36 @@ let inl = () => ()
 
 @inline
 let inl2 = (x,y) => x+y
+
+module AllLabels = {
+  let foo = (~x, ~y, ~z) => (x, y, z)
+
+  let ptl = foo(~y="y", ...)
+
+  let a1 = ptl(~x="x", ~z="z")
+  Js.log2("a1:", a1)
+}
+
+module OptAtEnd = {
+  let foo = (~x, ~y, ~z, ~d="d=0") => (x, y, z, d)
+
+  let ptl = foo(~y="y", ...)
+
+  let b1 = ptl(~x="x", ~z="z")
+  Js.log2("b1:", b1)
+  let b2 = ptl(~x="x", ~z="z", ~d="d<-100")
+  Js.log2("b2:", b2)
+}
+
+module OptMixed = {
+  let foo = (~d1="d1=0", ~x, ~d2="d2=0",  ~y, ~d3="d3=0", ~z, ~d4="d4=0", ~w, ~d5="d5=0") => (d1, x, d2, y, d3, z, d4, w, d5)
+
+  let ptl = foo(~y="y", ~w="w", ...)
+
+  let c1 = ptl(~x="x", ~z="z")
+  Js.log2("c1:", c1)
+  let c2 = ptl(~x="x", ~z="z", ~d1="d1<-100")
+  Js.log2("c2:", c2)
+  let c3 = ptl(~x="x", ~z="z", ~d2="d2<-200", ~d4="d4<-400")
+  Js.log2("c3:", c3)
+}


### PR DESCRIPTION
Partial application for uncurried functions used normal application. There's an issue with the code generated in the presence of labeled arguments, as the function generated is curried.

This PR changes the translation from typed ast to lambda for the uncurried partial application case, by writing a single function with all the leftover arguments. So it correctly represents an uncurried function.

Fixex https://github.com/rescript-lang/rescript-compiler/issues/6164