### PR TITLE
Add error messages for dangling doc comments/attributes and mutable i…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 - Make "rescript format" work with node 10 again and set minimum required node version to 10 in package.json. https://github.com/rescript-lang/rescript-compiler/pull/6186
 - Fix partial application for uncurried functions with labeled args https://github.com/rescript-lang/rescript-compiler/pull/6198
+- Add error messages for dangling doc comments/attributes and mutable in record type definition. https://github.com/rescript-lang/rescript-compiler/pull/6206
 
 # 11.0.0-alpha.4
 

--- a/res_syntax/src/res_core.ml
+++ b/res_syntax/src/res_core.ml
@@ -4498,7 +4498,18 @@ and parseFieldDeclarationRegion ?foundObjectField p =
     let loc = mkLoc startPos typ.ptyp_loc.loc_end in
     let attrs = if optional then optionalAttr :: attrs else attrs in
     Some (Ast_helper.Type.field ~attrs ~loc ~mut name typ)
-  | _ -> None
+  | _ ->
+    if attrs <> [] then
+      Parser.err ~startPos p
+        (Diagnostics.message
+           "Attributes and doc comments can only be used at the beginning of a \
+            field declaration");
+    if mut = Mutable then
+      Parser.err ~startPos p
+        (Diagnostics.message
+           "The `mutable` qualifier can only be used at the beginning of a \
+            field declaration");
+    None
 
 (* record-decl ::=
  *  | { field-decl }

--- a/res_syntax/tests/parsing/errors/typeDef/expected/recordDocComment.res.txt
+++ b/res_syntax/tests/parsing/errors/typeDef/expected/recordDocComment.res.txt
@@ -1,0 +1,13 @@
+
+  Syntax error!
+  tests/parsing/errors/typeDef/recordDocComment.res:2:16-3:1
+
+  1 │ type a = {
+  2 │   foo: string, /** here */
+  3 │ }
+  4 │ 
+
+  Attributes and doc comments can only be used at the beginning of a field declaration
+
+type nonrec a = {
+  foo: string }

--- a/res_syntax/tests/parsing/errors/typeDef/expected/recordMutable.res.txt
+++ b/res_syntax/tests/parsing/errors/typeDef/expected/recordMutable.res.txt
@@ -1,0 +1,13 @@
+
+  Syntax error!
+  tests/parsing/errors/typeDef/recordMutable.res:2:16-3:1
+
+  1 │ type d = {
+  2 │   foo: string, mutable
+  3 │ }
+  4 │ 
+
+  The `mutable` qualifier can only be used at the beginning of a field declaration
+
+type nonrec d = {
+  foo: string }

--- a/res_syntax/tests/parsing/errors/typeDef/recordDocComment.res
+++ b/res_syntax/tests/parsing/errors/typeDef/recordDocComment.res
@@ -1,0 +1,3 @@
+type a = {
+  foo: string, /** here */
+}

--- a/res_syntax/tests/parsing/errors/typeDef/recordMutable.res
+++ b/res_syntax/tests/parsing/errors/typeDef/recordMutable.res
@@ -1,0 +1,3 @@
+type d = {
+  foo: string, mutable
+}


### PR DESCRIPTION
…n record type definition.

Fixes https://github.com/rescript-lang/rescript-compiler/issues/6111