### PR TITLE
Refactor untagged logic

### DIFF
--- a/jscomp/core/j.ml
+++ b/jscomp/core/j.ml
@@ -244,7 +244,7 @@ and case_clause = {
   comment : string option;
 }
 
-and string_clause = Ast_untagged_variants.literal_type * case_clause
+and string_clause = Ast_untagged_variants.tag_type * case_clause
 and int_clause = int * case_clause
 
 and statement_desc =

--- a/jscomp/core/js_dump.ml
+++ b/jscomp/core/js_dump.ml
@@ -779,15 +779,15 @@ and expression_desc cxt ~(level : int) f x : cxt =
           tails
         else
           (Js_op.Lit tag_name, (* TAG:xx for inline records *)
-            match Ast_untagged_variants.process_literal_type p.attrs with
+            match Ast_untagged_variants.process_tag_type p.attrs with
             | None -> E.str p.name
-            | Some literal -> E.literal literal )
+            | Some t -> E.tag_type t )
           :: tails
       in
       expression_desc cxt ~level f (Object objs)
   | Caml_block (el, _, tag, Blk_constructor p) ->
       let not_is_cons = p.name <> Literals.cons in
-      let literal = Ast_untagged_variants.process_literal_type p.attrs in
+      let tag_type = Ast_untagged_variants.process_tag_type p.attrs in
       let untagged = Ast_untagged_variants.process_untagged p.attrs in
       let tag_name = match Ast_untagged_variants.process_tag_name p.attrs with
         | None -> L.tag
@@ -808,9 +808,9 @@ and expression_desc cxt ~(level : int) f x : cxt =
         if untagged || (not_is_cons = false) && p.num_nonconst = 1 then tails
         else
           ( Js_op.Lit tag_name, (* TAG:xx *) 
-            match literal with
+            match tag_type with
             | None -> E.str p.name
-            | Some literal -> E.literal literal )
+            | Some t -> E.tag_type t )
           :: tails
       in
       let exp = match objs with
@@ -1210,8 +1210,8 @@ and statement_desc top cxt f (s : J.statement_desc) : cxt =
       let cxt = P.paren_group f 1 (fun _ -> expression ~level:0 cxt f e) in
       P.space f;
       P.brace_vgroup f 1 (fun _ ->
-          let pp_as_value f (literal: Ast_untagged_variants.literal_type) =
-            let e = E.literal literal in
+          let pp_as_value f (tag_type: Ast_untagged_variants.tag_type) =
+            let e = E.tag_type tag_type in
             ignore @@ expression_desc cxt ~level:0 f e.expression_desc in
           let cxt = loop_case_clauses cxt f pp_as_value cc in
           match def with

--- a/jscomp/core/js_exp_make.ml
+++ b/jscomp/core/js_exp_make.ml
@@ -767,13 +767,13 @@ let tag_type = function
   | Bool b -> bool b
   | Null -> nil
   | Undefined -> undefined
-  | Block IntType -> str "number"
-  | Block FloatType -> str "number"
-  | Block StringType -> str "string"
-  | Block ArrayType -> str "Array" ~delim:DNoQuotes
-  | Block ObjectType -> str "object"
-  | Block UnknownType ->
-    (* TODO: clean up pattern mathing algo whih confuses literal with blocks *)
+  | Untagged IntType -> str "number"
+  | Untagged FloatType -> str "number"
+  | Untagged StringType -> str "string"
+  | Untagged ArrayType -> str "Array" ~delim:DNoQuotes
+  | Untagged ObjectType -> str "object"
+  | Untagged UnknownType ->
+    (* TODO: this should not happen *)
     assert false
 
 let rec is_a_literal_case ~(literal_cases : Ast_untagged_variants.tag_type list) ~block_cases (e:t) : t =

--- a/jscomp/core/js_exp_make.ml
+++ b/jscomp/core/js_exp_make.ml
@@ -760,7 +760,7 @@ let string_equal ?comment (e0 : t) (e1 : t) : t =
 let is_type_number ?comment (e : t) : t =
   string_equal ?comment (typeof e) (str "number")
 
-let literal = function
+let tag_type = function
   | Ast_untagged_variants.String s -> str s ~delim:DStarJ
   | Int i -> small_int i
   | Float f -> float f
@@ -776,7 +776,7 @@ let literal = function
     (* TODO: clean up pattern mathing algo whih confuses literal with blocks *)
     assert false
 
-let rec is_a_literal_case ~(literal_cases : Ast_untagged_variants.literal_type list) ~block_cases (e:t) : t =
+let rec is_a_literal_case ~(literal_cases : Ast_untagged_variants.tag_type list) ~block_cases (e:t) : t =
   let literals_overlaps_with_string () = 
     Ext_list.exists literal_cases (function
       | String _ -> true
@@ -793,8 +793,8 @@ let rec is_a_literal_case ~(literal_cases : Ast_untagged_variants.literal_type l
   let (!=) x y = bin NotEqEq x y in
   let (||) x y = bin Or x y in
   let (&&) x y = bin And x y in
-  let is_literal_case (l:Ast_untagged_variants.literal_type) : t =  e == (literal l) in
-  let is_not_block_case (c:Ast_untagged_variants.block_type) : t = match c with
+  let is_literal_case (t: Ast_untagged_variants.tag_type) : t =  e == (tag_type t) in
+  let is_not_block_case (c: Ast_untagged_variants.block_type) : t = match c with
   | StringType when literals_overlaps_with_string () = false  (* No overlap *) -> 
     (typeof e) != (str "string")
   | IntType when literals_overlaps_with_number () = false ->

--- a/jscomp/core/js_exp_make.ml
+++ b/jscomp/core/js_exp_make.ml
@@ -336,22 +336,6 @@ let zero_float_lit : t =
 let float_mod ?comment e1 e2 : J.expression =
   { comment; expression_desc = Bin (Mod, e1, e2) }
 
-let literal = function
-  | Ast_untagged_variants.String s -> str s ~delim:DStarJ
-  | Int i -> small_int i
-  | Float f -> float f
-  | Bool b -> bool b
-  | Null -> nil
-  | Undefined -> undefined
-  | Block IntType -> str "number"
-  | Block FloatType -> str "number"
-  | Block StringType -> str "string"
-  | Block Array -> str "Array" ~delim:DNoQuotes
-  | Block Object -> str "object"
-  | Block Unknown ->
-    (* TODO: clean up pattern mathing algo whih confuses literal with blocks *)
-    assert false
-
 let array_index ?comment (e0 : t) (e1 : t) : t =
   match (e0.expression_desc, e1.expression_desc) with
   | Array (l, _), Number (Int { i; _ })
@@ -776,6 +760,22 @@ let string_equal ?comment (e0 : t) (e1 : t) : t =
 let is_type_number ?comment (e : t) : t =
   string_equal ?comment (typeof e) (str "number")
 
+let literal = function
+  | Ast_untagged_variants.String s -> str s ~delim:DStarJ
+  | Int i -> small_int i
+  | Float f -> float f
+  | Bool b -> bool b
+  | Null -> nil
+  | Undefined -> undefined
+  | Block IntType -> str "number"
+  | Block FloatType -> str "number"
+  | Block StringType -> str "string"
+  | Block ArrayType -> str "Array" ~delim:DNoQuotes
+  | Block ObjectType -> str "object"
+  | Block UnknownType ->
+    (* TODO: clean up pattern mathing algo whih confuses literal with blocks *)
+    assert false
+
 let rec is_a_literal_case ~(literal_cases : Ast_untagged_variants.literal_type list) ~block_cases (e:t) : t =
   let literals_overlaps_with_string () = 
     Ext_list.exists literal_cases (function
@@ -801,16 +801,16 @@ let rec is_a_literal_case ~(literal_cases : Ast_untagged_variants.literal_type l
     (typeof e) != (str "number")
   | FloatType when literals_overlaps_with_number () = false ->
     (typeof e) != (str "number")
-  | Array -> 
+  | ArrayType -> 
     not (is_array e)
-  | Object when literals_overlaps_with_object () = false ->
+  | ObjectType when literals_overlaps_with_object () = false ->
     (typeof e) != (str "object")
-  | Object (* overlap *) ->
+  | ObjectType (* overlap *) ->
     e == nil || (typeof e) != (str "object")
   | StringType (* overlap *)
   | IntType (* overlap *)
   | FloatType (* overlap *)
-  | Unknown ->
+  | UnknownType ->
     (* We don't know the type of unknown, so we need to express:
        this is not one of the literals *)
     (match literal_cases with

--- a/jscomp/core/js_exp_make.mli
+++ b/jscomp/core/js_exp_make.mli
@@ -186,7 +186,7 @@ val assign_by_exp : t -> t -> t -> t
 
 val assign : ?comment:string -> t -> t -> t
 
-val literal : Ast_untagged_variants.literal_type -> t
+val tag_type : Ast_untagged_variants.tag_type -> t
 
 val triple_equal : ?comment:string -> t -> t -> t
 (* TODO: reduce [triple_equal] use *)
@@ -205,7 +205,7 @@ val is_type_number : ?comment:string -> t -> t
 
 val is_int_tag : ?has_null_undefined_other:(bool * bool * bool) -> t -> t
 
-val is_a_literal_case : literal_cases:Ast_untagged_variants.literal_type list -> block_cases:Ast_untagged_variants.block_type list -> t -> t
+val is_a_literal_case : literal_cases:Ast_untagged_variants.tag_type list -> block_cases:Ast_untagged_variants.block_type list -> t -> t
 
 val is_type_string : ?comment:string -> t -> t
 

--- a/jscomp/core/js_stmt_make.ml
+++ b/jscomp/core/js_stmt_make.ml
@@ -138,9 +138,8 @@ let string_switch ?(comment : string option)
             match switch_case with
             | String s ->
               if s = txt then Some x.switch_body else None
-            | Int _  | Float _| Bool _ | Null
-            | Undefined
-            | Block _ -> None)
+            | Int _  | Float _| Bool _ | Null | Undefined | Untagged _ ->
+              None)
         with
         | Some case -> case
         | None -> ( match default with Some x -> x | None -> assert false)

--- a/jscomp/core/js_stmt_make.ml
+++ b/jscomp/core/js_stmt_make.ml
@@ -129,7 +129,7 @@ let int_switch ?(comment : string option)
 
 let string_switch ?(comment : string option)
     ?(declaration : (J.property * Ident.t) option) ?(default : J.block option)
-    (e : J.expression) (clauses : (Ast_untagged_variants.literal_type * J.case_clause) list) : t =
+    (e : J.expression) (clauses : (Ast_untagged_variants.tag_type * J.case_clause) list) : t =
   match e.expression_desc with
   | Str {txt} -> (
       let continuation =

--- a/jscomp/core/js_stmt_make.mli
+++ b/jscomp/core/js_stmt_make.mli
@@ -77,7 +77,7 @@ val string_switch :
   ?declaration:Lam_compat.let_kind * Ident.t ->
   ?default:J.block ->
   J.expression ->
-  (Ast_untagged_variants.literal_type * J.case_clause) list ->
+  (Ast_untagged_variants.tag_type * J.case_clause) list ->
   t
 
 val declare_variable :

--- a/jscomp/core/lam_compile.ml
+++ b/jscomp/core/lam_compile.ml
@@ -757,20 +757,20 @@ and compile_untagged_cases cxt switch_exp cases default =
   | Block IntType
   | Block StringType
   | Block FloatType
-  | Block Object -> E.string_equal (E.typeof y) x 
-  | Block Array -> E.is_array y
-  | Block Unknown ->
+  | Block ObjectType -> E.string_equal (E.typeof y) x 
+  | Block ArrayType -> E.is_array y
+  | Block UnknownType ->
     (* This should not happen because unknown must be the only non-literal case *)
     assert false 
   | Bool _ | Float _ | Int _ | String _ | Null | Undefined -> x in
   let mk_eq (i : Ast_untagged_variants.literal_type option) x j y = match i, j with
-    | Some literal, _ -> (* XX *)
+    | Some literal, _ ->
       add_runtime_type_check literal x y
     | _, Some literal ->
       add_runtime_type_check literal y x
     | _ -> E.string_equal x y
   in
-  let is_array (l, _) = l = Ast_untagged_variants.Block Array in
+  let is_array (l, _) = l = Ast_untagged_variants.Block ArrayType in
   let switch ?default ?declaration e clauses =
     let array_clauses = Ext_list.filter clauses is_array in
     match array_clauses with

--- a/jscomp/core/lam_compile.ml
+++ b/jscomp/core/lam_compile.ml
@@ -674,8 +674,8 @@ and compile_switch (switch_arg : Lam.t) (sw : Lam.lambda_switch)
   let get_block_tag i : Ast_untagged_variants.tag option = match get_block i with
     | None -> None
     | Some ({tag = {name}; block_type = Some block_type}) ->
-      Some {name; tag_type = Some (Block block_type)}
-    | Some ({block_type = None; tag}) ->
+      Some {name; tag_type = Some (Untagged block_type)} (* untagged block *)
+    | Some ({block_type = None; tag}) -> (* tagged block *)
       Some tag in
   let tag_name = get_tag_name sw_names in
   let untagged = block_cases <> [] in
@@ -751,12 +751,12 @@ and compile_string_cases ~cxt ~switch_exp ~default cases: initialization  =
     ~default
 and compile_untagged_cases ~cxt ~switch_exp ~default cases =
   let add_runtime_type_check (literal: Ast_untagged_variants.tag_type) x y = match literal with
-  | Block IntType
-  | Block StringType
-  | Block FloatType
-  | Block ObjectType -> E.string_equal (E.typeof y) x 
-  | Block ArrayType -> E.is_array y
-  | Block UnknownType ->
+  | Untagged IntType
+  | Untagged StringType
+  | Untagged FloatType
+  | Untagged ObjectType -> E.string_equal (E.typeof y) x 
+  | Untagged ArrayType -> E.is_array y
+  | Untagged UnknownType ->
     (* This should not happen because unknown must be the only non-literal case *)
     assert false 
   | Bool _ | Float _ | Int _ | String _ | Null | Undefined -> x in
@@ -767,7 +767,7 @@ and compile_untagged_cases ~cxt ~switch_exp ~default cases =
       add_runtime_type_check literal y x
     | _ -> E.string_equal x y
   in
-  let is_array (l, _) = l = Ast_untagged_variants.Block ArrayType in
+  let is_array (l, _) = l = Ast_untagged_variants.Untagged ArrayType in
   let switch ?default ?declaration e clauses =
     let array_clauses = Ext_list.filter clauses is_array in
     match array_clauses with

--- a/jscomp/core/lam_compile.ml
+++ b/jscomp/core/lam_compile.ml
@@ -673,10 +673,10 @@ and compile_switch (switch_arg : Lam.t) (sw : Lam.lambda_switch)
   let block_cases = get_block_cases sw_names in
   let get_block_tag i : Ast_untagged_variants.tag option = match get_block i with
     | None -> None
-    | Some ({name; block_type = Some block_type}) ->
+    | Some ({tag = {name}; block_type = Some block_type}) ->
       Some {name; literal_type = Some (Block block_type)}
-    | Some ({block_type = None; name; literal_type}) ->
-      Some {name; literal_type} in
+    | Some ({block_type = None; tag}) ->
+      Some tag in
   let tag_name = get_tag_name sw_names in
   let untagged = block_cases <> [] in
   let compile_whole (cxt : Lam_compile_context.t) =

--- a/jscomp/core/lam_compile_const.ml
+++ b/jscomp/core/lam_compile_const.ml
@@ -47,10 +47,10 @@ and translate (x : Lam_constant.t) : J.expression =
   | Const_js_false -> E.bool false
   | Const_js_null -> E.nil
   | Const_js_undefined -> E.undefined
-  | Const_int { i; comment = Pt_constructor {cstr_name={name; literal_type=None}}} when name <> "[]" ->
+  | Const_int { i; comment = Pt_constructor {cstr_name={name; tag_type=None}}} when name <> "[]" ->
       E.str name
-  | Const_int { i; comment = Pt_constructor {cstr_name={literal_type = Some literal}}}  ->
-      E.literal literal
+  | Const_int { i; comment = Pt_constructor {cstr_name={tag_type = Some t}}}  ->
+      E.tag_type t
   | Const_int { i; comment } ->
       E.int i ?comment:(Lam_constant.string_of_pointer_info comment)
   | Const_char i -> Js_of_lam_string.const_char i

--- a/jscomp/core/lam_constant_convert.ml
+++ b/jscomp/core/lam_constant_convert.ml
@@ -49,11 +49,11 @@ let rec convert_constant (const : Lambda.structured_constant) : Lam_constant.t =
       | Pt_assertfalse ->
           Const_int { i = Int32.of_int i; comment = Pt_assertfalse }
       | Pt_constructor { name; const; non_const; attrs } ->
-          let literal_type = Ast_untagged_variants.process_literal_type attrs in
+          let tag_type = Ast_untagged_variants.process_tag_type attrs in
           Const_int
             {
               i = Int32.of_int i;
-              comment = Pt_constructor { cstr_name={name; literal_type}; const; non_const };
+              comment = Pt_constructor { cstr_name={name; tag_type}; const; non_const };
             }
       | Pt_variant { name } ->
           if Ext_string.is_valid_hash_number name then

--- a/jscomp/core/lam_print.ml
+++ b/jscomp/core/lam_print.ml
@@ -322,7 +322,7 @@ let lambda ppf v =
             (fun (n, l) ->
               if !spc then fprintf ppf "@ " else spc := true;
               fprintf ppf "@[<hv 1>case tag %i %S:@ %a@]" n
-                (match sw.sw_names with None -> "" | Some x -> x.blocks.(n).literal.name)
+                (match sw.sw_names with None -> "" | Some x -> x.blocks.(n).name)
                 lam l)
             sw.sw_blocks;
           match sw.sw_failaction with

--- a/jscomp/core/lam_print.ml
+++ b/jscomp/core/lam_print.ml
@@ -322,7 +322,7 @@ let lambda ppf v =
             (fun (n, l) ->
               if !spc then fprintf ppf "@ " else spc := true;
               fprintf ppf "@[<hv 1>case tag %i %S:@ %a@]" n
-                (match sw.sw_names with None -> "" | Some x -> x.blocks.(n).name)
+                (match sw.sw_names with None -> "" | Some x -> x.blocks.(n).tag.name)
                 lam l)
             sw.sw_blocks;
           match sw.sw_failaction with

--- a/jscomp/frontend/lam_constant.ml
+++ b/jscomp/frontend/lam_constant.ml
@@ -23,7 +23,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 type constructor_tag = {
-  cstr_name: Ast_untagged_variants.literal;
+  cstr_name: Ast_untagged_variants.tag;
   const: int;
   non_const: int;
 }

--- a/jscomp/frontend/lam_constant.mli
+++ b/jscomp/frontend/lam_constant.mli
@@ -23,7 +23,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 type constructor_tag = {
-  cstr_name: Ast_untagged_variants.literal;
+  cstr_name: Ast_untagged_variants.tag;
   const: int;
   non_const: int;
 }

--- a/jscomp/ml/ast_untagged_variants.ml
+++ b/jscomp/ml/ast_untagged_variants.ml
@@ -33,7 +33,7 @@ type literal_type =
   | String of string | Int of int | Float of string | Bool of bool | Null | Undefined
   | Block of block_type
 type literal = {name: string; literal_type: literal_type option}
-type block = {literal: literal; tag_name: string option; block_type : block_type option}
+type block = {name: string; literal_type: literal_type option; tag_name: string option; block_type: block_type option}
 type switch_names = {consts: literal array; blocks: block array}
 
 let untagged = "unboxed"
@@ -216,8 +216,9 @@ let names_from_type_variant ?(isUntaggedDef=false) ~env (cstrs : Types.construct
     (cstr.cd_loc,
       { name = Ident.name cstr.cd_id;
         literal_type = process_literal_type cstr.cd_attributes }) in
-  let get_block cstr : block =
-    {literal = snd (get_cstr_name cstr); tag_name = get_tag_name cstr; block_type = get_block_type ~env cstr} in
+  let get_block (cstr: Types.constructor_declaration) : block =
+    let literal = snd (get_cstr_name cstr) in
+    {name = literal.name; literal_type = literal.literal_type; tag_name = get_tag_name cstr; block_type = get_block_type ~env cstr} in
   let consts, blocks =
     Ext_list.fold_left cstrs ([], []) (fun (consts, blocks) cstr ->
         if is_nullary_variant cstr.cd_args then

--- a/jscomp/ml/ast_untagged_variants.ml
+++ b/jscomp/ml/ast_untagged_variants.ml
@@ -32,9 +32,9 @@ type block_type =
 type literal_type =
   | String of string | Int of int | Float of string | Bool of bool | Null | Undefined
   | Block of block_type
-type literal = {name: string; literal_type: literal_type option}
+type tag = {name: string; literal_type: literal_type option}
 type block = {name: string; literal_type: literal_type option; tag_name: string option; block_type: block_type option}
-type switch_names = {consts: literal array; blocks: block array}
+type switch_names = {consts: tag array; blocks: block array}
 
 let untagged = "unboxed"
 
@@ -146,7 +146,7 @@ let get_tag_name (cstr: Types.constructor_declaration) =
 let is_nullary_variant (x : Types.constructor_arguments) =
   match x with Types.Cstr_tuple [] -> true | _ -> false
 
-let checkInvariant ~isUntaggedDef ~(consts : (Location.t * literal) list) ~(blocks : (Location.t * block) list) =
+let checkInvariant ~isUntaggedDef ~(consts : (Location.t * tag) list) ~(blocks : (Location.t * block) list) =
   let module StringSet = Set.Make(String) in
   let string_literals = ref StringSet.empty in
   let nonstring_literals = ref StringSet.empty in

--- a/jscomp/ml/ast_untagged_variants.ml
+++ b/jscomp/ml/ast_untagged_variants.ml
@@ -33,7 +33,7 @@ type literal_type =
   | String of string | Int of int | Float of string | Bool of bool | Null | Undefined
   | Block of block_type
 type tag = {name: string; literal_type: literal_type option}
-type block = {name: string; literal_type: literal_type option; tag_name: string option; block_type: block_type option}
+type block = {tag: tag; tag_name: string option; block_type: block_type option}
 type switch_names = {consts: tag array; blocks: block array}
 
 let untagged = "unboxed"
@@ -217,8 +217,8 @@ let names_from_type_variant ?(isUntaggedDef=false) ~env (cstrs : Types.construct
       { name = Ident.name cstr.cd_id;
         literal_type = process_literal_type cstr.cd_attributes }) in
   let get_block (cstr: Types.constructor_declaration) : block =
-    let literal = snd (get_cstr_name cstr) in
-    {name = literal.name; literal_type = literal.literal_type; tag_name = get_tag_name cstr; block_type = get_block_type ~env cstr} in
+    let tag = snd (get_cstr_name cstr) in
+    {tag; tag_name = get_tag_name cstr; block_type = get_block_type ~env cstr} in
   let consts, blocks =
     Ext_list.fold_left cstrs ([], []) (fun (consts, blocks) cstr ->
         if is_nullary_variant cstr.cd_args then

--- a/jscomp/ml/ast_untagged_variants.ml
+++ b/jscomp/ml/ast_untagged_variants.ml
@@ -27,11 +27,18 @@ let report_error ppf =
     | DuplicateLiteral s -> "Duplicate literal " ^ s ^ "."
     )
 
+(* Type of the runtime representation of an untagged block (case with payoad) *)
 type block_type =
   | IntType | StringType | FloatType | ArrayType | ObjectType | UnknownType
+
+(*
+  Type of the runtime representation of a tag.
+  Can be a literal (case with no payload), or a block (case with payload).
+  In the case of block it can be tagged or untagged.
+*)
 type tag_type =
-  | String of string | Int of int | Float of string | Bool of bool | Null | Undefined
-  | Block of block_type
+  | String of string | Int of int | Float of string | Bool of bool | Null | Undefined (* literal or tagged block *)
+  | Untagged of block_type (* untagged block *)
 type tag = {name: string; tag_type: tag_type option}
 type block = {tag: tag; tag_name: string option; block_type: block_type option}
 type switch_names = {consts: tag array; blocks: block array}
@@ -188,7 +195,7 @@ let checkInvariant ~isUntaggedDef ~(consts : (Location.t * tag) list) ~(blocks :
       addNonstringLiteral ~loc "undefined"
     | Some (Bool b) ->
       addNonstringLiteral ~loc (if b then "true" else "false")
-    | Some (Block _) -> ()
+    | Some (Untagged _) -> ()
     | None ->
       addStringLiteral ~loc literal.name
     );


### PR DESCRIPTION
This is a cleanup of the type definitions and code for untagged variants.
No semantic change.
