### PR TITLE
Unboxed variants stdlib types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Add location information to duplicate type definition error messages. https://github.com/rescript-lang/rescript-compiler/pull/6199
 - Replace normal module errors with Super_error module, and clean up Super_error. https://github.com/rescript-lang/rescript-compiler/pull/6199
+- `Js.Json.t`, `Js.null` and `Js.nullable` are now untagged variants representing their runtime values, instead of abstract types. https://github.com/rescript-lang/rescript-compiler/pull/6218
 
 # 11.0.0-alpha.5
 

--- a/jscomp/others/js.ml
+++ b/jscomp/others/js.ml
@@ -86,7 +86,10 @@ end
 
 (**/**)
 
-type +'a null
+type +'a null =
+  | Value of 'a
+  | Null [@as null]
+[@@unboxed]
 (**
   Nullable value of this type can be either null or 'a. This type is equivalent to Js.Null.t.
 *)
@@ -97,7 +100,7 @@ type +'a undefined
 *)
 
 type +'a nullable =
-  | Present of 'a
+  | Value of 'a
   | Null [@as null]
   | Undefined [@as undefined]
 [@@unboxed]

--- a/jscomp/others/js.ml
+++ b/jscomp/others/js.ml
@@ -96,7 +96,12 @@ type +'a undefined
   A value of this type can be either undefined or 'a. This type is equivalent to Js.Undefined.t.
 *)
 
-type +'a nullable
+type +'a nullable =
+  | Present of 'a
+  | Null [@as null]
+  | Undefined [@as undefined]
+[@@unboxed]
+
 (**
   A value of this type can be undefined, null or 'a. This type is equivalent to Js.Null_undefined.t.
 *)

--- a/jscomp/others/js_json.ml
+++ b/jscomp/others/js_json.ml
@@ -24,7 +24,15 @@
 
 (** Efficient JSON encoding using JavaScript API *)
 
-type t
+type t =
+  | False [@as false]
+  | True [@as true]
+  | Null [@as null]
+  | String of string
+  | Number of float
+  | Object of t Js.Dict.t
+  | Array of t array
+[@@unboxed]
 
 type _ kind =
   | String : Js_string.t kind

--- a/jscomp/others/js_json.mli
+++ b/jscomp/others/js_json.mli
@@ -30,7 +30,15 @@
 
 (** ## Types *)
 
-type t
+type t =
+  | False [@as false]
+  | True [@as true]
+  | Null [@as null]
+  | String of string
+  | Number of float
+  | Object of t Js.Dict.t
+  | Array of t array
+[@@unboxed]
 (** The JSON data structure *)
 
 (** Underlying type of a JSON value *)

--- a/jscomp/others/js_null.ml
+++ b/jscomp/others/js_null.ml
@@ -25,7 +25,10 @@
 (** Provides functionality for dealing with the `'a Js.null` type *)
 
 
-type + 'a t = 'a Js.null
+type + 'a t = 'a Js.null =
+  | Value of 'a
+  | Null [@as null]
+[@@unboxed]
 
 external to_opt : 'a t -> 'a option = "#null_to_opt"
 external toOption : 'a t -> 'a option = "#null_to_opt"

--- a/jscomp/others/js_null.mli
+++ b/jscomp/others/js_null.mli
@@ -26,7 +26,10 @@
 
 (** Provides functionality for dealing with the `Js.null('a)` type *)
 
-type +'a t = 'a Js.null
+type +'a t = 'a Js.null =
+  | Value of 'a
+  | Null [@as null]
+[@@unboxed]
 (** Local alias for `Js.null('a)` *)
 
 external return : 'a -> 'a t = "%identity"

--- a/jscomp/others/js_null_undefined.ml
+++ b/jscomp/others/js_null_undefined.ml
@@ -25,7 +25,7 @@
 (** Contains functionality for dealing with values that can be both `null` and `undefined` *)
 
 type + 'a t = 'a Js.nullable = 
-  | Present of 'a
+  | Value of 'a
   | Null [@as null]
   | Undefined [@as undefined]
 [@@unboxed]

--- a/jscomp/others/js_null_undefined.ml
+++ b/jscomp/others/js_null_undefined.ml
@@ -24,7 +24,12 @@
 
 (** Contains functionality for dealing with values that can be both `null` and `undefined` *)
 
-type + 'a t = 'a Js.nullable
+type + 'a t = 'a Js.nullable = 
+  | Present of 'a
+  | Null [@as null]
+  | Undefined [@as undefined]
+[@@unboxed]
+
 external toOption : 'a t -> 'a option = "#nullable_to_opt"
 external to_opt : 'a t -> 'a option = "#nullable_to_opt"
 external return : 'a -> 'a t = "%identity"

--- a/jscomp/others/js_null_undefined.mli
+++ b/jscomp/others/js_null_undefined.mli
@@ -24,7 +24,11 @@
 
 (** Contains functionality for dealing with values that can be both `null` and `undefined` *)
 
-type +'a t = 'a Js.null_undefined
+type +'a t = 'a Js.nullable = 
+  | Present of 'a
+  | Null [@as null]
+  | Undefined [@as undefined]
+[@@unboxed]
 (** Local alias for `Js.null_undefined('a)`. *)
 
 external return : 'a -> 'a t = "%identity"

--- a/jscomp/others/js_null_undefined.mli
+++ b/jscomp/others/js_null_undefined.mli
@@ -25,7 +25,7 @@
 (** Contains functionality for dealing with values that can be both `null` and `undefined` *)
 
 type +'a t = 'a Js.nullable = 
-  | Present of 'a
+  | Value of 'a
   | Null [@as null]
   | Undefined [@as undefined]
 [@@unboxed]

--- a/jscomp/others/release.ninja
+++ b/jscomp/others/release.ninja
@@ -32,7 +32,7 @@ o others/js_float.cmi others/js_float.cmj : cc others/js_float.ml | others/belt_
 o others/js_global.cmi others/js_global.cmj : cc others/js_global.ml | others/belt_internals.cmi others/js.cmi $bsc
 o others/js_int.cmi others/js_int.cmj : cc others/js_int.ml | others/belt_internals.cmi others/js.cmi $bsc
 o others/js_json.cmj : cc_cmi others/js_json.ml | others/belt_internals.cmi others/js.cmi others/js.cmj others/js_array2.cmj others/js_dict.cmj others/js_json.cmi others/js_string.cmj others/js_types.cmj $bsc
-o others/js_json.cmi : cc others/js_json.mli | others/belt_internals.cmi others/js.cmi others/js_dict.cmi others/js_null.cmi others/js_string.cmj others/js_types.cmi $bsc
+o others/js_json.cmi : cc others/js_json.mli | others/belt_internals.cmi others/js.cmi others/js.cmj others/js_dict.cmi others/js_null.cmi others/js_string.cmj others/js_types.cmi $bsc
 o others/js_list.cmj : cc_cmi others/js_list.ml | others/belt_internals.cmi others/js.cmi others/js_array2.cmj others/js_list.cmi others/js_vector.cmj $bsc
 o others/js_list.cmi : cc others/js_list.mli | others/belt_internals.cmi others/js.cmi $bsc
 o others/js_map.cmi others/js_map.cmj : cc others/js_map.ml | others/belt_internals.cmi others/js.cmi $bsc

--- a/jscomp/runtime/js.ml
+++ b/jscomp/runtime/js.ml
@@ -57,7 +57,10 @@ end
 (**/**)
 
 
-type + 'a null
+type + 'a null =
+  | Value of 'a
+  | Null [@as null]
+[@@unboxed]
 (** nullable, value of this type can be either [null] or ['a]
     this type is the same as type [t] in {!Null}
 *)
@@ -67,7 +70,7 @@ type + 'a undefined
     this type is the same as type [t] in {!Undefined}  *)
 
 type + 'a nullable =
-  | Present of 'a
+  | Value of 'a
   | Null [@as null]
   | Undefined [@as undefined]
 [@@unboxed]

--- a/jscomp/runtime/js.ml
+++ b/jscomp/runtime/js.ml
@@ -66,7 +66,11 @@ type + 'a undefined
 (** value of this type can be either [undefined] or ['a]
     this type is the same as type [t] in {!Undefined}  *)
 
-type + 'a nullable
+type + 'a nullable =
+  | Present of 'a
+  | Null [@as null]
+  | Undefined [@as undefined]
+[@@unboxed]
 (** value of this type can be [undefined], [null] or ['a]
     this type is the same as type [t] n {!Null_undefined} *)
 

--- a/jscomp/test/custom_error_test.js
+++ b/jscomp/test/custom_error_test.js
@@ -2,7 +2,6 @@
 'use strict';
 
 var Js_exn = require("../../lib/js/js_exn.js");
-var Caml_option = require("../../lib/js/caml_option.js");
 var Caml_js_exceptions = require("../../lib/js/caml_js_exceptions.js");
 
 function test_js_error(param) {
@@ -18,7 +17,7 @@ function test_js_error(param) {
     }
     throw err;
   }
-  return Caml_option.some(e);
+  return e;
 }
 
 function test_js_error2(param) {
@@ -48,12 +47,12 @@ function example1(param) {
     }
     throw err;
   }
-  return Caml_option.some(v);
+  return v;
 }
 
 function example2(param) {
   try {
-    return Caml_option.some(JSON.parse(" {\"x\"}"));
+    return JSON.parse(" {\"x\"}");
   }
   catch (raw_exn){
     var exn = Caml_js_exceptions.internalToOCamlException(raw_exn);

--- a/jscomp/test/js_json_test.js
+++ b/jscomp/test/js_json_test.js
@@ -81,7 +81,7 @@ add_test("File \"js_json_test.res\", line 22, characters 11-18", (function (para
                   _0: false
                 };
         }
-        var ty2 = Js_json.classify(Caml_option.valFromOption(v$1));
+        var ty2 = Js_json.classify(v$1);
         if (typeof ty2 !== "object") {
           return {
                   TAG: "Ok",


### PR DESCRIPTION
This changes 3 type definitions in the stdlib:
1. `Js.Json.t` is now an untagged variant representing valid JSON
2. `Js.nullable` is now an untagged variant representing `Value('a) | Null | Undefined`
3. `Js.null` is now an untagged variant representing `Value('a) | Null`

I'm trying to do as little as possible here, and the rest will be done in `Core`. But, in order to be able to make using these types smooth, I'd like the source definitions to be in here so it can be reused everywhere.

I've opted to only do `nullable` in the global `Js` scope of all of the nullable types (`null`, `undefined` etc). I'm very much open to feedback here, but my reasoning is that that's the most important one, and having multiple definitions with `Value`/`Null`/`Undefined` constructors is going to create a headache inference wise. Choosing just one should let us expose it in the global scope (which will be very useful for interop) without causing headaches.

Changelog coming as soon as we agree this is a good plan.

cc @cristianoc 