### PR TITLE
Bool as unboxed variant payload

### DIFF
--- a/jscomp/core/js_exp_make.ml
+++ b/jscomp/core/js_exp_make.ml
@@ -770,6 +770,7 @@ let tag_type = function
   | Untagged IntType -> str "number"
   | Untagged FloatType -> str "number"
   | Untagged StringType -> str "string"
+  | Untagged BoolType -> str "boolean"
   | Untagged ArrayType -> str "Array" ~delim:DNoQuotes
   | Untagged ObjectType -> str "object"
   | Untagged UnknownType ->

--- a/jscomp/test/UntaggedVariants.js
+++ b/jscomp/test/UntaggedVariants.js
@@ -145,6 +145,8 @@ function classify$4(x) {
         return "string";
     case "number" :
         return "int";
+    case "boolean" :
+        return "bool";
     case "object" :
         return "Object" + x.name;
     

--- a/jscomp/test/UntaggedVariants.res
+++ b/jscomp/test/UntaggedVariants.res
@@ -110,12 +110,13 @@ module MultipleBlocks = {
 
 module OnlyBlocks = {
   @unboxed
-  type t<'a> = String(string) | Int(int) | Object({name: string})
+  type t<'a> = String(string) | Int(int) | Boolean(bool) | Object({name: string})
 
   let classify = x =>
     switch x {
     | String(_) => "string"
     | Int(_) => "int"
+    | Boolean(_) => "bool"
     | Object({name}) => "Object" ++ name
     }
 }


### PR DESCRIPTION
`bool` didn't seem to be implemented for unboxed variants. This PR is trying to enable this:

```rescript
@unboxed type value = String(string) | Boolean(bool) | Number(float)
```

Not sure if this is correct, looking for some guidance @cristianoc .