### PR TITLE
Fix option unboxing logic in the presence of untagged variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 #### :bug: Bug Fix
 
 - Remove unnecessary require and import statements when using dynamic imports. https://github.com/rescript-lang/rescript-compiler/pull/6232
+- Fix option unboxing logic in the presence of untagged variants. https://github.com/rescript-lang/rescript-compiler/pull/6233
 
 #### :nail_care: Polish
 

--- a/jscomp/ml/matching.ml
+++ b/jscomp/ml/matching.ml
@@ -1345,7 +1345,7 @@ let make_constr_matching p def ctx = function
                                  [ {
                                    pat_type ; pat_env
                                  } ])
-                  when Typeopt.cannot_inhabit_none_like_value pat_type pat_env
+                  when Typeopt.type_cannot_contain_undefined pat_type pat_env
                   -> val_from_unnest_option_bs_primitive
                 | _ -> val_from_option_bs_primitive in 
               (Lprim (from_option, [arg], p.pat_loc), Alias) :: argl

--- a/jscomp/ml/translcore.ml
+++ b/jscomp/ml/translcore.ml
@@ -839,7 +839,7 @@ and transl_exp0 (e : Typedtree.expression) : Lambda.lambda =
               if Datarepr.constructor_has_optional_shape cstr then
                 match args with
                 | [ arg ]
-                  when Typeopt.cannot_inhabit_none_like_value arg.exp_type
+                  when Typeopt.type_cannot_contain_undefined arg.exp_type
                          arg.exp_env ->
                     (* Format.fprintf Format.err_formatter "@[special boxingl@]@."; *)
                     Blk_some_not_nested

--- a/jscomp/ml/typeopt.mli
+++ b/jscomp/ml/typeopt.mli
@@ -34,7 +34,7 @@ val classify_lazy_argument : Typedtree.expression ->
                              | `Identifier of [`Forward_value | `Other]
                              | `Other]
 
-val cannot_inhabit_none_like_value:
+val type_cannot_contain_undefined:
   Types.type_expr ->
   Env.t -> 
   bool

--- a/jscomp/test/UntaggedVariants.js
+++ b/jscomp/test/UntaggedVariants.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var Caml_array = require("../../lib/js/caml_array.js");
+var Caml_option = require("../../lib/js/caml_option.js");
 
 function classify(x) {
   if (x === "A" && typeof x !== "number") {
@@ -318,6 +319,49 @@ var ArrayAndObject = {
   classify: classify$8
 };
 
+function testHasNull(x) {
+  return x;
+}
+
+function testHasUndefined(x) {
+  return Caml_option.some(x);
+}
+
+function untaggedWithOptionPayload(x) {
+  return Caml_option.some(x);
+}
+
+function untaggedWithIntPayload(x) {
+  return x;
+}
+
+function untaggedInlineNoOptions(x) {
+  return x;
+}
+
+function untaggedInlineUnaryWihtExplicitOption(x) {
+  return Caml_option.some(x);
+}
+
+function untaggedInlineUnaryWihtImplicitOption(x) {
+  return Caml_option.some(x);
+}
+
+function untaggedInlineMultinaryOption(x) {
+  return x;
+}
+
+var OptionUnboxingHeuristic = {
+  testHasNull: testHasNull,
+  testHasUndefined: testHasUndefined,
+  untaggedWithOptionPayload: untaggedWithOptionPayload,
+  untaggedWithIntPayload: untaggedWithIntPayload,
+  untaggedInlineNoOptions: untaggedInlineNoOptions,
+  untaggedInlineUnaryWihtExplicitOption: untaggedInlineUnaryWihtExplicitOption,
+  untaggedInlineUnaryWihtImplicitOption: untaggedInlineUnaryWihtImplicitOption,
+  untaggedInlineMultinaryOption: untaggedInlineMultinaryOption
+};
+
 var i = 42;
 
 var i2 = 42.5;
@@ -357,4 +401,5 @@ exports.OverlapNumber = OverlapNumber;
 exports.OverlapObject = OverlapObject;
 exports.RecordIsObject = RecordIsObject;
 exports.ArrayAndObject = ArrayAndObject;
+exports.OptionUnboxingHeuristic = OptionUnboxingHeuristic;
 /* l2 Not a pure module */

--- a/jscomp/test/UntaggedVariants.res
+++ b/jscomp/test/UntaggedVariants.res
@@ -261,3 +261,35 @@ module ArrayAndObject = {
     | Array(a) => a[0]
     }
 }
+
+module OptionUnboxingHeuristic = {
+  type hasNull = | @as(null) Null | B(int)
+  let testHasNull = (x: hasNull) => Some(x)
+
+  type hasUndefined = | @as(undefined) Undefined | B(int)
+  let testHasUndefined = (x: hasUndefined) => Some(x)
+
+  @unboxed
+  type untaggedWithOptionPayload = A | B(option<string>)
+  let untaggedWithOptionPayload = (x: untaggedWithOptionPayload) => Some(x)
+
+  @unboxed
+  type untaggedWithIntPayload = A | B(int)
+  let untaggedWithIntPayload = (x: untaggedWithIntPayload) => Some(x)
+
+  @unboxed
+  type untaggedInlineNoOption = A | B({x: int})
+  let untaggedInlineNoOptions = (x: untaggedInlineNoOption) => Some(x)
+
+  @unboxed
+  type untaggedInlineUnaryWihtExplicitOption = A | B({x: option<int>})
+  let untaggedInlineUnaryWihtExplicitOption = (x: untaggedInlineUnaryWihtExplicitOption) => Some(x)
+
+  @unboxed
+  type untaggedInlineUnaryWihtImplicitOption = A | B({x?: int})
+  let untaggedInlineUnaryWihtImplicitOption = (x: untaggedInlineUnaryWihtImplicitOption) => Some(x)
+
+  @unboxed
+  type untaggedInlineMultinaryOption = A | B({x: option<int>, y?: string})
+  let untaggedInlineMultinaryOption = (x: untaggedInlineMultinaryOption) => Some(x)
+}


### PR DESCRIPTION
The compiler's logic for unboxing options assumes that variant types cannot hold the `undefined` value.
This PR updates the logic taking into account the custom representation and untagged.

Fixes https://github.com/rescript-lang/rescript-compiler/issues/6222