### PR TITLE
Remove stalebot exemptions

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -3,30 +3,8 @@ daysUntilStale: 720
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7
 # Issues with these labels will never be considered stale
-exemptLabels:
-  - "PRIORITY:HIGH"
-  - bug
-  - non-critical-bug
-  - security
-  - enhancement
-  - optimization
-  - v8-breaking-changes
-  - documentation
-  - "need feedback"
-  - "GOOD FIRST TASK"
-  - "BREAKING CHANGES"
-  - APPROVED
-  - discussion
-  - BUILD
-  - "help wanted"
-  - "GOOD FOR PR"
-  - "TO REPRODUCE"
-  - FFI
-  - internal
-  - ideas
-  - playground
-  - Syntax
-  - test
+# exemptLabels:
+#   - test
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
This repo has stalebot configured to mark issues older than 720 days as stale and then close them after 7 days of inactivity.

However, there is a long list of exempt labels defined that causes obsolete issues from as early as 2016 to still remain open.

This PR removes that exempt labels list.