### PR TITLE
Deprecate -bs-super-errors flag for backward compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 #### :boom: Breaking Change
 
-- `-bs-super-errors` flag has been removed along with Super_errors. https://github.com/rescript-lang/rescript-compiler/pull/6199
+- `-bs-super-errors` flag has been deprecated along with Super_errors. https://github.com/rescript-lang/rescript-compiler/pull/6243
 
 #### :bug: Bug Fix
 

--- a/jscomp/bsc/rescript_compiler_main.ml
+++ b/jscomp/bsc/rescript_compiler_main.ml
@@ -292,6 +292,9 @@ let buckle_script_flags : (string * Bsc_args.spec * string) array =
 
     (******************************************************************************)
 
+    "-bs-super-errors", unit_call (fun _ -> ()),
+    "*deprecated* Better error message combined with other tools ";
+
     "-unboxed-types", set Clflags.unboxed_types,
     "*internal* Unannotated unboxable types will be unboxed";
 


### PR DESCRIPTION
Fixes #6242 
Related #6199 

This PR revives the compiler's `-bs-super-errors` flag and deprecates it. Actually, it can be called a deprecation of the flag because super_errors is removed but merged into normal errors. This allows you to avoid build errors if your dependent packages still use that flag.