### PR TITLE
Build playground compiler in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,22 @@ jobs:
         if: runner.os == 'Windows'
         run: node scripts/ciTest.js -mocha -theme -format
 
+      # Build the playground compiler on our fastest runner (macOS ARM)
+      - name: Install JSOO
+        if: matrix.os == 'macos-arm'
+        run: opam install js_of_ocaml.4.0.0
+
+      - name: Build playground compiler
+        if: matrix.os == 'macos-arm'
+        run: |
+          opam exec -- node packages/playground-bundling/scripts/generate_cmijs.js
+          opam exec -- dune build --profile browser
+          cp ./_build/default/jscomp/jsoo/jsoo_playground_main.bc.js playground/compiler.js
+
+      - name: Test playground compiler
+        if: matrix.os == 'macos-arm'
+        run: node playground/playground_test.js
+
       - name: Prepare artifact upload
         run: node .github/workflows/get_artifact_info.js
 

--- a/jscomp/core/js_name_of_module_id.ml
+++ b/jscomp/core/js_name_of_module_id.ml
@@ -25,7 +25,22 @@
 let (=)  (x : int) (y:float) = assert false 
 *)
 
+#ifdef BROWSER
 
+let string_of_module_id_in_browser (x : Lam_module_ident.t) =  
+  match x.kind with
+  | External {name} -> name
+  | Runtime | Ml -> 
+    "./stdlib/" ^  Ext_string.uncapitalize_ascii x.id.name ^ ".js"
+
+let string_of_module_id 
+    (id : Lam_module_ident.t)
+    ~output_dir:(_:string)
+    (_module_system : Js_packages_info.module_system)
+  = string_of_module_id_in_browser id
+
+#else
+  
 let (//) = Filename.concat 
 
 
@@ -86,8 +101,6 @@ let get_runtime_module_path
            | Some path -> 
              path //dep_path // js_file 
           )  
-
-
 
 (* [output_dir] is decided by the command line argument *)
 let string_of_module_id 
@@ -187,18 +200,4 @@ let string_of_module_id
           | None -> 
             Bs_exception.error (Js_not_found js_file))
 
-
-
-(* Override it in browser *)
-#ifdef BROWSER
-let string_of_module_id_in_browser (x : Lam_module_ident.t) =  
-  match x.kind with
-  | External {name} -> name
-  | Runtime | Ml -> 
-    "./stdlib/" ^  Ext_string.uncapitalize_ascii x.id.name ^ ".js"
-let string_of_module_id 
-    (id : Lam_module_ident.t)
-    ~output_dir:(_:string)
-    (_module_system : Js_packages_info.module_system)
-  = string_of_module_id_in_browser id
 #endif

--- a/jscomp/ml/cmt_format.ml
+++ b/jscomp/ml/cmt_format.ml
@@ -13,7 +13,10 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Cmi_format
+#ifdef BROWSER
+[@@@warning "-32"]
+#endif
+
 open Typedtree
 
 (* Note that in Typerex, there is an awful hack to save a cmt file
@@ -164,10 +167,12 @@ let record_value_dependency vd1 vd2 =
   if vd1.Types.val_loc <> vd2.Types.val_loc then
     value_deps := (vd1, vd2) :: !value_deps
 
-let save_cmt filename modname binary_annots sourcefile initial_env cmi =
 #ifdef BROWSER
-  ()  
-#else  
+let save_cmt _filename _modname _binary_annots _sourcefile _initial_env _cmi = ()  
+#else
+open Cmi_format
+
+let save_cmt filename modname binary_annots sourcefile initial_env cmi =
   if !Clflags.binary_annotations then begin
     (if !Config.bs_only then Misc.output_to_bin_file_directly else 
     Misc.output_to_file_via_temporary


### PR DESCRIPTION
This fixes some warnings for the playground compiler build and adds it to CI to prevent breakage of the playground build in the future.

It does not automatically run the upload to the CDN yet. (Still to be discussed under what conditions this should be run.)