### PR TITLE
Fix issue where uncurried type internals leak in type error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
 
 - Introduced a new `%ffi` extension that provides a more robust mechanism for JavaScript function interoperation by considering function arity in type constraints. This enhancement improves safety when dealing with JavaScript functions by enforcing type constraints based on the arity of the function. [PR #6251](https://github.com/rescript-lang/rescript-compiler/pull/6251)
 
+#### :bug: Bug Fix
+
+- Fix issue where uncurried type internals leak in type error. https://github.com/rescript-lang/rescript-compiler/pull/6264
+
+
 # 11.0.0-beta.1
 
 #### :rocket: Main New Feature

--- a/jscomp/syntax/src/res_outcome_printer.ml
+++ b/jscomp/syntax/src/res_outcome_printer.ml
@@ -217,6 +217,9 @@ let rec printOutTypeDoc (outType : Outcometree.out_type) =
     ->
     (* function$<(int, int) => int, [#2]> -> (. int, int) => int *)
     printOutArrowType ~uncurried:true arrowType
+  | Otyp_constr (Oide_ident "function$", [Otyp_var _; _arity]) ->
+    (* function$<'a, arity> -> _ => _ *)
+    printOutTypeDoc (Otyp_stuff "_ => _")
   | Otyp_constr (outIdent, []) -> printOutIdentDoc ~allowUident:false outIdent
   | Otyp_manifest (typ1, typ2) ->
     Doc.concat [printOutTypeDoc typ1; Doc.text " = "; printOutTypeDoc typ2]


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-compiler/issues/6263

```res
  We've found a bug for you!
  tst.res:4:13-22

  2 │ 
  3 │ let foo = (x: array<_>) => ()
  4 │ let x = foo(a => a + 1)
  5 │ 

  This has type: _ => _
  Somewhere wanted: array<'b>
```