### PR TITLE
Untagged variants: consider regexp as an object type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 # 11.0.0-beta.3 (Unreleased)
 
+#### :rocket: New Feature
+- Untagged variants: consider regexp as an object type. https://github.com/rescript-lang/rescript-compiler/pull/6296
+
 # 11.0.0-beta.2
 
 #### :rocket: New Feature

--- a/jscomp/ml/ast_untagged_variants.ml
+++ b/jscomp/ml/ast_untagged_variants.ml
@@ -117,7 +117,7 @@ let type_is_builtin_object (t : Types.type_expr) =
   match t.desc with
   | Tconstr (path, _, _) ->
     let name = Path.name path in
-    name = "Js.Dict.t" || name = "Js_dict.t"
+    name = "Js.Dict.t" || name = "Js_dict.t" || name = "Js.Re.t" || name = "RescriptCore.Re.t"
   | _ -> false
 
 let get_block_type ~env (cstr : Types.constructor_declaration) :


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-compiler/issues/6140