### PR TITLE
ensure trailing comma is never printed after ... for partial application

### DIFF
--- a/jscomp/syntax/src/res_printer.ml
+++ b/jscomp/syntax/src/res_printer.ml
@@ -4018,7 +4018,7 @@ and printPexpApply ~state expr cmtTbl =
           argsDoc;
         ]
     else
-      let argsDoc = printArguments ~state ~dotted args cmtTbl in
+      let argsDoc = printArguments ~state ~dotted ~partial args cmtTbl in
       Doc.concat [printAttributes ~state attrs cmtTbl; callExprDoc; argsDoc]
   | _ -> assert false
 
@@ -4524,7 +4524,7 @@ and printArgumentsWithCallbackInLastPosition ~state ~dotted args cmtTbl =
         Lazy.force breakAllArgs;
       ]
 
-and printArguments ~state ~dotted
+and printArguments ~state ~dotted ?(partial = false)
     (args : (Asttypes.arg_label * Parsetree.expression) list) cmtTbl =
   match args with
   | [
@@ -4564,7 +4564,7 @@ and printArguments ~state ~dotted
                     ~sep:(Doc.concat [Doc.comma; Doc.line])
                     (List.map (fun arg -> printArgument ~state arg cmtTbl) args);
                 ]);
-           Doc.trailingComma;
+           (if partial then Doc.nil else Doc.trailingComma);
            Doc.softLine;
            Doc.rparen;
          ])

--- a/jscomp/syntax/tests/printer/expr/UncurriedByDefault.res
+++ b/jscomp/syntax/tests/printer/expr/UncurriedByDefault.res
@@ -159,3 +159,20 @@ let aU = (() => "foo")->Ok
 Ok("_")->Belt.Result.map(concatStrings(_, "foo"))
 
 let ptl1 =  add(1, ...)
+
+let fn = (
+  i,
+  ~hello,
+  ~moreGoesHere,
+  ~provikingMultilineFormattingaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+) => {
+  i + hello + moreGoesHere + provikingMultilineFormattingaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+}
+
+let partial =
+  fn(
+    ~hello=1,
+    ~moreGoesHere=1,
+    ~provikingMultilineFormattingaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=1,
+    ...
+  )

--- a/jscomp/syntax/tests/printer/expr/expected/UncurriedByDefault.res.txt
+++ b/jscomp/syntax/tests/printer/expr/expected/UncurriedByDefault.res.txt
@@ -159,3 +159,23 @@ let aU = (() => "foo")->Ok
 Ok("_")->Belt.Result.map(concatStrings(_, "foo"))
 
 let ptl1 = add(1, ...)
+
+let fn = (
+  i,
+  ~hello,
+  ~moreGoesHere,
+  ~provikingMultilineFormattingaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+) => {
+  i +
+  hello +
+  moreGoesHere +
+  provikingMultilineFormattingaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+}
+
+let partial =
+  fn(
+    ~hello=1,
+    ~moreGoesHere=1,
+    ~provikingMultilineFormattingaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=1,
+    ...
+  )


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-compiler/issues/6299

@cristianoc I'm not very familiar with the parser/printer, so I'm unsure whether this is a good/acceptable approach to solve the problem. Would appreciate some feedback on that.