### PR TITLE
Dynamic import in expression

### DIFF
--- a/jscomp/frontend/bs_builtin_ppx.ml
+++ b/jscomp/frontend/bs_builtin_ppx.ml
@@ -72,6 +72,19 @@ let pat_mapper (self : mapper) (p : Parsetree.pattern) =
     Ast_utf8_string_interp.transform_pat p s delim
   | _ -> default_pat_mapper self p
 
+let local_module_name =
+  let v = ref 0 in
+  fun () ->
+    incr v;
+    "local_" ^ string_of_int !v
+
+(* Unpack requires core_type package for type inference:
+   Generate a module type name eg. __Belt_List__*)
+let local_module_type_name txt =
+  "_"
+  ^ (Longident.flatten txt |> List.fold_left (fun ll l -> ll ^ "_" ^ l) "")
+  ^ "__"
+
 let expr_mapper ~async_context ~in_function_def (self : mapper)
     (e : Parsetree.expression) =
   let old_in_function_def = !in_function_def in
@@ -214,6 +227,19 @@ let expr_mapper ~async_context ~in_function_def (self : mapper)
      the attribute to the whole expression, in general, when shuffuling the ast
      it is very hard to place attributes correctly
   *)
+  | Pexp_letmodule
+      (lid, ({pmod_desc = Pmod_ident {txt}; pmod_attributes} as me), expr)
+    when Res_parsetree_viewer.hasAwaitAttribute pmod_attributes ->
+    let safe_module_type_name = local_module_type_name txt in
+    {
+      e with
+      pexp_desc =
+        Pexp_letmodule
+          ( lid,
+            Ast_await.create_await_module_expression
+              ~module_type_name:safe_module_type_name me,
+            expr );
+    }
   | _ -> default_expr_mapper self e
 
 let expr_mapper ~async_context ~in_function_def (self : mapper)
@@ -418,19 +444,6 @@ let structure_item_mapper (self : mapper) (str : Parsetree.structure_item) :
   | Pstr_attribute ({txt = "bs.config" | "config"}, _) -> str
   | _ -> default_mapper.structure_item self str
 
-let local_module_name =
-  let v = ref 0 in
-  fun () ->
-    incr v;
-    "local_" ^ string_of_int !v
-
-(* Unpack requires core_type package for type inference:
-   Generate a module type name eg. __Belt_List__*)
-let local_module_type_name txt =
-  "_"
-  ^ (Longident.flatten txt |> List.fold_left (fun ll l -> ll ^ "_" ^ l) "")
-  ^ "__"
-
 let expand_reverse (stru : Ast_structure.t) (acc : Ast_structure.t) :
     Ast_structure.t =
   if stru = [] then acc
@@ -532,6 +545,72 @@ let rec structure_mapper ~await_context (self : mapper) (stru : Ast_structure.t)
             };
       }
       :: structure_mapper ~await_context self rest
+    | Pstr_eval
+        ( {
+            pexp_desc =
+              Pexp_letmodule
+                ( _,
+                  ({pmod_desc = Pmod_ident {txt; loc}; pmod_attributes} as me),
+                  _ );
+          },
+          _ )
+      when Res_parsetree_viewer.hasAwaitAttribute pmod_attributes ->
+      let item = self.structure_item self item in
+      let safe_module_type_name = local_module_type_name txt in
+      let has_local_module_name =
+        Hashtbl.find_opt !await_context safe_module_type_name
+      in
+      (* module __Belt_List__ = module type of Belt.List *)
+      let module_type_decl =
+        match has_local_module_name with
+        | Some _ -> []
+        | None ->
+          let open Ast_helper in
+          Hashtbl.add !await_context safe_module_type_name safe_module_type_name;
+          [
+            Str.modtype ~loc
+              (Mtd.mk ~loc
+                 {txt = safe_module_type_name; loc}
+                 ~typ:(Mty.typeof_ ~loc me));
+          ]
+      in
+      module_type_decl @ (item :: structure_mapper ~await_context self rest)
+    | Pstr_value (_, vbs) ->
+      let item = self.structure_item self item in
+      let module_exprs =
+        vbs
+        |> List.filter_map (fun ({pvb_expr} : Parsetree.value_binding) ->
+               match pvb_expr.pexp_desc with
+               | Pexp_letmodule (_, ({pmod_attributes} as me), _)
+                 when Res_parsetree_viewer.hasAwaitAttribute pmod_attributes ->
+                 Some me
+               | _ -> None)
+      in
+      (* [ module __Belt_List__ = module type of Belt.List ] *)
+      let module_type_decls =
+        module_exprs
+        |> List.filter_map (fun ({pmod_desc} as me : Parsetree.module_expr) ->
+               match pmod_desc with
+               | Pmod_ident {txt; loc} -> (
+                 let safe_module_type_name = local_module_type_name txt in
+                 let has_local_module_name =
+                   Hashtbl.find_opt !await_context safe_module_type_name
+                 in
+
+                 match has_local_module_name with
+                 | Some _ -> None
+                 | None ->
+                   let open Ast_helper in
+                   Hashtbl.add !await_context safe_module_type_name
+                     safe_module_type_name;
+                   Some
+                     (Str.modtype ~loc
+                        (Mtd.mk ~loc
+                           {txt = safe_module_type_name; loc}
+                           ~typ:(Mty.typeof_ ~loc me))))
+               | _ -> None)
+      in
+      module_type_decls @ (item :: structure_mapper ~await_context self rest)
     | _ ->
       self.structure_item self item :: structure_mapper ~await_context self rest
     )

--- a/jscomp/syntax/tests/parsing/grammar/expressions/await.res
+++ b/jscomp/syntax/tests/parsing/grammar/expressions/await.res
@@ -28,3 +28,13 @@ let () = {
 let forEach = await @a @b Js.Import(Belt.List.forEach)
 
 module M = await @a @b Belt.List
+
+let f = () => {
+  module M = await @a @b Belt.List
+  M.forEach
+}
+
+let () = {
+  module M = await @a @b Belt.List
+  M.forEach
+}

--- a/jscomp/syntax/tests/parsing/grammar/expressions/expected/await.res.txt
+++ b/jscomp/syntax/tests/parsing/grammar/expressions/expected/await.res.txt
@@ -18,3 +18,8 @@ let () = ((((delay 10)[@res.await ]); ((delay 20)[@res.await ]))
   [@res.braces ])
 let forEach = ((Js.Import Belt.List.forEach)[@res.await ][@a ][@b ])
 module M = ((Belt.List)[@res.await ][@a ][@b ])
+let f () =
+  ((let module M = ((Belt.List)[@res.await ][@a ][@b ]) in M.forEach)
+  [@res.braces ])
+let () = ((let module M = ((Belt.List)[@res.await ][@a ][@b ]) in M.forEach)
+  [@res.braces ])

--- a/jscomp/test/Import.js
+++ b/jscomp/test/Import.js
@@ -2,7 +2,6 @@
 'use strict';
 
 var Curry = require("../../lib/js/curry.js");
-var Belt_List = require("../../lib/js/belt_List.js");
 
 async function eachIntAsync(list, f) {
   return Curry._2(await import("../../lib/js/belt_List.js").then(function (m) {
@@ -76,8 +75,8 @@ var M0 = await import("../../lib/js/belt_List.js");
 
 var M1 = await import("../../lib/js/belt_List.js");
 
-function f(param) {
-  return Belt_List.forEach;
+async function f(param) {
+  return (await import("../../lib/js/belt_List.js")).forEach;
 }
 
 var each = M1.forEach;

--- a/jscomp/test/Import.js
+++ b/jscomp/test/Import.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var Curry = require("../../lib/js/curry.js");
+var Belt_List = require("../../lib/js/belt_List.js");
 
 async function eachIntAsync(list, f) {
   return Curry._2(await import("../../lib/js/belt_List.js").then(function (m) {
@@ -75,6 +76,10 @@ var M0 = await import("../../lib/js/belt_List.js");
 
 var M1 = await import("../../lib/js/belt_List.js");
 
+function f(param) {
+  return Belt_List.forEach;
+}
+
 var each = M1.forEach;
 
 var M2;
@@ -91,4 +96,5 @@ exports.M1 = M1;
 exports.each = each;
 exports.M2 = M2;
 exports.each2 = each2;
+exports.f = f;
 /*  Not a pure module */

--- a/jscomp/test/Import.res
+++ b/jscomp/test/Import.res
@@ -37,3 +37,8 @@ let each = M1.forEach
 
 module M2 = N.N1.O
 let each2 = M2.forEach
+
+let f = async () => {
+  module M3 = await Belt.List
+  M3.forEach
+}


### PR DESCRIPTION
Fixes #6300 

This PR fixes the issue #6300 that is formatting removes `await` keyword. This is not just a formatting issue, it's an issue because there is no transformation for when dynamic imports are used in expressions in addition to one of the structure_items, `Pstr_module`.

This PR add the transformation for `Pstr_eval` and `Pstr_value`.