### PR TITLE
Exploring variant-to-variant coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 > - :nail_care: [Polish]
 
 # 11.0.0-beta.4 (Unreleased)
+#### :rocket: New Feature
+- Variants: Allow coercing from variant to variant, where applicable. https://github.com/rescript-lang/rescript-compiler/pull/6314
 
 # 11.0.0-beta.3
 

--- a/jscomp/build_tests/super_errors/expected/variant_to_variant_coercion.res.expected
+++ b/jscomp/build_tests/super_errors/expected/variant_to_variant_coercion.res.expected
@@ -1,0 +1,10 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/variant_to_variant_coercion.res[0m:[2m6:10-15[0m
+
+  4 [2m│[0m let x: x = One(true)
+  5 [2m│[0m 
+  [1;31m6[0m [2m│[0m let y = ([1;31mx :> y[0m)
+  7 [2m│[0m 
+
+  Type x is not a subtype of y

--- a/jscomp/build_tests/super_errors/expected/variant_to_variant_coercion_as.res.expected
+++ b/jscomp/build_tests/super_errors/expected/variant_to_variant_coercion_as.res.expected
@@ -1,0 +1,10 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/variant_to_variant_coercion_as.res[0m:[2m6:10-15[0m
+
+  4 [2m│[0m let x: x = One(true)
+  5 [2m│[0m 
+  [1;31m6[0m [2m│[0m let y = ([1;31mx :> y[0m)
+  7 [2m│[0m 
+
+  Type x is not a subtype of y

--- a/jscomp/build_tests/super_errors/expected/variant_to_variant_coercion_tag.res.expected
+++ b/jscomp/build_tests/super_errors/expected/variant_to_variant_coercion_tag.res.expected
@@ -1,0 +1,10 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/variant_to_variant_coercion_tag.res[0m:[2m6:10-15[0m
+
+  4 [2m│[0m let x: x = One(true)
+  5 [2m│[0m 
+  [1;31m6[0m [2m│[0m let y = ([1;31mx :> y[0m)
+  7 [2m│[0m 
+
+  Type x is not a subtype of y

--- a/jscomp/build_tests/super_errors/expected/variant_to_variant_coercion_unboxed.res.expected
+++ b/jscomp/build_tests/super_errors/expected/variant_to_variant_coercion_unboxed.res.expected
@@ -1,0 +1,10 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/variant_to_variant_coercion_unboxed.res[0m:[2m6:10-15[0m
+
+  4 [2m│[0m let x: x = One(true)
+  5 [2m│[0m 
+  [1;31m6[0m [2m│[0m let y = ([1;31mx :> y[0m)
+  7 [2m│[0m 
+
+  Type x is not a subtype of y

--- a/jscomp/build_tests/super_errors/fixtures/variant_to_variant_coercion.res
+++ b/jscomp/build_tests/super_errors/fixtures/variant_to_variant_coercion.res
@@ -1,0 +1,6 @@
+type x = One(bool) | Two
+type y = One(string) | Two
+
+let x: x = One(true)
+
+let y = (x :> y)

--- a/jscomp/build_tests/super_errors/fixtures/variant_to_variant_coercion_as.res
+++ b/jscomp/build_tests/super_errors/fixtures/variant_to_variant_coercion_as.res
@@ -1,0 +1,6 @@
+type x = | @as("one") One(bool) | Two(string)
+type y = One(bool) | Two(string)
+
+let x: x = One(true)
+
+let y = (x :> y)

--- a/jscomp/build_tests/super_errors/fixtures/variant_to_variant_coercion_tag.res
+++ b/jscomp/build_tests/super_errors/fixtures/variant_to_variant_coercion_tag.res
@@ -1,0 +1,6 @@
+@tag("kind") type x = One(bool) | Two(string)
+type y = One(bool) | Two(string)
+
+let x: x = One(true)
+
+let y = (x :> y)

--- a/jscomp/build_tests/super_errors/fixtures/variant_to_variant_coercion_unboxed.res
+++ b/jscomp/build_tests/super_errors/fixtures/variant_to_variant_coercion_unboxed.res
@@ -1,0 +1,6 @@
+@unboxed type x = One(bool) | Two
+type y = One(bool) | Two
+
+let x: x = One(true)
+
+let y = (x :> y)

--- a/jscomp/core/matching_polyfill.ml
+++ b/jscomp/core/matching_polyfill.ml
@@ -22,6 +22,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
+let () = Ast_untagged_variants.extract_concrete_typedecl := Ctype.extract_concrete_typedecl
+
 let names_from_construct_pattern (pat : Typedtree.pattern) =
   let rec resolve_path n (path : Path.t) =
     match Env.find_type path pat.pat_env with

--- a/jscomp/ml/ast_uncurried.ml
+++ b/jscomp/ml/ast_uncurried.ml
@@ -69,12 +69,7 @@ let coreTypeIsUncurriedFun (typ : Parsetree.core_type) =
     true
   | _ -> false
 
-let typeIsUncurriedFun (typ : Types.type_expr) =
-  match typ.desc with
-  | Tconstr (Pident {name = "function$"}, [{desc = Tarrow _}; _], _) ->
-    true
-  | _ -> false
-
+let typeIsUncurriedFun = Ast_uncurried_utils.typeIsUncurriedFun
 
 let typeExtractUncurriedFun (typ : Parsetree.core_type) =
   match typ.ptyp_desc with

--- a/jscomp/ml/ast_uncurried_utils.ml
+++ b/jscomp/ml/ast_uncurried_utils.ml
@@ -1,0 +1,5 @@
+let typeIsUncurriedFun (typ : Types.type_expr) =
+  match typ.desc with
+  | Tconstr (Pident {name = "function$"}, [{desc = Tarrow _}; _], _) ->
+    true
+  | _ -> false

--- a/jscomp/ml/ctype.ml
+++ b/jscomp/ml/ctype.ml
@@ -3952,10 +3952,10 @@ let rec subtype_rec env trace t1 t2 cstrs =
     | (Tconstr(p1, _, _), _) when generic_private_abbrev env p1 ->
         subtype_rec env trace (expand_abbrev_opt env t1) t2 cstrs
     | (Tconstr(_, [], _), Tconstr(path, [], _)) when Variant_coercion.can_coerce_path path && 
-        extract_concrete_typedecl env t1 |> Variant_coercion.is_variant_typedecl |> Option.is_some 
-        -> 
+        extract_concrete_typedecl env t1 |> Variant_coercion.can_try_coerce_variant_to_primitive |> Option.is_some
+        ->
       (* type coercion for variants to primitives *)
-      (match Variant_coercion.is_variant_typedecl (extract_concrete_typedecl env t1) with
+      (match Variant_coercion.can_try_coerce_variant_to_primitive (extract_concrete_typedecl env t1) with
       | Some constructors -> 
         if constructors |> Variant_coercion.can_coerce_variant ~path then
           cstrs

--- a/jscomp/ml/record_coercion.ml
+++ b/jscomp/ml/record_coercion.ml
@@ -1,0 +1,33 @@
+let check_record_fields ?repr1 ?repr2 (fields1 : Types.label_declaration list)
+    (fields2 : Types.label_declaration list) =
+  let field_is_optional id repr =
+    match repr with
+    | Some (Types.Record_optional_labels lbls) -> List.mem (Ident.name id) lbls
+    | _ -> false
+  in
+  let violation = ref false in
+  let label_decl_sub (acc1, acc2) (ld2 : Types.label_declaration) =
+    match
+      Ext_list.find_first fields1 (fun ld1 -> ld1.ld_id.name = ld2.ld_id.name)
+    with
+    | Some ld1 ->
+      if field_is_optional ld1.ld_id repr1 <> field_is_optional ld2.ld_id repr2
+      then (* optional field can't be modified *)
+        violation := true;
+      let get_as (({txt}, payload) : Parsetree.attribute) =
+        if txt = "as" then Ast_payload.is_single_string payload else None
+      in
+      let get_as_name (ld : Types.label_declaration) =
+        match Ext_list.filter_map ld.ld_attributes get_as with
+        | [] -> ld.ld_id.name
+        | (s, _) :: _ -> s
+      in
+      if get_as_name ld1 <> get_as_name ld2 then violation := true;
+      (ld1.ld_type :: acc1, ld2.ld_type :: acc2)
+    | None ->
+      (* field must be present *)
+      violation := true;
+      (acc1, acc2)
+  in
+  let tl1, tl2 = List.fold_left label_decl_sub ([], []) fields2 in
+  (!violation, tl1, tl2)

--- a/jscomp/ml/variant_coercion.ml
+++ b/jscomp/ml/variant_coercion.ml
@@ -40,10 +40,10 @@ let can_coerce_variant ~(path : Path.t)
   then true
   else false
 
-let is_variant_typedecl
-    ((_, _, typedecl) : Path.t * Path.t * Types.type_declaration) =
+let can_try_coerce_variant_to_primitive
+    ((_, p, typedecl) : Path.t * Path.t * Types.type_declaration) =
   match typedecl with
-  | {type_kind = Type_variant constructors} -> Some constructors
+  | {type_kind = Type_variant constructors; type_params=[]} when Path.name p <> "bool"-> Some constructors
   | _ -> None
 
 let variant_representation_matches (c1_attrs : Parsetree.attributes)

--- a/jscomp/ml/variant_coercion.ml
+++ b/jscomp/ml/variant_coercion.ml
@@ -1,12 +1,5 @@
 (* TODO: Improve error messages? Say why we can't coerce. *)
 
-let check_constructors (constructors : Types.constructor_declaration list) check
-    =
-  List.for_all
-    (fun (c : Types.constructor_declaration) ->
-      check c.cd_args (Ast_untagged_variants.process_tag_type c.cd_attributes))
-    constructors
-
 (* Right now we only allow coercing to primitives string/int/float *)
 let can_coerce_path (path : Path.t) =
   Path.same path Predef.path_string

--- a/jscomp/ml/variant_coercion.ml
+++ b/jscomp/ml/variant_coercion.ml
@@ -1,9 +1,12 @@
-let find_as_attribute_payload (attributes : Parsetree.attribute list) =
+let find_attribute_payload name (attributes : Parsetree.attribute list) =
   attributes
   |> List.find_map (fun (attr : Parsetree.attribute) ->
          match attr with
-         | {txt = "as"}, payload -> Some payload
+         | {txt}, payload when txt = name -> Some payload
          | _ -> None)
+
+let find_as_attribute_payload (attributes : Parsetree.attribute list) =
+  find_attribute_payload "as" attributes
 
 (* TODO: Improve error messages? Say why we can't coerce. *)
 
@@ -59,3 +62,59 @@ let is_variant_typedecl
   match typedecl with
   | {type_kind = Type_variant constructors} -> Some constructors
   | _ -> None
+
+let find_attribute_payload_as_string name attrs =
+  match find_attribute_payload name attrs with
+  | None -> None
+  | Some payload -> Ast_payload.is_single_string payload
+
+let variant_representation_matches (c1_attrs : Parsetree.attributes)
+    (c2_attrs : Parsetree.attributes) =
+  match
+    (find_as_attribute_payload c1_attrs, find_as_attribute_payload c2_attrs)
+  with
+  | None, None -> true
+  | Some p1, Some p2 -> (
+    let string_matches = match
+      (Ast_payload.is_single_string p1, Ast_payload.is_single_string p2)
+    with
+    | Some (a, _), Some (b, _) when a = b -> true
+    | _ -> false in
+    if string_matches then true else
+    let float_matches = match
+      (Ast_payload.is_single_float p1, Ast_payload.is_single_float p2)
+    with
+    | Some a, Some b when a = b -> true
+    | _ -> false in
+    if float_matches then true else
+    let int_matches = match
+      (Ast_payload.is_single_int p1, Ast_payload.is_single_int p2)
+    with
+    | Some a, Some b when a = b -> true
+    | _ -> false in
+    if int_matches then true else
+    false)
+  | _ -> false
+
+let variant_configuration_can_be_coerced (a1 : Parsetree.attributes)
+    (a2 : Parsetree.attributes) =
+  let unboxed =
+    match
+      (find_attribute_payload "unboxed" a1, find_attribute_payload "unboxed" a2)
+    with
+    | Some (PStr []), Some (PStr []) -> true
+    | None, None -> true
+    | _ -> false
+  in
+  if not unboxed then false
+  else
+    let tag =
+      match
+        ( find_attribute_payload_as_string "tag" a1,
+          find_attribute_payload_as_string "tag" a2 )
+      with
+      | Some (tag1, _), Some (tag2, _) when tag1 = tag2 -> true
+      | None, None -> true
+      | _ -> false
+    in
+    if not tag then false else true

--- a/jscomp/ml/variant_coercion.ml
+++ b/jscomp/ml/variant_coercion.ml
@@ -43,7 +43,9 @@ let can_coerce_variant ~(path : Path.t)
 let can_try_coerce_variant_to_primitive
     ((_, p, typedecl) : Path.t * Path.t * Types.type_declaration) =
   match typedecl with
-  | {type_kind = Type_variant constructors; type_params=[]} when Path.name p <> "bool"-> Some constructors
+  | {type_kind = Type_variant constructors; type_params = []}
+    when Path.name p <> "bool" ->
+    Some constructors
   | _ -> None
 
 let variant_representation_matches (c1_attrs : Parsetree.attributes)

--- a/jscomp/ml/variant_coercion.ml
+++ b/jscomp/ml/variant_coercion.ml
@@ -63,57 +63,32 @@ let is_variant_typedecl
   | {type_kind = Type_variant constructors} -> Some constructors
   | _ -> None
 
-let find_attribute_payload_as_string name attrs =
-  match find_attribute_payload name attrs with
-  | None -> None
-  | Some payload -> Ast_payload.is_single_string payload
-
 let variant_representation_matches (c1_attrs : Parsetree.attributes)
     (c2_attrs : Parsetree.attributes) =
   match
-    (find_as_attribute_payload c1_attrs, find_as_attribute_payload c2_attrs)
+    (Ast_untagged_variants.process_tag_type c1_attrs, Ast_untagged_variants.process_tag_type c2_attrs)
   with
   | None, None -> true
-  | Some p1, Some p2 -> (
-    let string_matches = match
-      (Ast_payload.is_single_string p1, Ast_payload.is_single_string p2)
-    with
-    | Some (a, _), Some (b, _) when a = b -> true
-    | _ -> false in
-    if string_matches then true else
-    let float_matches = match
-      (Ast_payload.is_single_float p1, Ast_payload.is_single_float p2)
-    with
-    | Some a, Some b when a = b -> true
-    | _ -> false in
-    if float_matches then true else
-    let int_matches = match
-      (Ast_payload.is_single_int p1, Ast_payload.is_single_int p2)
-    with
-    | Some a, Some b when a = b -> true
-    | _ -> false in
-    if int_matches then true else
-    false)
+  | Some s1, Some s2 when s1 = s2 -> true
   | _ -> false
 
 let variant_configuration_can_be_coerced (a1 : Parsetree.attributes)
     (a2 : Parsetree.attributes) =
   let unboxed =
     match
-      (find_attribute_payload "unboxed" a1, find_attribute_payload "unboxed" a2)
+      (Ast_untagged_variants.process_untagged a1, Ast_untagged_variants.process_untagged a2)
     with
-    | Some (PStr []), Some (PStr []) -> true
-    | None, None -> true
+    | true, true | false, false -> true
     | _ -> false
   in
   if not unboxed then false
   else
     let tag =
       match
-        ( find_attribute_payload_as_string "tag" a1,
-          find_attribute_payload_as_string "tag" a2 )
+        (Ast_untagged_variants.process_tag_name a1,
+          Ast_untagged_variants.process_tag_name a2 )
       with
-      | Some (tag1, _), Some (tag2, _) when tag1 = tag2 -> true
+      | Some (tag1), Some (tag2) when tag1 = tag2 -> true
       | None, None -> true
       | _ -> false
     in

--- a/jscomp/test/VariantCoercion.js
+++ b/jscomp/test/VariantCoercion.js
@@ -2,9 +2,16 @@
 'use strict';
 
 
+var x = {
+  kind: "One",
+  age: 1
+};
+
 var CoerceVariants = {
   a: 1.1,
-  b: 1.1
+  b: 1.1,
+  x: x,
+  y: x
 };
 
 var a = "Three";

--- a/jscomp/test/VariantCoercion.js
+++ b/jscomp/test/VariantCoercion.js
@@ -2,6 +2,11 @@
 'use strict';
 
 
+var CoerceVariants = {
+  a: 1.1,
+  b: 1.1
+};
+
 var a = "Three";
 
 var b = "Three";
@@ -20,4 +25,5 @@ exports.i = i;
 exports.d = d;
 exports.ii = ii;
 exports.dd = dd;
+exports.CoerceVariants = CoerceVariants;
 /* No side effect */

--- a/jscomp/test/VariantCoercion.res
+++ b/jscomp/test/VariantCoercion.res
@@ -15,3 +15,12 @@ type onlyFloats = | @as(1.1) Onef | @as(2.2) Twof | @as(3.3) Threef
 let ii = Onef
 
 let dd = (ii :> float)
+
+module CoerceVariants = {
+  type a = One(int) | @as(1.1) Two
+  type b = One(int) | @as(1.1) Two | Three
+
+  let a: a = Two
+
+  let b: b = (a :> b)
+}

--- a/jscomp/test/VariantCoercion.res
+++ b/jscomp/test/VariantCoercion.res
@@ -17,10 +17,16 @@ let ii = Onef
 let dd = (ii :> float)
 
 module CoerceVariants = {
-  type a = One(int) | @as(1.1) Two
-  type b = One(int) | @as(1.1) Two | Three
+  @unboxed type a = One(int) | @as(1.1) Two | @as(null) T2
+  @unboxed type b = One(int) | @as(1.1) Two | @as(null) T2 | Three
 
   let a: a = Two
 
   let b: b = (a :> b)
+
+  @tag("kind") type x = One({age: int, name?: string})
+  @tag("kind") type y = One({age: int, name?: string}) | Two({two: string})
+
+  let x: x = One({age: 1})
+  let y: y = (x :> y)
 }


### PR DESCRIPTION
Allow coercing between variants which have the same exact constructors. We need to ensure that the runtime representation exactly matches as we coerce. The following restrictions are therefore in place:
* Both variants must have the same configuration for @unboxed and @tag
* Each constructor pair must have the same configuration of @as