### PR TITLE
Fix shadowing Js.Json.t with type kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Variants: Allow coercing from variant to variant, where applicable. https://github.com/rescript-lang/rescript-compiler/pull/6314
 
 #### :boom: Breaking Change
-- Fixed the issue of name collision between the newly defined Js.Json.t and the variant constructor in the existing Js.Json.kind type. To address this, the usage of the existing Js.Json.kind type can be updated to Js.Json.Kind.s. https://github.com/rescript-lang/rescript-compiler/pull/6317
+- Fixed the issue of name collision between the newly defined Js.Json.t and the variant constructor in the existing Js.Json.kind type. To address this, the usage of the existing Js.Json.kind type can be updated to Js.Json.Kind.t. https://github.com/rescript-lang/rescript-compiler/pull/6317
 
 # 11.0.0-beta.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 #### :rocket: New Feature
 - Variants: Allow coercing from variant to variant, where applicable. https://github.com/rescript-lang/rescript-compiler/pull/6314
 
+#### :boom: Breaking Change
+- Fixed Js.Json.kind type shadowing Js.Json.t type: `type kind<_>` -> `type Kind.kind<_>` https://github.com/rescript-lang/rescript-compiler/pull/6317
+
 # 11.0.0-beta.3
 
 #### :rocket: New Feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Variants: Allow coercing from variant to variant, where applicable. https://github.com/rescript-lang/rescript-compiler/pull/6314
 
 #### :boom: Breaking Change
-- Fixed Js.Json.kind type shadowing Js.Json.t type: `type kind<_>` -> `type Kind.kind<_>` https://github.com/rescript-lang/rescript-compiler/pull/6317
+- Fixed the issue of name collision between the newly defined Js.Json.t and the variant constructor in the existing Js.Json.kind type. To address this, the usage of the existing Js.Json.kind type can be updated to Js.Json.Kind.s. https://github.com/rescript-lang/rescript-compiler/pull/6317
 
 # 11.0.0-beta.3
 

--- a/jscomp/others/js_json.res
+++ b/jscomp/others/js_json.res
@@ -35,13 +35,13 @@ type rec t =
   | Array(array<t>)
 
 module Kind = {
-  type rec s<_> =
-    | String: s<Js_string.t>
-    | Number: s<float>
-    | Object: s<Js_dict.t<t>>
-    | Array: s<array<t>>
-    | Boolean: s<bool>
-    | Null: s<Js_types.null_val>
+  type rec kind<_> =
+    | String: kind<Js_string.t>
+    | Number: kind<float>
+    | Object: kind<Js_dict.t<t>>
+    | Array: kind<array<t>>
+    | Boolean: kind<bool>
+    | Null: kind<Js_types.null_val>
 }
 
 type tagged_t =
@@ -74,7 +74,7 @@ let classify = (x: t): tagged_t => {
   }
 }
 
-let test = (type a, x: 'a, v: Kind.s<a>): bool =>
+let test = (type a, x: 'a, v: Kind.kind<a>): bool =>
   switch v {
   | Kind.Number => Js.typeof(x) == "number"
   | Kind.Boolean => Js.typeof(x) == "boolean"

--- a/jscomp/others/js_json.res
+++ b/jscomp/others/js_json.res
@@ -34,13 +34,15 @@ type rec t =
   | Object(Js.Dict.t<t>)
   | Array(array<t>)
 
-type rec kind<_> =
-  | String: kind<Js_string.t>
-  | Number: kind<float>
-  | Object: kind<Js_dict.t<t>>
-  | Array: kind<array<t>>
-  | Boolean: kind<bool>
-  | Null: kind<Js_types.null_val>
+module Kind = {
+  type rec kind<_> =
+    | String: kind<Js_string.t>
+    | Number: kind<float>
+    | Object: kind<Js_dict.t<t>>
+    | Array: kind<array<t>>
+    | Boolean: kind<bool>
+    | Null: kind<Js_types.null_val>
+}
 
 type tagged_t =
   | JSONFalse
@@ -72,14 +74,14 @@ let classify = (x: t): tagged_t => {
   }
 }
 
-let test = (type a, x: 'a, v: kind<a>): bool =>
+let test = (type a, x: 'a, v: Kind.kind<a>): bool =>
   switch v {
-  | Number => Js.typeof(x) == "number"
-  | Boolean => Js.typeof(x) == "boolean"
-  | String => Js.typeof(x) == "string"
-  | Null => Obj.magic(x) === Js.null
-  | Array => Js_array2.isArray(x)
-  | Object => Obj.magic(x) !== Js.null && (Js.typeof(x) == "object" && !Js_array2.isArray(x))
+  | Kind.Number => Js.typeof(x) == "number"
+  | Kind.Boolean => Js.typeof(x) == "boolean"
+  | Kind.String => Js.typeof(x) == "string"
+  | Kind.Null => Obj.magic(x) === Js.null
+  | Kind.Array => Js_array2.isArray(x)
+  | Kind.Object => Obj.magic(x) !== Js.null && (Js.typeof(x) == "object" && !Js_array2.isArray(x))
   }
 
 let decodeString = json =>

--- a/jscomp/others/js_json.res
+++ b/jscomp/others/js_json.res
@@ -35,13 +35,13 @@ type rec t =
   | Array(array<t>)
 
 module Kind = {
-  type rec kind<_> =
-    | String: kind<Js_string.t>
-    | Number: kind<float>
-    | Object: kind<Js_dict.t<t>>
-    | Array: kind<array<t>>
-    | Boolean: kind<bool>
-    | Null: kind<Js_types.null_val>
+  type rec s<_> =
+    | String: s<Js_string.t>
+    | Number: s<float>
+    | Object: s<Js_dict.t<t>>
+    | Array: s<array<t>>
+    | Boolean: s<bool>
+    | Null: s<Js_types.null_val>
 }
 
 type tagged_t =
@@ -74,7 +74,7 @@ let classify = (x: t): tagged_t => {
   }
 }
 
-let test = (type a, x: 'a, v: Kind.kind<a>): bool =>
+let test = (type a, x: 'a, v: Kind.s<a>): bool =>
   switch v {
   | Kind.Number => Js.typeof(x) == "number"
   | Kind.Boolean => Js.typeof(x) == "boolean"

--- a/jscomp/others/js_json.res
+++ b/jscomp/others/js_json.res
@@ -35,13 +35,14 @@ type rec t =
   | Array(array<t>)
 
 module Kind = {
-  type rec kind<_> =
-    | String: kind<Js_string.t>
-    | Number: kind<float>
-    | Object: kind<Js_dict.t<t>>
-    | Array: kind<array<t>>
-    | Boolean: kind<bool>
-    | Null: kind<Js_types.null_val>
+  type json = t
+  type rec t<_> =
+    | String: t<Js_string.t>
+    | Number: t<float>
+    | Object: t<Js_dict.t<json>>
+    | Array: t<array<json>>
+    | Boolean: t<bool>
+    | Null: t<Js_types.null_val>
 }
 
 type tagged_t =
@@ -74,7 +75,7 @@ let classify = (x: t): tagged_t => {
   }
 }
 
-let test = (type a, x: 'a, v: Kind.kind<a>): bool =>
+let test = (type a, x: 'a, v: Kind.t<a>): bool =>
   switch v {
   | Kind.Number => Js.typeof(x) == "number"
   | Kind.Boolean => Js.typeof(x) == "boolean"

--- a/jscomp/others/js_json.resi
+++ b/jscomp/others/js_json.resi
@@ -40,14 +40,16 @@ type rec t =
   | Object(Js.Dict.t<t>)
   | Array(array<t>)
 
-/** Underlying type of a JSON value */
-type rec kind<_> =
-  | String: kind<Js_string.t>
-  | Number: kind<float>
-  | Object: kind<Js_dict.t<t>>
-  | Array: kind<array<t>>
-  | Boolean: kind<bool>
-  | Null: kind<Js_types.null_val>
+module Kind: {
+  /** Underlying type of a JSON value */
+  type rec kind<_> =
+    | String: kind<Js_string.t>
+    | Number: kind<float>
+    | Object: kind<Js_dict.t<t>>
+    | Array: kind<array<t>>
+    | Boolean: kind<bool>
+    | Null: kind<Js_types.null_val>
+}
 
 type tagged_t =
   | JSONFalse
@@ -63,7 +65,7 @@ type tagged_t =
 let classify: t => tagged_t
 
 /** `test(v, kind)` returns `true` if `v` is of `kind`. */
-let test: ('a, kind<'b>) => bool
+let test: ('a, Kind.kind<'b>) => bool
 
 /** `decodeString(json)` returns `Some(s)` if `json` is a `string`, `None` otherwise. */
 let decodeString: t => option<Js_string.t>

--- a/jscomp/others/js_json.resi
+++ b/jscomp/others/js_json.resi
@@ -42,13 +42,13 @@ type rec t =
 
 module Kind: {
   /** Underlying type of a JSON value */
-  type rec s<_> =
-    | String: s<Js_string.t>
-    | Number: s<float>
-    | Object: s<Js_dict.t<t>>
-    | Array: s<array<t>>
-    | Boolean: s<bool>
-    | Null: s<Js_types.null_val>
+  type rec kind<_> =
+    | String: kind<Js_string.t>
+    | Number: kind<float>
+    | Object: kind<Js_dict.t<t>>
+    | Array: kind<array<t>>
+    | Boolean: kind<bool>
+    | Null: kind<Js_types.null_val>
 }
 
 type tagged_t =
@@ -65,7 +65,7 @@ type tagged_t =
 let classify: t => tagged_t
 
 /** `test(v, kind)` returns `true` if `v` is of `kind`. */
-let test: ('a, Kind.s<'b>) => bool
+let test: ('a, Kind.kind<'b>) => bool
 
 /** `decodeString(json)` returns `Some(s)` if `json` is a `string`, `None` otherwise. */
 let decodeString: t => option<Js_string.t>

--- a/jscomp/others/js_json.resi
+++ b/jscomp/others/js_json.resi
@@ -42,13 +42,13 @@ type rec t =
 
 module Kind: {
   /** Underlying type of a JSON value */
-  type rec kind<_> =
-    | String: kind<Js_string.t>
-    | Number: kind<float>
-    | Object: kind<Js_dict.t<t>>
-    | Array: kind<array<t>>
-    | Boolean: kind<bool>
-    | Null: kind<Js_types.null_val>
+  type rec s<_> =
+    | String: s<Js_string.t>
+    | Number: s<float>
+    | Object: s<Js_dict.t<t>>
+    | Array: s<array<t>>
+    | Boolean: s<bool>
+    | Null: s<Js_types.null_val>
 }
 
 type tagged_t =
@@ -65,7 +65,7 @@ type tagged_t =
 let classify: t => tagged_t
 
 /** `test(v, kind)` returns `true` if `v` is of `kind`. */
-let test: ('a, Kind.kind<'b>) => bool
+let test: ('a, Kind.s<'b>) => bool
 
 /** `decodeString(json)` returns `Some(s)` if `json` is a `string`, `None` otherwise. */
 let decodeString: t => option<Js_string.t>

--- a/jscomp/others/js_json.resi
+++ b/jscomp/others/js_json.resi
@@ -41,14 +41,15 @@ type rec t =
   | Array(array<t>)
 
 module Kind: {
+  type json = t
   /** Underlying type of a JSON value */
-  type rec kind<_> =
-    | String: kind<Js_string.t>
-    | Number: kind<float>
-    | Object: kind<Js_dict.t<t>>
-    | Array: kind<array<t>>
-    | Boolean: kind<bool>
-    | Null: kind<Js_types.null_val>
+  type rec t<_> =
+    | String: t<Js_string.t>
+    | Number: t<float>
+    | Object: t<Js_dict.t<json>>
+    | Array: t<array<json>>
+    | Boolean: t<bool>
+    | Null: t<Js_types.null_val>
 }
 
 type tagged_t =
@@ -65,7 +66,7 @@ type tagged_t =
 let classify: t => tagged_t
 
 /** `test(v, kind)` returns `true` if `v` is of `kind`. */
-let test: ('a, Kind.kind<'b>) => bool
+let test: ('a, Kind.t<'b>) => bool
 
 /** `decodeString(json)` returns `Some(s)` if `json` is a `string`, `None` otherwise. */
 let decodeString: t => option<Js_string.t>

--- a/jscomp/test/js_json_test.res
+++ b/jscomp/test/js_json_test.res
@@ -145,7 +145,7 @@ let () = {
 
 /* Check that the given json value is an array and that its element
  * a position [i] is equal to both the [kind] and [expected] value */
-let eq_at_i = (type a, loc: string, json: J.t, i: int, kind: J.Kind.kind<a>, expected: a): unit => {
+let eq_at_i = (type a, loc: string, json: J.t, i: int, kind: J.Kind.t<a>, expected: a): unit => {
   let ty = J.classify(json)
   switch ty {
   | J.JSONArray(x) =>

--- a/jscomp/test/js_json_test.res
+++ b/jscomp/test/js_json_test.res
@@ -145,40 +145,40 @@ let () = {
 
 /* Check that the given json value is an array and that its element
  * a position [i] is equal to both the [kind] and [expected] value */
-let eq_at_i = (type a, loc: string, json: J.t, i: int, kind: J.kind<a>, expected: a): unit => {
+let eq_at_i = (type a, loc: string, json: J.t, i: int, kind: J.Kind.kind<a>, expected: a): unit => {
   let ty = J.classify(json)
   switch ty {
   | J.JSONArray(x) =>
     let ty = J.classify(x[i])
     switch kind {
-    | J.Boolean =>
+    | J.Kind.Boolean =>
       switch ty {
       | JSONTrue => eq(loc, true, expected)
 
       | JSONFalse => eq(loc, false, expected)
       | _ => false_(loc)
       }
-    | J.Number =>
+    | J.Kind.Number =>
       switch ty {
       | JSONNumber(f) => eq(loc, f, expected)
       | _ => false_(loc)
       }
-    | J.Object =>
+    | J.Kind.Object =>
       switch ty {
       | JSONObject(f) => eq(loc, f, expected)
       | _ => false_(loc)
       }
-    | J.Array =>
+    | J.Kind.Array =>
       switch ty {
       | JSONArray(f) => eq(loc, f, expected)
       | _ => false_(loc)
       }
-    | J.Null =>
+    | J.Kind.Null =>
       switch ty {
       | JSONNull => true_(loc)
       | _ => false_(loc)
       }
-    | J.String =>
+    | J.Kind.String =>
       switch ty {
       | JSONString(f) => eq(loc, f, expected)
       | _ => false_(loc)
@@ -196,18 +196,18 @@ let () = {
     |> J.stringify
     |> J.parseExn
 
-  eq_at_i(__LOC__, json, 0, J.String, "string 0")
-  eq_at_i(__LOC__, json, 1, J.String, "string 1")
-  eq_at_i(__LOC__, json, 2, J.String, "string 2")
+  eq_at_i(__LOC__, json, 0, J.Kind.String, "string 0")
+  eq_at_i(__LOC__, json, 1, J.Kind.String, "string 1")
+  eq_at_i(__LOC__, json, 2, J.Kind.String, "string 2")
   ()
 }
 
 let () = {
   let json = ["string 0", "string 1", "string 2"] |> J.stringArray |> J.stringify |> J.parseExn
 
-  eq_at_i(__LOC__, json, 0, J.String, "string 0")
-  eq_at_i(__LOC__, json, 1, J.String, "string 1")
-  eq_at_i(__LOC__, json, 2, J.String, "string 2")
+  eq_at_i(__LOC__, json, 0, J.Kind.String, "string 0")
+  eq_at_i(__LOC__, json, 1, J.Kind.String, "string 1")
+  eq_at_i(__LOC__, json, 2, J.Kind.String, "string 2")
   ()
 }
 
@@ -216,9 +216,9 @@ let () = {
   let json = a |> J.numberArray |> J.stringify |> J.parseExn
 
   /* Loop is unrolled to keep relevant location information */
-  eq_at_i(__LOC__, json, 0, J.Number, a[0])
-  eq_at_i(__LOC__, json, 1, J.Number, a[1])
-  eq_at_i(__LOC__, json, 2, J.Number, a[2])
+  eq_at_i(__LOC__, json, 0, J.Kind.Number, a[0])
+  eq_at_i(__LOC__, json, 1, J.Kind.Number, a[1])
+  eq_at_i(__LOC__, json, 2, J.Kind.Number, a[2])
   ()
 }
 
@@ -227,9 +227,9 @@ let () = {
   let json = a |> Array.map(float_of_int) |> J.numberArray |> J.stringify |> J.parseExn
 
   /* Loop is unrolled to keep relevant location information */
-  eq_at_i(__LOC__, json, 0, J.Number, float_of_int(a[0]))
-  eq_at_i(__LOC__, json, 1, J.Number, float_of_int(a[1]))
-  eq_at_i(__LOC__, json, 2, J.Number, float_of_int(a[2]))
+  eq_at_i(__LOC__, json, 0, J.Kind.Number, float_of_int(a[0]))
+  eq_at_i(__LOC__, json, 1, J.Kind.Number, float_of_int(a[1]))
+  eq_at_i(__LOC__, json, 2, J.Kind.Number, float_of_int(a[2]))
   ()
 }
 
@@ -238,9 +238,9 @@ let () = {
   let json = a |> J.booleanArray |> J.stringify |> J.parseExn
 
   /* Loop is unrolled to keep relevant location information */
-  eq_at_i(__LOC__, json, 0, J.Boolean, a[0])
-  eq_at_i(__LOC__, json, 1, J.Boolean, a[1])
-  eq_at_i(__LOC__, json, 2, J.Boolean, a[2])
+  eq_at_i(__LOC__, json, 0, J.Kind.Boolean, a[0])
+  eq_at_i(__LOC__, json, 1, J.Kind.Boolean, a[1])
+  eq_at_i(__LOC__, json, 2, J.Kind.Boolean, a[2])
   ()
 }
 

--- a/jscomp/test/js_json_test.res
+++ b/jscomp/test/js_json_test.res
@@ -145,7 +145,7 @@ let () = {
 
 /* Check that the given json value is an array and that its element
  * a position [i] is equal to both the [kind] and [expected] value */
-let eq_at_i = (type a, loc: string, json: J.t, i: int, kind: J.Kind.s<a>, expected: a): unit => {
+let eq_at_i = (type a, loc: string, json: J.t, i: int, kind: J.Kind.kind<a>, expected: a): unit => {
   let ty = J.classify(json)
   switch ty {
   | J.JSONArray(x) =>

--- a/jscomp/test/js_json_test.res
+++ b/jscomp/test/js_json_test.res
@@ -145,7 +145,7 @@ let () = {
 
 /* Check that the given json value is an array and that its element
  * a position [i] is equal to both the [kind] and [expected] value */
-let eq_at_i = (type a, loc: string, json: J.t, i: int, kind: J.Kind.kind<a>, expected: a): unit => {
+let eq_at_i = (type a, loc: string, json: J.t, i: int, kind: J.Kind.s<a>, expected: a): unit => {
   let ty = J.classify(json)
   switch ty {
   | J.JSONArray(x) =>

--- a/lib/es6/js_json.js
+++ b/lib/es6/js_json.js
@@ -2,6 +2,8 @@
 
 import * as Caml_option from "./caml_option.js";
 
+var Kind = {};
+
 function classify(x) {
   var ty = typeof x;
   if (ty === "string") {
@@ -158,6 +160,7 @@ function deserializeUnsafe(s) {
 }
 
 export {
+  Kind ,
   classify ,
   test ,
   decodeString ,

--- a/lib/js/js_json.js
+++ b/lib/js/js_json.js
@@ -2,6 +2,8 @@
 
 var Caml_option = require("./caml_option.js");
 
+var Kind = {};
+
 function classify(x) {
   var ty = typeof x;
   if (ty === "string") {
@@ -157,6 +159,7 @@ function deserializeUnsafe(s) {
   return patch(JSON.parse(s));
 }
 
+exports.Kind = Kind;
 exports.classify = classify;
 exports.test = test;
 exports.decodeString = decodeString;


### PR DESCRIPTION
This PR fixes an issue with existing Js.Json.kind types shadowing the variant constructor of Js.Json.t types.