### PR TITLE
Don't export $$default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 - GenType: Propagate comments from record fields to emitted TypeScript types. https://github.com/rescript-lang/rescript-compiler/pull/6333
 
+#### :boom: Breaking Change
+
+- `$$default` is no longer exported from the generated JavaScript when using default exports. https://github.com/rescript-lang/rescript-compiler/pull/6328
+
 # 11.0.0-beta.4
 
 #### :rocket: New Feature

--- a/jscomp/core/js_dump.ml
+++ b/jscomp/core/js_dump.ml
@@ -500,7 +500,9 @@ and vident cxt f (v : J.vident) =
   | Qualified ({ id; kind = Ml | Runtime }, Some name) ->
       let cxt = Ext_pp_scope.ident cxt f id in
       P.string f L.dot;
-      P.string f (Ext_ident.convert name);
+      P.string f
+        (if name = Js_dump_import_export.default_export then name
+        else Ext_ident.convert name);
       cxt
   | Qualified ({ id; kind = External _ }, Some name) ->
       let cxt = Ext_pp_scope.ident cxt f id in

--- a/jscomp/core/js_dump_import_export.ml
+++ b/jscomp/core/js_dump_import_export.ml
@@ -50,7 +50,7 @@ let exports cxt f (idents : Ident.t list) =
         ( cxt,
           if id_name = default_export then
             (* TODO check how it will affect AMDJS*)
-            esModule :: (default_export, str) :: (s, str) :: acc
+            esModule :: (default_export, str) :: acc
           else (s, str) :: acc ))
   in
   P.at_least_two_lines f;
@@ -77,7 +77,7 @@ let es6_export cxt f (idents : Ident.t list) =
         let str, cxt = Ext_pp_scope.str_of_ident cxt id in
         ( cxt,
           if id_name = default_export then
-            (default_export, str) :: (s, str) :: acc
+            (default_export, str) :: acc
           else (s, str) :: acc ))
   in
   P.at_least_two_lines f;

--- a/jscomp/core/js_dump_import_export.mli
+++ b/jscomp/core/js_dump_import_export.mli
@@ -22,6 +22,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
+val default_export : string
+
 val exports : Ext_pp_scope.t -> Ext_pp.t -> Ident.t list -> Ext_pp_scope.t
 
 val es6_export : Ext_pp_scope.t -> Ext_pp.t -> Ident.t list -> Ext_pp_scope.t

--- a/jscomp/test/default_export_test.js
+++ b/jscomp/test/default_export_test.js
@@ -4,7 +4,6 @@
 
 var $$default = "xx";
 
-exports.$$default = $$default;
 exports.default = $$default;
 exports.__esModule = true;
 /* No side effect */

--- a/jscomp/test/es6_export.js
+++ b/jscomp/test/es6_export.js
@@ -4,7 +4,6 @@
 
 var $$default = 3;
 
-exports.$$default = $$default;
 exports.default = $$default;
 exports.__esModule = true;
 /* No side effect */

--- a/jscomp/test/es6_export.mjs
+++ b/jscomp/test/es6_export.mjs
@@ -4,7 +4,6 @@
 var $$default = 3;
 
 export {
-  $$default ,
   $$default as default,
 }
 /* No side effect */

--- a/jscomp/test/es6_import.js
+++ b/jscomp/test/es6_import.js
@@ -3,6 +3,6 @@
 
 var Es6_export = require("./es6_export.js");
 
-console.log(Es6_export.$$default);
+console.log(Es6_export.default);
 
 /*  Not a pure module */

--- a/jscomp/test/es6_import.mjs
+++ b/jscomp/test/es6_import.mjs
@@ -2,7 +2,7 @@
 
 import * as Es6_export from "./es6_export.mjs";
 
-console.log(Es6_export.$$default);
+console.log(Es6_export.default);
 
 export {
   

--- a/jscomp/test/escape_esmodule.js
+++ b/jscomp/test/escape_esmodule.js
@@ -7,7 +7,6 @@ var $$__esModule = false;
 var $$default = 4;
 
 exports.$$__esModule = $$__esModule;
-exports.$$default = $$default;
 exports.default = $$default;
 exports.__esModule = true;
 /* No side effect */

--- a/jscomp/test/key_word_property.js
+++ b/jscomp/test/key_word_property.js
@@ -52,7 +52,6 @@ function u(param) {
 
 var $$case = 3;
 
-exports.$$default = $$default;
 exports.default = $$default;
 exports.__esModule = true;
 exports.default2 = default2;

--- a/lib/es6/js_option.js
+++ b/lib/es6/js_option.js
@@ -96,7 +96,6 @@ export {
   andThen ,
   map ,
   getWithDefault ,
-  $$default ,
   $$default as default,
   filter ,
   firstSome ,

--- a/lib/js/js_option.js
+++ b/lib/js/js_option.js
@@ -95,7 +95,6 @@ exports.equal = equal;
 exports.andThen = andThen;
 exports.map = map;
 exports.getWithDefault = getWithDefault;
-exports.$$default = $$default;
 exports.default = $$default;
 exports.__esModule = true;
 exports.filter = filter;


### PR DESCRIPTION
Closes https://github.com/rescript-lang/rescript-compiler/issues/4906#issuecomment-1637042291.

## Investigation
* The compiler exports any invalid identifier as `$$<identifierName>`. For example, `let else = "hello"` is valid ReScript, but not valid JS because else is a keyword. Therefore, you couldn't export `else` from a JS file, even if it's valid ReScript. So, the compiler prepends `$$` to any identifier it thinks might be invalid. And via that, it also exports the identifier as `$$<identifierName>`. The alternative would be to not export those identifiers at all, which doesn't really make sense.
* However, `default` is a special case that might just be possible to support, because we're always adding a dedicated default export whenever we see `default`. So, even if `$$default` isn't exported anymore, ~~we should be able to tweak the compiler to just refer to `default` where it now refers to `$$default`~~ (done).