### PR TITLE
Flip order of error message for wrong name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 #### :nail_care: Polish
 - Conditionally print error message about record with missing label potentially being a component. https://github.com/rescript-lang/rescript-compiler/pull/6337
+- Put definition in the bottom and the actual error at the top when reporting errors for supplying fields etc with the wrong name. https://github.com/rescript-lang/rescript-compiler/pull/6336
 
 # 11.0.0-beta.4
 

--- a/jscomp/build_tests/super_errors/expected/component_missing_prop_test.res.expected
+++ b/jscomp/build_tests/super_errors/expected/component_missing_prop_test.res.expected
@@ -1,0 +1,13 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/component_missing_prop_test.res[0m:[2m5:35-39[0m
+
+  3 [2m│[0m   type props<'name> = {name: 'name}
+  4 [2m│[0m 
+  [1;31m5[0m [2m│[0m   let make = (): props<'name> => {[1;31mnname[0m: "hello"}
+  6 [2m│[0m }
+  7 [2m│[0m 
+
+  This record expression is expected to have type [1;33m'test[0m
+  The field [1;31mnname[0m does not belong to type [1;33mprops[0m
+Hint: Did you mean name?

--- a/jscomp/build_tests/super_errors/expected/wrong_name_component_prop.res.expected
+++ b/jscomp/build_tests/super_errors/expected/wrong_name_component_prop.res.expected
@@ -1,0 +1,23 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/wrong_name_component_prop.res[0m:[2m32:28-38[0m
+
+  30 [2m│[0m }
+  31 [2m│[0m 
+  [1;31m32[0m [2m│[0m let dddd = Component.make({[1;31mnonExistant[0m: "hello"})
+  33 [2m│[0m 
+
+  The field [1;31mnonExistant[0m does not belong to type [1;33mComponent.props[0m
+  
+  This record expression is expected to have type
+    [1;33mComponent.props<
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+>[0m

--- a/jscomp/build_tests/super_errors/expected/wrong_name_record_field.res.expected
+++ b/jscomp/build_tests/super_errors/expected/wrong_name_record_field.res.expected
@@ -1,0 +1,13 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/wrong_name_record_field.res[0m:[2m4:3-4[0m
+
+  2 [2m│[0m 
+  3 [2m│[0m let ff: d = {
+  [1;31m4[0m [2m│[0m   [1;31mzz[0m: 123,
+  5 [2m│[0m }
+  6 [2m│[0m 
+
+  The field [1;31mzz[0m does not belong to type [1;33md[0m
+  
+  This record expression is expected to have type [1;33md[0m

--- a/jscomp/build_tests/super_errors/fixtures/component_missing_prop_test.res
+++ b/jscomp/build_tests/super_errors/fixtures/component_missing_prop_test.res
@@ -1,0 +1,6 @@
+// Since the React transform isn't active in the tests, mimic what the transform outputs.
+module Component = {
+  type props<'name> = {name: 'name}
+
+  let make = (): props<'name> => {nname: "hello"}
+}

--- a/jscomp/build_tests/super_errors/fixtures/wrong_name_component_prop.res
+++ b/jscomp/build_tests/super_errors/fixtures/wrong_name_component_prop.res
@@ -1,0 +1,32 @@
+module SomeComplicatedModuleStructure = {
+  module NestedModuleHere = {
+    type t = string
+  }
+}
+
+module Component = {
+  type props<'name, 'second, 'third, 'fourth, 'fifth, 'sixth, 'seventh, 'eight, 'ninth> = {
+    name: 'name,
+    second: 'second,
+    third: 'third,
+    fourth: 'fourth,
+    fifth: 'fifth,
+    sixth: 'sixth,
+    seventh: 'seventh,
+    eight: 'eight,
+    ninth: 'ninth,
+  }
+  let make = props => {
+    props.name ++
+    props.second ++
+    props.third ++
+    props.fourth ++
+    props.fifth ++
+    props.sixth ++
+    props.seventh ++
+    props.eight ++
+    props.ninth
+  }
+}
+
+let dddd = Component.make({nonExistant: "hello"})

--- a/jscomp/build_tests/super_errors/fixtures/wrong_name_record_field.res
+++ b/jscomp/build_tests/super_errors/fixtures/wrong_name_record_field.res
@@ -1,0 +1,5 @@
+type d = {z: int}
+
+let ff: d = {
+  zz: 123,
+}

--- a/jscomp/ml/typecore.ml
+++ b/jscomp/ml/typecore.ml
@@ -3889,11 +3889,11 @@ let report_error env ppf = function
       fprintf ppf "@[<v>";
 
       fprintf ppf "@[<2>The %s @{<error>%s@} does not belong to type @{<info>%a@}@]@,@,"
-              (label_of_kind kind)
-              name (*kind*) Printtyp.path p;
+        (label_of_kind kind)
+        name (*kind*) Printtyp.path p;
 
       fprintf ppf "@[<2>%s type@ @{<info>%a@}@]"
-              eorp type_expr ty;
+        eorp type_expr ty;
 
       fprintf ppf "@]";      
     end;

--- a/jscomp/ml/typecore.ml
+++ b/jscomp/ml/typecore.ml
@@ -3886,12 +3886,16 @@ let report_error env ppf = function
         name
         Printtyp.path p;
     end else begin
-      fprintf ppf "@[@[<2>%s type@ @{<info>%a@}@]@ "
-        eorp type_expr ty;
+      fprintf ppf "@[<v>";
 
-      fprintf ppf "The %s @{<error>%s@} does not belong to type @{<info>%a@}@]"
-        (label_of_kind kind)
-        name (*kind*) Printtyp.path p;
+      fprintf ppf "@[<2>The %s @{<error>%s@} does not belong to type @{<info>%a@}@]@,@,"
+              (label_of_kind kind)
+              name (*kind*) Printtyp.path p;
+
+      fprintf ppf "@[<2>%s type@ @{<info>%a@}@]"
+              eorp type_expr ty;
+
+      fprintf ppf "@]";      
     end;
     spellcheck ppf name valid_names;
   | Name_type_mismatch (kind, lid, tp, tpl) ->


### PR DESCRIPTION
This flips the order of the error message parts for the "wrong name" error message. This is to make things clearer. Instead of starting with the _definition_ of the thing we're looking for, we start with what's wrong, and _then_ print the definition. 

This makes things clearer in general, but it especially improves the situation for React components with a large amount of props, or with props with types that are verbose.

React component before:
```
This record expression is expected to have type
    Component.props<
  string,
  string,
  string,
  string,
  string,
  string,
  string,
  string,
  string,
>
  The field nonExistant does not belong to type Component.props

```

After:
```
The field nonExistant does not belong to type Component.props
  
  This record expression is expected to have type
    Component.props<
  string,
  string,
  string,
  string,
  string,
  string,
  string,
  string,
  string,
>
```

The biggest improvement is seen in the editor, where the relevant information is now visible without needing to scroll in the hover or problems tab:

![image](https://github.com/rescript-lang/rescript-compiler/assets/1457626/b3dae2d7-b592-4a88-814c-d90e1ca4bddf)
