### PR TITLE
Conditionally print message about record possibly being component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 
 - `$$default` is no longer exported from the generated JavaScript when using default exports. https://github.com/rescript-lang/rescript-compiler/pull/6328
 
+#### :nail_care: Polish
+- Conditionally print error message about record with missing label potentially being a component. https://github.com/rescript-lang/rescript-compiler/pull/6337
+
 # 11.0.0-beta.4
 
 #### :rocket: New Feature

--- a/jscomp/build_tests/super_errors/expected/component_missing_prop.res.expected
+++ b/jscomp/build_tests/super_errors/expected/component_missing_prop.res.expected
@@ -1,0 +1,12 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/component_missing_prop.res[0m:[2m5:34-35[0m
+
+  3 [2m│[0m   type props<'name> = {name: 'name}
+  4 [2m│[0m 
+  [1;31m5[0m [2m│[0m   let make = (): props<'name> => [1;31m{}[0m
+  6 [2m│[0m }
+  7 [2m│[0m 
+
+  Some required record fields are missing:
+  name. If this is a component, add the missing props.

--- a/jscomp/build_tests/super_errors/expected/variant_spread_inline_records.res.expected
+++ b/jscomp/build_tests/super_errors/expected/variant_spread_inline_records.res.expected
@@ -6,5 +6,4 @@
   3 [2m│[0m 
   [1;31m4[0m [2m│[0m let b: b = One([1;31m{name: "hello"}[0m)
 
-  Some required record fields are missing:
-  age. If this is a component, add the missing props.
+  Some required record fields are missing: age.

--- a/jscomp/build_tests/super_errors/fixtures/component_missing_prop.res
+++ b/jscomp/build_tests/super_errors/fixtures/component_missing_prop.res
@@ -1,0 +1,6 @@
+// Since the React transform isn't active in the tests, mimic what the transform outputs.
+module Component = {
+  type props<'name> = {name: 'name}
+
+  let make = (): props<'name> => {}
+}

--- a/jscomp/ml/typecore.mli
+++ b/jscomp/ml/typecore.mli
@@ -72,7 +72,7 @@ type error =
   | Apply_non_function of type_expr
   | Apply_wrong_label of arg_label * type_expr
   | Label_multiply_defined of string
-  | Labels_missing of string list
+  | Labels_missing of string list * bool
   | Label_not_mutable of Longident.t
   | Wrong_name of string * type_expr * string * Path.t * string * string list
   | Name_type_mismatch of


### PR DESCRIPTION
Whenever there's a missing property in a record, we optimistically tell the user this might be a component. While that is great, we're _always_ printing it for any record. 

This diff applies a simple heuristic ("is the record called props?") when deciding to print the message about this being a component or not.