### PR TITLE
Fix outcome printer in uncurried mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 # 11.0.0-rc.2 (Unreleased)
 
+#### :bug: Bug Fix
+
+- Fixed outcome printer resolution of uncurried config. https://github.com/rescript-lang/rescript-compiler/pull/6353
+
 # 11.0.0-rc.1
 
 #### :rocket: New Feature

--- a/jscomp/syntax/src/res_outcome_printer.ml
+++ b/jscomp/syntax/src/res_outcome_printer.ml
@@ -322,9 +322,7 @@ let rec printOutTypeDoc (outType : Outcometree.out_type) =
       ]
 
 and printOutArrowType ~uncurried typ =
-  let uncurried =
-    if !Config.uncurried <> Legacy then not uncurried else uncurried
-  in
+  let uncurried = Res_uncurried.getDotted ~uncurried !Config.uncurried in
   let typArgs, typ = collectArrowArgs typ [] in
   let args =
     Doc.join


### PR DESCRIPTION
The outcome printer was deciding whether something is uncurried or not in its own way. Probably just an oversight when centralizing how uncurried config is resolved. I changed it to resolve the uncurried config the same way as the rest of the code does.

This might fix a few issues we've had with formatting being with dots even when it shouldn't be. Hopefully.