### PR TITLE
add Bun as reserved name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 #### :nail_care: Polish
 
-- Add [`Bun`](https://bun.sh) to reserved names, so that modules named `Bun` don't clash with the globally exposed `Bun` object. 
+- Add [`Bun`](https://bun.sh) to reserved names, so that modules named `Bun` don't clash with the globally exposed `Bun` object. https://github.com/rescript-lang/rescript-compiler/pull/6381
 
 #### :bug: Bug Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 # 11.0.0-rc.3 (Unreleased)
 
+#### :nail_care: Polish
+
+- Add [`Bun`](https://bun.sh) to reserved names, so that modules named `Bun` don't clash with the globally exposed `Bun` object. 
+
 #### :bug: Bug Fix
 
 - Fix issue with JSX V4 when component props have the default value with same name. https://github.com/rescript-lang/rescript-compiler/pull/6377

--- a/jscomp/ext/js_reserved_map.ml
+++ b/jscomp/ext/js_reserved_map.ml
@@ -71,6 +71,7 @@ let sorted_keywords = [|
   "BroadcastChannel";
   "BrowserCaptureMediaStreamTrack";
   "Buffer";
+  "Bun";
   "ByteLengthQueuingStrategy";
   "CDATASection";
   "CSS";


### PR DESCRIPTION
https://bun.sh/ adds `Bun` as global object. This reserves that names to that modules cannot accidentally clash.