### PR TITLE
Remove unused rollup from dependencies

### DIFF
--- a/jscomp/gentype_tests/typescript-react-example/package-lock.json
+++ b/jscomp/gentype_tests/typescript-react-example/package-lock.json
@@ -31,10 +31,9 @@
         "rescript": "rescript"
       },
       "devDependencies": {
-        "mocha": "^10.1.0",
-        "nyc": "^15.0.0",
-        "prettier": "^2.7.1",
-        "rollup": "^0.49.2"
+        "mocha": "10.1.0",
+        "nyc": "15.0.0",
+        "prettier": "2.7.1"
       },
       "engines": {
         "node": ">=10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,9 @@
         "rescript": "rescript"
       },
       "devDependencies": {
-        "mocha": "^10.1.0",
-        "nyc": "^15.0.0",
-        "prettier": "^2.7.1",
-        "rollup": "^0.49.2"
+        "mocha": "10.1.0",
+        "nyc": "15.0.0",
+        "prettier": "2.7.1"
       },
       "engines": {
         "node": ">=10"
@@ -1895,15 +1894,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rollup": {
-      "version": "0.49.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.49.2.tgz",
-      "integrity": "sha512-9mySqItSwq5/dXYQyFGrrzqV282EZfz4kSCU2m4e6OjgqLmIsp9zK6qNQ6wbBWR4EhASEqQMBQ/IF45jaNPAtw==",
-      "dev": true,
-      "bin": {
-        "rollup": "bin/rollup"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -3754,12 +3744,6 @@
       "requires": {
         "glob": "^7.1.3"
       }
-    },
-    "rollup": {
-      "version": "0.49.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.49.2.tgz",
-      "integrity": "sha512-9mySqItSwq5/dXYQyFGrrzqV282EZfz4kSCU2m4e6OjgqLmIsp9zK6qNQ6wbBWR4EhASEqQMBQ/IF45jaNPAtw==",
-      "dev": true
     },
     "safe-buffer": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,9 @@
   "name": "rescript",
   "version": "11.0.0-rc.4",
   "devDependencies": {
-    "mocha": "^10.1.0",
-    "nyc": "^15.0.0",
-    "prettier": "^2.7.1",
-    "rollup": "^0.49.2"
+    "mocha": "10.1.0",
+    "nyc": "15.0.0",
+    "prettier": "2.7.1"
   },
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
Also, pin dev dependencies versions, so they are not updated by themselves.