### PR TITLE
ReScript cli clean up + watcher fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Improve "Somewhere wanted" error messages by changing wording and adding more context + suggested solutions to the error messages where appropriate. https://github.com/rescript-lang/rescript-compiler/pull/6410
 - Add smart printer for pipe-chains. https://github.com/rescript-lang/rescript-compiler/pull/6411
 - Display the compile time for `rescript build` command. https://github.com/rescript-lang/rescript-compiler/pull/6404
-- Actualize help message for `build` and `clean` commands. https://github.com/rescript-lang/rescript-compiler/pull/6404
+- Improve help message for `build` and `clean` commands. https://github.com/rescript-lang/rescript-compiler/pull/6404
 - Pass through the `-verbose` flag to builds in watch mode. https://github.com/rescript-lang/rescript-compiler/pull/6404
 
 # 11.0.0-rc.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 
 #### :bug: Bug Fix
 
-- Fix issue with GenType and labelled arguments https://github.com/rescript-lang/rescript-compiler/pull/6406
+- Fix issue with GenType and labelled arguments. https://github.com/rescript-lang/rescript-compiler/pull/6406
+- Fix dependencies reinitialization on every change in watch mode. Leads to faster rebuilds and cleaner terminal. https://github.com/rescript-lang/rescript-compiler/pull/6404
 
 #### :rocket: New Feature
 
@@ -29,6 +30,9 @@
 - The error message for "toplevel expressions should evaluate to unit" has been revamped and improved. https://github.com/rescript-lang/rescript-compiler/pull/6407
 - Improve "Somewhere wanted" error messages by changing wording and adding more context + suggested solutions to the error messages where appropriate. https://github.com/rescript-lang/rescript-compiler/pull/6410
 - Add smart printer for pipe-chains. https://github.com/rescript-lang/rescript-compiler/pull/6411
+- Display the compile time for `rescript build` command. https://github.com/rescript-lang/rescript-compiler/pull/6404
+- Actualize help message for `build` and `clean` commands. https://github.com/rescript-lang/rescript-compiler/pull/6404
+- Pass through the `-verbose` flag to builds in watch mode. https://github.com/rescript-lang/rescript-compiler/pull/6404
 
 # 11.0.0-rc.3
 

--- a/jscomp/bsb_exe/rescript_main.ml
+++ b/jscomp/bsb_exe/rescript_main.ml
@@ -85,7 +85,7 @@ let ninja_command_exit (type t) (ninja_args : string array) : t =
 *)
 let clean_usage =
   "Usage: rescript clean <options>\n\n\
-   `rescript clean` cleans build artifacts. It is useful for edge-case reasons in case you get into a stale build\n"
+   `rescript clean` cleans build artifacts\n"
 
 let build_usage =
   "Usage: rescript build <options> -- <ninja_options>\n\n\

--- a/rescript
+++ b/rescript
@@ -15,20 +15,13 @@ var bsc_exe = require("./scripts/bin_path").bsc_exe;
 var rescript_exe = require("./scripts/bin_path").rescript_exe;
 var bsconfig = "bsconfig.json";
 
-var LAST_BUILD_START = 0;
-var LAST_FIRED_EVENT = 0;
-/**
- * @type {[string,string][]}
- */
-var reasonsToRebuild = [["proj", "started"]];
-
 var LAST_SUCCESS_BUILD_STAMP = 0;
 var cwd = process.cwd();
 var lockFileName = path.join(cwd, ".bsb.lock");
 process.env.BSB_PROJECT_ROOT = cwd;
 
-var error_is_tty = process.stderr.isTTY;
-var std_is_tty = process.stdout.isTTY;
+const isTtyError = process.stderr.isTTY;
+const isTtyStd = process.stdout.isTTY;
 
 // If the project uses gentype and uses custom file extension
 // via generatedFileExtension, ignore them in watch mode
@@ -41,31 +34,17 @@ if (fs.existsSync(bsConfigFile)) {
   }
 }
 
-// All clients of type MiniWebSocket
-/**
- * @type {any[]}
- */
-var wsClients = [];
-var isWatchMode = false;
-var verbose = false;
-/**
- * @type {string | undefined}
- */
-var postBuild = undefined;
-var withWebSocket = false;
-var webSocketHost = "localhost";
-var webSocketPort = 9999;
+let verbose = false;
 
 /**
  * @time{[number,number]}
  */
-var startTime;
+let startTime;
 function updateStartTime() {
   startTime = process.hrtime();
-  return "";
 }
 function updateFinishTime() {
-  var diff = process.hrtime(startTime);
+  const diff = process.hrtime(startTime);
   return diff[0] * 1e9 + diff[1];
 }
 
@@ -92,51 +71,6 @@ function dlog(str) {
   }
 }
 
-function notifyClients() {
-  wsClients = wsClients.filter(x => !x.closed && !x.socket.destroyed);
-  var wsClientsLen = wsClients.length;
-  dlog(`Alive sockets number: ${wsClientsLen}`);
-  var data = '{"LAST_SUCCESS_BUILD_STAMP":' + LAST_SUCCESS_BUILD_STAMP + "}";
-  for (var i = 0; i < wsClientsLen; ++i) {
-    // in reverse order, the last pushed get notified earlier
-    var client = wsClients[wsClientsLen - i - 1];
-    if (!client.closed) {
-      client.sendText(data);
-    }
-  }
-}
-
-function setUpWebSocket() {
-  var WebSocket = require("./lib/minisocket.js").MiniWebSocket;
-  var id = setInterval(notifyClients, 3000);
-  require("http")
-    .createServer()
-    .on("upgrade", function (req, socket, upgradeHead) {
-      dlog("connection opened");
-      var ws = new WebSocket(req, socket, upgradeHead);
-      socket.on("error", function (err) {
-        dlog(`Socket Error ${err}`);
-      });
-      wsClients.push(ws);
-    })
-    .on("error", function (err) {
-      // @ts-ignore
-      if (err !== undefined && err.code === "EADDRINUSE") {
-        var error = std_is_tty ? `\x1b[1;31mERROR:\x1b[0m` : `ERROR:`;
-        console.error(`${error} The websocket port number ${webSocketPort} is in use.
-Please pick a different one using the \`-ws [host:]port\` flag from bsb.`);
-      } else {
-        console.error(err);
-      }
-      process.exit(2);
-    })
-    .listen(webSocketPort, webSocketHost);
-}
-
-/**
- * @type {string[]}
- */
-var delegatedArgs = [];
 var process_argv = process.argv;
 
 if (process.env.NINJA_ANSI_FORCED === undefined) {
@@ -204,9 +138,76 @@ function onUncaughtException(err) {
   releaseBuild();
   process.exit(1);
 }
+
 function exitProcess() {
   releaseBuild();
   process.exit(0);
+}
+
+/**
+ * @param {number} [code]
+ */
+function logFinishCompiling(code) {
+  let log = `>>>> Finish compiling`;
+  if (code) {
+    log = log + " (exit: " + code + ")";
+  }
+  if (isTtyStd) {
+    log = "\x1b[36m" + log + "\x1b[0m";
+  }
+  if (code) {
+    console.log(log);
+  } else {
+    console.log(log, Math.floor(updateFinishTime() / 1e6), "mseconds");
+  }
+}
+
+function logStartCompiling() {
+  updateStartTime();
+  let log = `>>>> Start compiling`;
+  if (isTtyStd) {
+    log = "\x1b[36m" + log + "\x1b[0m";
+  }
+  console.log(log);
+}
+
+/**
+ * @param {Array<string>} args
+ * @param {() => void} [maybeOnSuccess]
+ */
+function delegateCommand(args, maybeOnSuccess) {
+  /**
+   * @type {child_process.ChildProcess}
+   */
+  var p;
+  if (acquireBuild()) {
+    try {
+      p = child_process.spawn(rescript_exe, args, {
+        stdio: "inherit",
+      });
+    } catch (e) {
+      if (e.code === "ENOENT") {
+        // when bsb is actually not found
+        console.error(String(e));
+      }
+      releaseBuild();
+      process.exit(2);
+    }
+    // The 'close' event will always emit after 'exit' was already emitted, or
+    // 'error' if the child failed to spawn.
+    p.on("close", code => {
+      releaseBuild();
+      if (maybeOnSuccess && !code) {
+        maybeOnSuccess();
+        return;
+      }
+      process.exit(code || 0);
+    });
+  } else {
+    console.warn(`Another build detected or stale lockfile ${lockFileName}`);
+    // rasing magic code
+    process.exit(133);
+  }
 }
 
 process.on("uncaughtException", onUncaughtException);
@@ -220,15 +221,317 @@ process.on("SIGUSR2", exitProcess);
 process.on("SIGTERM", exitProcess);
 process.on("SIGHUP", exitProcess);
 
-var maybeSubcommand = process_argv[2];
-if (
-  maybeSubcommand !== undefined &&
-  maybeSubcommand !== "build" &&
-  maybeSubcommand !== "clean" &&
-  maybeSubcommand !== "info"
-  // delegate to native
-) {
+const maybeSubcommand = process_argv[2];
+
+if (maybeSubcommand === "build" && process_argv.includes("-w")) {
+  // All clients of type MiniWebSocket
+  /**
+   * @type {any[]}
+   */
+  let wsClients = [];
+  let withWebSocket = false;
+  let webSocketHost = "localhost";
+  let webSocketPort = 9999;
+
+  const sourcedirs = path.join("lib", "bs", ".sourcedirs.json");
+
+  let LAST_BUILD_START = 0;
+  let LAST_FIRED_EVENT = 0;
+  /**
+   * @type {[string,string][]}
+   */
+  let reasonsToRebuild = [];
+  let watchGenerated = [];
+
+  /**
+   * watchers are held so that we close it later
+   */
+  let watchers = [];
+
+  const delegatedArgs = process_argv.slice(2);
+  verbose = delegatedArgs.includes("-verbose");
+
+  var wsParamIndex = delegatedArgs.indexOf("-ws");
+  if (wsParamIndex > -1) {
+    var hostAndPortNumber = (delegatedArgs[wsParamIndex + 1] || "").split(":");
+    /**
+     * @type {number}
+     */
+    var portNumber;
+    if (hostAndPortNumber.length === 1) {
+      portNumber = parseInt(hostAndPortNumber[0]);
+    } else {
+      webSocketHost = hostAndPortNumber[0];
+      portNumber = parseInt(hostAndPortNumber[1]);
+    }
+    if (!isNaN(portNumber)) {
+      webSocketPort = portNumber;
+    }
+    withWebSocket = true;
+    dlog(`WebSocket host & port number: ${webSocketHost}:${webSocketPort}`);
+  }
+
+  const rescriptWatchBuildArgs = verbose
+    ? ["build", "-no-deps", "-verbose"]
+    : ["build", "-no-deps"];
+
+  function notifyClients() {
+    wsClients = wsClients.filter(x => !x.closed && !x.socket.destroyed);
+    var wsClientsLen = wsClients.length;
+    dlog(`Alive sockets number: ${wsClientsLen}`);
+    var data = '{"LAST_SUCCESS_BUILD_STAMP":' + LAST_SUCCESS_BUILD_STAMP + "}";
+    for (var i = 0; i < wsClientsLen; ++i) {
+      // in reverse order, the last pushed get notified earlier
+      var client = wsClients[wsClientsLen - i - 1];
+      if (!client.closed) {
+        client.sendText(data);
+      }
+    }
+  }
+
+  function setUpWebSocket() {
+    var WebSocket = require("./lib/minisocket.js").MiniWebSocket;
+    var id = setInterval(notifyClients, 3000);
+    require("http")
+      .createServer()
+      .on("upgrade", function (req, socket, upgradeHead) {
+        dlog("connection opened");
+        var ws = new WebSocket(req, socket, upgradeHead);
+        socket.on("error", function (err) {
+          dlog(`Socket Error ${err}`);
+        });
+        wsClients.push(ws);
+      })
+      .on("error", function (err) {
+        // @ts-ignore
+        if (err !== undefined && err.code === "EADDRINUSE") {
+          var error = isTtyStd ? `\x1b[1;31mERROR:\x1b[0m` : `ERROR:`;
+          console.error(`${error} The websocket port number ${webSocketPort} is in use.
+Please pick a different one using the \`-ws [host:]port\` flag from bsb.`);
+        } else {
+          console.error(err);
+        }
+        process.exit(2);
+      })
+      .listen(webSocketPort, webSocketHost);
+  }
+
+  function watchBuild(watchConfig) {
+    var watchFiles = watchConfig.dirs;
+    watchGenerated = watchConfig.generated;
+    // close and remove all unused watchers
+    watchers = watchers.filter(function (watcher) {
+      if (watcher.dir === bsconfig) {
+        return true;
+      } else if (watchFiles.indexOf(watcher.dir) < 0) {
+        dlog(`${watcher.dir} is no longer watched`);
+        watcher.watcher.close();
+        return false;
+      } else {
+        return true;
+      }
+    });
+
+    // adding new watchers
+    for (var i = 0; i < watchFiles.length; ++i) {
+      var dir = watchFiles[i];
+      if (
+        !watchers.find(function (watcher) {
+          return watcher.dir === dir;
+        })
+      ) {
+        dlog(`watching dir ${dir} now`);
+        var watcher = fs.watch(dir, onChange);
+        watchers.push({ dir: dir, watcher: watcher });
+      } else {
+        // console.log(dir, 'already watched')
+      }
+    }
+  }
+
+  /**
+   * @param {string | null} fileName
+   */
+  function checkIsRebuildReason(fileName) {
+    // Return true if filename is nil, filename is only provided on Linux, macOS, Windows, and AIX.
+    // On other systems, we just have to assume that any change is valid.
+    // This could cause problems if source builds (generating js files in the same directory) are supported.
+    if (!fileName) return true;
+
+    return !(
+      fileName === ".merlin" ||
+      fileName.endsWith(".js") ||
+      fileName.endsWith(".mjs") ||
+      fileName.endsWith(".cjs") ||
+      fileName.endsWith(genTypeFileExtension) ||
+      watchGenerated.indexOf(fileName) >= 0 ||
+      fileName.endsWith(".swp")
+    );
+  }
+
+  /**
+   * @return {boolean}
+   */
+  function needRebuild() {
+    return reasonsToRebuild.length !== 0;
+  }
+
+  /**
+   * @param code {number}
+   */
+  function buildFinishedCallback(code) {
+    if (code === 0) {
+      LAST_SUCCESS_BUILD_STAMP = Date.now();
+      notifyClients();
+    }
+    logFinishCompiling(code);
+    releaseBuild();
+    if (needRebuild()) {
+      build(0);
+    } else {
+      var files = getWatchFiles(sourcedirs);
+      watchBuild(files);
+    }
+  }
+
+  /**
+   * TODO: how to make it captured by vscode
+   * @param error {string}
+   * @param highlight {string}
+   */
+  function outputError(error, highlight) {
+    if (isTtyError && highlight) {
+      process.stderr.write(
+        error.replace(highlight, "\x1b[1;31m" + highlight + "\x1b[0m")
+      );
+    } else {
+      process.stderr.write(error);
+    }
+  }
+
+  // Note this function filters the error output
+  // it relies on the fact that ninja will merege stdout and stderr
+  // of the compiler output, if it does not
+  // then we should have a way to not filter the compiler output
+  /**
+   *
+   * @param {number} depth
+   */
+  function build(depth) {
+    if (reasonsToRebuild.length === 0) {
+      dlog("No need to rebuild");
+      return;
+    } else {
+      dlog(`Rebuilding since ${reasonsToRebuild}`);
+    }
+    if (acquireBuild()) {
+      logStartCompiling();
+      child_process
+        .spawn(rescript_exe, rescriptWatchBuildArgs, {
+          stdio: ["inherit", "inherit", "pipe"],
+        })
+        // @ts-ignore
+        .on("data", function (s) {
+          outputError(s, "ninja: error");
+        })
+        .on("exit", buildFinishedCallback)
+        .stderr.setEncoding("utf8");
+      // This is important to clean up all
+      // previous queued events
+      reasonsToRebuild = [];
+      LAST_BUILD_START = Date.now();
+    }
+    // if acquiring lock failed, no need retry here
+    // since buildFinishedCallback will try again
+    // however this is no longer the case for multiple-process
+    // it could fail due to other issues like .bsb.lock
+    else {
+      dlog(
+        `Acquire lock failed, do the build later ${depth} : ${reasonsToRebuild}`
+      );
+      const waitTime = Math.pow(2, depth) * 40;
+      setTimeout(() => {
+        build(Math.min(depth + 1, 5));
+      }, waitTime);
+    }
+  }
+
+  /**
+   *
+   * @param {fs.WatchEventType} event
+   * @param {string | null} reason
+   */
+  function onChange(event, reason) {
+    var eventTime = Date.now();
+    var timeDiff = eventTime - LAST_BUILD_START;
+    var eventDiff = eventTime - LAST_FIRED_EVENT;
+    dlog(`Since last build: ${timeDiff} -- ${eventDiff}`);
+    if (timeDiff < 5 || eventDiff < 5) {
+      // for 5ms, we could think that the ninja not get
+      // kicked yet, so there is really no need
+      // to send more events here
+
+      // note reasonsToRebuild also
+      // helps avoid redundant build, but this will
+      // save the event loop call `setImmediate`
+      return;
+    }
+    if (checkIsRebuildReason(reason)) {
+      dlog(`\nEvent ${event} ${reason}`);
+      LAST_FIRED_EVENT = eventTime;
+      reasonsToRebuild.push([event, reason || ""]);
+      // Some editors are using temporary files to store edits.
+      // This results in two sync change events: change + rename and two sync builds.
+      // Using setImmediate will ensure that only one build done.
+      setImmediate(() => {
+        if (needRebuild()) {
+          if (process.env.BS_WATCH_CLEAR && console.clear) {
+            console.clear();
+          }
+          build(0);
+        }
+      });
+    }
+  }
+
+  /**
+   *
+   * @param {boolean} withWebSocket
+   */
+  function startWatchMode(withWebSocket) {
+    if (withWebSocket) {
+      setUpWebSocket();
+    }
+    // for column one based error message
+
+    process.stdin.on("close", exitProcess);
+    // close when stdin stops
+    if (os.platform() !== "win32") {
+      process.stdin.on("end", exitProcess);
+      process.stdin.resume();
+    }
+
+    watchers.push({ watcher: fs.watch(bsconfig, onChange), dir: bsconfig });
+  }
+
+  logStartCompiling();
+  delegateCommand(delegatedArgs, () => {
+    startWatchMode(withWebSocket);
+    buildFinishedCallback(0);
+  });
+} else {
   switch (maybeSubcommand) {
+    case "info":
+    case "clean": {
+      delegateCommand(process_argv.slice(2));
+      break;
+    }
+    case undefined:
+    case "build": {
+      logStartCompiling();
+      delegateCommand(process_argv.slice(2), logFinishCompiling);
+      break;
+    }
     case "format":
       require("./scripts/rescript_format.js").main(
         process.argv.slice(3),
@@ -271,298 +574,5 @@ if (
       console.error(`Unknown subcommand or flags: ${maybeSubcommand}`);
       help();
       process.exit(2);
-  }
-} else {
-  var delegatedArgs = process_argv.slice(2);
-  var isWatchMode = delegatedArgs.includes("-w");
-  var wsParamIndex = delegatedArgs.indexOf("-ws");
-  if (wsParamIndex > -1) {
-    var hostAndPortNumber = (delegatedArgs[wsParamIndex + 1] || "").split(":");
-    /**
-     * @type {number}
-     */
-    var portNumber;
-    if (hostAndPortNumber.length === 1) {
-      portNumber = parseInt(hostAndPortNumber[0]);
-    } else {
-      webSocketHost = hostAndPortNumber[0];
-      portNumber = parseInt(hostAndPortNumber[1]);
-    }
-    if (!isNaN(portNumber)) {
-      webSocketPort = portNumber;
-    }
-    withWebSocket = true;
-    dlog(`WebSocket host & port number: ${webSocketHost}:${webSocketPort}`);
-  }
-
-  verbose = delegatedArgs.includes("-verbose");
-  /**
-   * @type {child_process.ChildProcess}
-   */
-  var p;
-  if (acquireBuild()) {
-    try {
-      p = child_process.spawn(rescript_exe, delegatedArgs, {
-        stdio: "inherit",
-      });
-      LAST_BUILD_START = Date.now();
-    } catch (e) {
-      if (e.code === "ENOENT") {
-        // when bsb is actually not found
-        console.error(String(e));
-      }
-      releaseBuild();
-      process.exit(2);
-    }
-    // The 'close' event will always emit after 'exit' was already emitted, or
-    // 'error' if the child failed to spawn.
-    p.on("close", code => {
-      releaseBuild();
-      if (code !== 0) {
-        process.exit(code);
-      } else if (isWatchMode) {
-        startWatchMode(withWebSocket);
-      }
-    });
-  } else {
-    console.warn(`Another build detected or stale lockfile ${lockFileName}`);
-    // racing magic code
-    process.exit(133);
-  }
-  /**
-   *
-   * @param {boolean} withWebSocket
-   */
-  function startWatchMode(withWebSocket) {
-    if (withWebSocket) {
-      setUpWebSocket();
-    }
-    // for column one based error message
-
-    /**
-     * watchers are held so that we close it later
-     */
-    var watchers = [];
-
-    process.stdin.on("close", exitProcess);
-    // close when stdin stops
-    if (os.platform() !== "win32") {
-      process.stdin.on("end", exitProcess);
-      process.stdin.resume();
-    }
-
-    var sourcedirs = path.join("lib", "bs", ".sourcedirs.json");
-    var watchGenerated = [];
-
-    function watchBuild(watchConfig) {
-      var watchFiles = watchConfig.dirs;
-      watchGenerated = watchConfig.generated;
-      // close and remove all unused watchers
-      watchers = watchers.filter(function (watcher) {
-        if (watcher.dir === bsconfig) {
-          return true;
-        } else if (watchFiles.indexOf(watcher.dir) < 0) {
-          dlog(`${watcher.dir} is no longer watched`);
-          watcher.watcher.close();
-          return false;
-        } else {
-          return true;
-        }
-      });
-
-      // adding new watchers
-      for (var i = 0; i < watchFiles.length; ++i) {
-        var dir = watchFiles[i];
-        if (
-          !watchers.find(function (watcher) {
-            return watcher.dir === dir;
-          })
-        ) {
-          dlog(`watching dir ${dir} now`);
-          var watcher = fs.watch(dir, onChange);
-          watchers.push({ dir: dir, watcher: watcher });
-        } else {
-          // console.log(dir, 'already watched')
-        }
-      }
-    }
-
-    /**
-     * @param {string | null} fileName
-     */
-    function checkIsRebuildReason(fileName) {
-      // Return true if filename is nil, filename is only provided on Linux, macOS, Windows, and AIX.
-      // On other systems, we just have to assume that any change is valid.
-      // This could cause problems if source builds (generating js files in the same directory) are supported.
-      if (!fileName) return true;
-
-      return !(
-        fileName === ".merlin" ||
-        fileName.endsWith(".js") ||
-        fileName.endsWith(".mjs") ||
-        fileName.endsWith(".cjs") ||
-        fileName.endsWith(genTypeFileExtension) ||
-        watchGenerated.indexOf(fileName) >= 0 ||
-        fileName.endsWith(".swp")
-      );
-    }
-
-    /**
-     * @return {boolean}
-     */
-    function needRebuild() {
-      return reasonsToRebuild.length !== 0;
-    }
-
-    function logFinish(code) {
-      let log = `>>>> Finish compiling`;
-      if (code !== 0) {
-        log = log + " (exit: " + code + ")";
-      }
-      if (std_is_tty) {
-        log = "\x1b[36m" + log + "\x1b[0m";
-      }
-      if (code !== 0) {
-        console.log(log);
-      } else {
-        console.log(log, Math.floor(updateFinishTime() / 1e6), "mseconds");
-      }
-    }
-
-    function logStart() {
-      updateStartTime();
-      let log = `>>>> Start compiling`;
-      if (std_is_tty) {
-        log = "\x1b[36m" + log + "\x1b[0m";
-      }
-      console.log(log);
-    }
-
-    /**
-     *
-     * @param code {number}
-     * @param signal {string}
-     */
-    function buildFinishedCallback(code, signal) {
-      if (code === 0) {
-        LAST_SUCCESS_BUILD_STAMP = Date.now();
-        notifyClients();
-        if (postBuild) {
-          dlog(`running postbuild command: ${postBuild}`);
-          child_process.exec(postBuild);
-        }
-      }
-      logFinish(code);
-      releaseBuild();
-      if (needRebuild()) {
-        build(0);
-      } else {
-        var files = getWatchFiles(sourcedirs);
-        watchBuild(files);
-      }
-    }
-
-    /**
-     * TODO: how to make it captured by vscode
-     * @param error {string}
-     * @param highlight {string}
-     */
-    function outputError(error, highlight) {
-      if (error_is_tty && highlight) {
-        process.stderr.write(
-          error.replace(highlight, "\x1b[1;31m" + highlight + "\x1b[0m")
-        );
-      } else {
-        process.stderr.write(error);
-      }
-    }
-    // Note this function filters the error output
-    // it relies on the fact that ninja will merege stdout and stderr
-    // of the compiler output, if it does not
-    // then we should have a way to not filter the compiler output
-    /**
-     *
-     * @param {number} depth
-     * @returns
-     */
-    function build(depth) {
-      if (reasonsToRebuild.length === 0) {
-        dlog("No need to rebuild");
-        return;
-      } else {
-        dlog(`Rebuilding since ${reasonsToRebuild}`);
-      }
-      if (acquireBuild()) {
-        logStart();
-        child_process
-          .spawn(rescript_exe, [], {
-            stdio: ["inherit", "inherit", "pipe"],
-          })
-          // @ts-ignore
-          .on("data", function (s) {
-            outputError(s, "ninja: error");
-          })
-          .on("exit", buildFinishedCallback)
-          .stderr.setEncoding("utf8");
-        // This is important to clean up all
-        // previous queued events
-        reasonsToRebuild = [];
-        LAST_BUILD_START = Date.now();
-      }
-      // if acquiring lock failed, no need retry here
-      // since buildFinishedCallback will try again
-      // however this is no longer the case for multiple-process
-      // it could fail due to other issues like .bsb.lock
-      else {
-        dlog(
-          `Acquire lock failed, do the build later ${depth} : ${reasonsToRebuild}`
-        );
-        var waitTime = Math.pow(2, depth) * 40;
-        setTimeout(function () {
-          var d = Math.min(depth + 1, 5);
-          build(d);
-        }, waitTime);
-      }
-    }
-    /**
-     *
-     * @param {fs.WatchEventType} event
-     * @param {string | null} reason
-     */
-    function onChange(event, reason) {
-      var eventTime = Date.now();
-      var timeDiff = eventTime - LAST_BUILD_START;
-      var eventDiff = eventTime - LAST_FIRED_EVENT;
-      dlog(`Since last build : ${timeDiff} -- ${eventDiff}`);
-      if (timeDiff < 5 || eventDiff < 5) {
-        // for 5ms, we could think that the ninja not get
-        // kicked yet, so there is really no need
-        // to send more events here
-
-        // note reasonsToRebuild also
-        // helps avoid redundant build, but this will
-        // save the event loop call `setImmediate`
-        return;
-      }
-      if (checkIsRebuildReason(reason)) {
-        dlog(`\nEvent ${event} ${reason}`);
-        LAST_FIRED_EVENT = eventTime;
-        reasonsToRebuild.push([event, reason || ""]);
-        // Some editors are using temporary files to store edits.
-        // This results in two sync change events: change + rename and two sync builds.
-        // Using setImmediate will ensure that only one build done.
-        setImmediate(() => {
-          if (needRebuild()) {
-            if (process.env.BS_WATCH_CLEAR && console.clear) {
-              console.clear();
-            }
-            build(0);
-          }
-        });
-      }
-    }
-
-    watchers.push({ watcher: fs.watch(bsconfig, onChange), dir: bsconfig });
-    build(0);
   }
 }


### PR DESCRIPTION
Fixed dependencies reinitialization on every save in watch mode.

Before:
<img width="418" alt="Screenshot 2023-09-15 at 03 27 26" src="https://github.com/rescript-lang/rescript-compiler/assets/49292466/034e9df2-9594-4cb8-88d1-e4b936571909">
After:
<img width="381" alt="Screenshot 2023-09-15 at 03 29 13" src="https://github.com/rescript-lang/rescript-compiler/assets/49292466/3677bb27-e2bc-4d69-b009-6bbc7513eb18">

Also:
- Actualized help for commands
- Started showing the compile time for `rescript build` command without watch mode
- Pass through the `-verbose` flag to builds in watch mode

What I want to do next:
- Fix the build needed condition.
- Resolve the problems with duplicated builds (existed before the changes)
- Enable watch mode for pinned dependencies 🤔
- Update documentation
