### PR TITLE
Add @as support for obj ppx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 #### :rocket: New Feature
 
 - Support renaming fields in inline records with `@as` attribute. [#6391](https://github.com/rescript-lang/rescript-compiler/pull/6391)
-- Support renaming fields of object created by `@obj` ppx with `@as` attribute. [#6391](https://github.com/rescript-lang/rescript-compiler/pull/6412)
+- Support renaming object fields of `@obj` external ppx with `@as` attribute. [#6391](https://github.com/rescript-lang/rescript-compiler/pull/6412)
 - Add builtin abstract types for File and Blob APIs. https://github.com/rescript-lang/rescript-compiler/pull/6383
 - Untagged variants: Support `promise`, RegExes, Dates, File and Blob. https://github.com/rescript-lang/rescript-compiler/pull/6383
 - Support aliased types as payloads to untagged variants. https://github.com/rescript-lang/rescript-compiler/pull/6394

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 #### :rocket: New Feature
 
 - Support renaming fields in inline records with `@as` attribute. [#6391](https://github.com/rescript-lang/rescript-compiler/pull/6391)
+- Support renaming fields of object created by `@obj` ppx with `@as` attribute. [#6391](https://github.com/rescript-lang/rescript-compiler/pull/6412)
 - Add builtin abstract types for File and Blob APIs. https://github.com/rescript-lang/rescript-compiler/pull/6383
 - Untagged variants: Support `promise`, RegExes, Dates, File and Blob. https://github.com/rescript-lang/rescript-compiler/pull/6383
 - Support aliased types as payloads to untagged variants. https://github.com/rescript-lang/rescript-compiler/pull/6394

--- a/jscomp/frontend/ast_external_process.ml
+++ b/jscomp/frontend/ast_external_process.ml
@@ -349,27 +349,6 @@ type response = {
   no_inline_cross_module: bool;
 }
 
-let get_maybe_obj_field_alias attributes =
-  attributes
-  |> List.find_map (fun (attr : Parsetree.attribute) ->
-         match attr with
-         | ( {txt = "as"; _},
-             PStr
-               [
-                 {
-                   pstr_desc =
-                     Pstr_eval
-                       ( {
-                           pexp_desc = Pexp_constant (Pconst_string (alias, _));
-                           _;
-                         },
-                         _ );
-                   _;
-                 };
-               ] ) ->
-           Some alias
-         | _ -> None)
-
 let process_obj (loc : Location.t) (st : external_desc) (prim_name : string)
     (arg_types_ty : Ast_core_type.param_type list)
     (result_type : Ast_core_type.t) : Parsetree.core_type * External_ffi_types.t
@@ -421,7 +400,7 @@ let process_obj (loc : Location.t) (st : external_desc) (prim_name : string)
                   "expect label, optional, or unit here")
             | Labelled label -> (
               let fieldName =
-                match get_maybe_obj_field_alias param_type.attr with
+                match Ast_attributes.iter_process_bs_string_as param_type.attr with
                 | Some alias -> alias
                 | None -> label
               in
@@ -481,7 +460,7 @@ let process_obj (loc : Location.t) (st : external_desc) (prim_name : string)
                   "%@obj label %s does not support %@unwrap arguments" label)
             | Optional label -> (
               let fieldName =
-                match get_maybe_obj_field_alias param_type.attr with
+                match Ast_attributes.iter_process_bs_string_as param_type.attr with
                 | Some alias -> alias
                 | None -> label
               in

--- a/jscomp/frontend/ast_external_process.ml
+++ b/jscomp/frontend/ast_external_process.ml
@@ -400,7 +400,9 @@ let process_obj (loc : Location.t) (st : external_desc) (prim_name : string)
                   "expect label, optional, or unit here")
             | Labelled label -> (
               let fieldName =
-                match Ast_attributes.iter_process_bs_string_as param_type.attr with
+                match
+                  Ast_attributes.iter_process_bs_string_as param_type.attr
+                with
                 | Some alias -> alias
                 | None -> label
               in
@@ -460,7 +462,9 @@ let process_obj (loc : Location.t) (st : external_desc) (prim_name : string)
                   "%@obj label %s does not support %@unwrap arguments" label)
             | Optional label -> (
               let fieldName =
-                match Ast_attributes.iter_process_bs_string_as param_type.attr with
+                match
+                  Ast_attributes.iter_process_bs_string_as param_type.attr
+                with
                 | Some alias -> alias
                 | None -> label
               in

--- a/jscomp/frontend/ast_external_process.ml
+++ b/jscomp/frontend/ast_external_process.ml
@@ -349,12 +349,26 @@ type response = {
   no_inline_cross_module: bool;
 }
 
-let get_maybe_obj_field_alias (attributes) =
-  attributes |> List.find_map (fun (attr: Parsetree.attribute) -> match attr with
-  | ({txt = "as"; _}, PStr [ { pstr_desc = Pstr_eval ({ pexp_desc = Pexp_constant (Pconst_string (alias, _)); _}, _); _ } ]) -> Some(alias)
-  | _ -> None
-  )
-
+let get_maybe_obj_field_alias attributes =
+  attributes
+  |> List.find_map (fun (attr : Parsetree.attribute) ->
+         match attr with
+         | ( {txt = "as"; _},
+             PStr
+               [
+                 {
+                   pstr_desc =
+                     Pstr_eval
+                       ( {
+                           pexp_desc = Pexp_constant (Pconst_string (alias, _));
+                           _;
+                         },
+                         _ );
+                   _;
+                 };
+               ] ) ->
+           Some alias
+         | _ -> None)
 
 let process_obj (loc : Location.t) (st : external_desc) (prim_name : string)
     (arg_types_ty : Ast_core_type.param_type list)
@@ -406,9 +420,10 @@ let process_obj (loc : Location.t) (st : external_desc) (prim_name : string)
                 Location.raise_errorf ~loc
                   "expect label, optional, or unit here")
             | Labelled label -> (
-              let fieldName = match get_maybe_obj_field_alias param_type.attr with
-              | Some(alias) -> alias
-              | None -> label
+              let fieldName =
+                match get_maybe_obj_field_alias param_type.attr with
+                | Some alias -> alias
+                | None -> label
               in
               let obj_arg_type = refine_obj_arg_type ~nolabel:false ty in
               match obj_arg_type with
@@ -465,9 +480,10 @@ let process_obj (loc : Location.t) (st : external_desc) (prim_name : string)
                 Location.raise_errorf ~loc
                   "%@obj label %s does not support %@unwrap arguments" label)
             | Optional label -> (
-              let fieldName = match get_maybe_obj_field_alias param_type.attr with
-              | Some(alias) -> alias
-              | None -> label
+              let fieldName =
+                match get_maybe_obj_field_alias param_type.attr with
+                | Some alias -> alias
+                | None -> label
               in
               let obj_arg_type = get_opt_arg_type ~nolabel:false ty in
               match obj_arg_type with

--- a/jscomp/gentype/TranslateStructure.ml
+++ b/jscomp/gentype/TranslateStructure.ml
@@ -57,6 +57,7 @@ and addAnnotationsToFields ~config (expr : Typedtree.expression)
   | _ -> (fields, argTypes)
   [@@live]
 
+[@@live]
 (** Recover from expr the renaming annotations on named arguments. *)
 let addAnnotationsToFunctionType ~config (expr : Typedtree.expression)
     (type_ : type_) =

--- a/jscomp/gentype/TranslateStructure.ml
+++ b/jscomp/gentype/TranslateStructure.ml
@@ -57,7 +57,6 @@ and addAnnotationsToFields ~config (expr : Typedtree.expression)
   | _ -> (fields, argTypes)
   [@@live]
 
-[@@live]
 (** Recover from expr the renaming annotations on named arguments. *)
 let addAnnotationsToFunctionType ~config (expr : Typedtree.expression)
     (type_ : type_) =

--- a/jscomp/syntax/tests/ppx/react/expected/mangleKeyword.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/mangleKeyword.res.txt
@@ -1,21 +1,38 @@
 @@jsxConfig({version: 3})
 
-module C30 = {
-  @obj external makeProps: (~_open: 'T_open, ~key: string=?, unit) => {"_open": 'T_open} = ""
+module C3A0 = {
+  @obj
+  external makeProps: (
+    ~_open: 'T_open,
+    ~_type: string,
+    ~key: string=?,
+    unit,
+  ) => {"_open": 'T_open, "_type": string} = ""
 
-  @react.component let make = @warning("-16") (~_open) => React.string(_open)
+  @react.component
+  let make =
+    @warning("-16")
+    (@as("open") ~_open) => @warning("-16") (@as("type") ~_type: string) => React.string(_open)
   let make = {
-    let \"MangleKeyword$C30" = (\"Props": {"_open": 'T_open}) => make(~_open=\"Props"["_open"])
-    \"MangleKeyword$C30"
+    let \"MangleKeyword$C3A0" = (\"Props": {"_open": 'T_open, "_type": string}) =>
+      make(~_type=\"Props"["_type"], ~_open=\"Props"["_open"])
+    \"MangleKeyword$C3A0"
   }
 }
-module C31 = {
-  @obj external makeProps: (~_open: string, ~key: string=?, unit) => {"_open": string} = ""
-  external make: React.componentLike<{"_open": string}, React.element> = "default"
+module C3A1 = {
+  @obj
+  external makeProps: (
+    ~_open: string,
+    ~_type: string,
+    ~key: string=?,
+    unit,
+  ) => {"_open": string, "_type": string} = ""
+  external make: @as("open")
+  React.componentLike<{"_open": string, "_type": string}, React.element> = "default"
 }
 
-let c30 = React.createElement(C30.make, C30.makeProps(~_open="x", ()))
-let c31 = React.createElement(C31.make, C31.makeProps(~_open="x", ()))
+let c3a0 = React.createElement(C3A0.make, C3A0.makeProps(~_open="x", ~_type="t", ()))
+let c3a1 = React.createElement(C3A1.make, C3A1.makeProps(~_open="x", ~_type="t", ()))
 
 @@jsxConfig({version: 4, mode: "classic"})
 

--- a/jscomp/syntax/tests/ppx/react/mangleKeyword.res
+++ b/jscomp/syntax/tests/ppx/react/mangleKeyword.res
@@ -1,16 +1,18 @@
 @@jsxConfig({version: 3})
 
-module C30 = {
+module C3A0 = {
   @react.component
-  let make = (~_open) => React.string(_open)
+  let make =
+    (@as("open") ~_open, @as("type") ~_type: string) => React.string(_open)
 }
-module C31 = {
+module C3A1 = {
   @react.component
-  external make: (~_open: string) => React.element = "default"
+  external make: (@as("open") ~_open: string, @as("type") ~_type: string) => React.element =
+    "default"
 }
 
-let c30 = <C30 _open="x" />
-let c31 = <C31 _open="x" />
+let c3a0 = <C3A0 _open="x" _type="t" />
+let c3a1 = <C3A1 _open="x" _type="t" />
 
 @@jsxConfig({version: 4, mode: "classic"})
 

--- a/jscomp/test/external_ppx.js
+++ b/jscomp/test/external_ppx.js
@@ -3,6 +3,17 @@
 
 var External_ppxGen = require("./external_ppx.gen");
 
+function renamed(param) {
+  var tmp = {
+    type: "123",
+    normal: 12
+  };
+  if (param !== undefined) {
+    tmp.WIDTH = param;
+  }
+  return tmp;
+}
+
 var u = {
   hi: 2,
   lo: 3,
@@ -15,6 +26,7 @@ function f(prim) {
   return External_ppxGen.f(prim);
 }
 
+exports.renamed = renamed;
 exports.u = u;
 exports.f = f;
 /* ./external_ppx.gen Not a pure module */

--- a/jscomp/test/external_ppx.res
+++ b/jscomp/test/external_ppx.res
@@ -10,6 +10,15 @@ external make_config: (~length: 'a, ~width: int) => unit = ""
 @obj external opt_make: (~length: int, ~width: int=?) => (_ as 'event) = ""
 
 @obj
+external renamed_make: (
+  @as("type") ~_type: string,
+  @as("WIDTH") ~width: int=?,
+  ~normal: float,
+) => (_ as 'event) = ""
+
+let renamed = renamed_make(~_type="123", ~normal=12.)
+
+@obj
 external ff: (
   ~hi: int,
   ~lo: @as(3) _,


### PR DESCRIPTION
After we removed field mangling, it happened that it was not possible to migrate to rescript@11 because rescript-relay relied on it to support queriend data having names as reserved keywords. So, as an alternative solution for the field mangling, I think we should allow creating field aliases in the obj ppx, as it works in other places.

@zth Will you be able to update rescript-relay to use `@as` instead of prefixing reserved keywords with underscore? Or should I do this? It's currently the only blocker for us to start using rescript@11 at Carla.