### PR TITLE
Fix allowing using dyanmic import of module instead of async function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Fix issue with Dynamic import of module in nested expressions https://github.com/rescript-lang/rescript-compiler/pull/6431
 - Fix issue where GenType was not supporting `@tag` on ordinary variatns https://github.com/rescript-lang/rescript-compiler/pull/6437
+- Fixed using dynamic import of module in block instead of async function https://github.com/rescript-lang/rescript-compiler/pull/6434
 
 #### :nail_care: Polish
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 - Fix issue with Dynamic import of module in nested expressions https://github.com/rescript-lang/rescript-compiler/pull/6431
 - Fix issue where GenType was not supporting `@tag` on ordinary variatns https://github.com/rescript-lang/rescript-compiler/pull/6437
-- Fixed using dynamic import of module in block instead of async function https://github.com/rescript-lang/rescript-compiler/pull/6434
+- Fix using dynamic import of module in block instead of async function https://github.com/rescript-lang/rescript-compiler/pull/6434
 
 #### :nail_care: Polish
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@
 
 #### :bug: Bug Fix
 
-- Fix issue with Dynamic import of module in nested expressions https://github.com/rescript-lang/rescript-compiler/pull/6431
+- Fix issue with dynamic import of module in nested expressions https://github.com/rescript-lang/rescript-compiler/pull/6431
 - Fix issue where GenType was not supporting `@tag` on ordinary variatns https://github.com/rescript-lang/rescript-compiler/pull/6437
 - Fix using dynamic import of module in block instead of async function https://github.com/rescript-lang/rescript-compiler/pull/6434
+- Fix issue with using dynamic import of module in uncurried mode https://github.com/rescript-lang/rescript-compiler/pull/6434
 
 #### :nail_care: Polish
 

--- a/jscomp/frontend/bs_builtin_ppx.ml
+++ b/jscomp/frontend/bs_builtin_ppx.ml
@@ -620,6 +620,7 @@ let rec structure_mapper ~await_context (self : mapper) (stru : Ast_structure.t)
             | Pexp_let (_, vbs, expr) -> aux expr @ spelunk_vbs acc vbs
             | Pexp_ifthenelse (_, then_expr, Some else_expr) ->
               aux then_expr @ aux else_expr
+            | Pexp_construct (_, Some expr) -> aux expr
             | Pexp_fun (_, _, _, expr) | Pexp_newtype (_, expr) -> aux expr
             | _ -> acc
           in


### PR DESCRIPTION
This PR fixes not allowing to using the dynamic import of module in the normal function that is not async function.
```res
// should not compiled
let f0 = () => {
  module O = await Belt.Option
  O.forEach
}

// Ok
let f1 = async () => {
  module O = await Belt.Option
  O.forEach
}
```

Plus, This PR fixes build error using the dynamic import of module in uncurried mode:
```res
// should be fine in uncurried mode
let f1 = async () => {
  module O = await Belt.Option
  O.forEach
}
```