### PR TITLE
Support coercing string to elgible untagged variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 #### :rocket: New Feature
 - Allow coercing unboxed variants with only strings (now including with a single payload of string) to the primitive string. https://github.com/rescript-lang/rescript-compiler/pull/6441
-- Allow coercing strings to unboxed variants that are coercable to string and has a catch-all unboxed string case. https://github.com/rescript-lang/rescript-compiler/pull/6443
+- Allow coercing strings to unboxed variants that has a catch-all unboxed string case. https://github.com/rescript-lang/rescript-compiler/pull/6443
 
 #### :bug: Bug Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 #### :rocket: New Feature
 - Allow coercing unboxed variants with only strings (now including with a single payload of string) to the primitive string. https://github.com/rescript-lang/rescript-compiler/pull/6441
+- Allow coercing strings to unboxed variants that are coercable to string and has a catch-all unboxed string case. https://github.com/rescript-lang/rescript-compiler/pull/6443
 
 #### :bug: Bug Fix
 

--- a/jscomp/build_tests/super_errors/expected/variant_coercion_string_to_variant_no_payload.res.expected
+++ b/jscomp/build_tests/super_errors/expected/variant_coercion_string_to_variant_no_payload.res.expected
@@ -1,0 +1,10 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/variant_coercion_string_to_variant_no_payload.res[0m:[2m6:10-15[0m
+
+  4 [2m│[0m let x = "one"
+  5 [2m│[0m 
+  [1;31m6[0m [2m│[0m let y = ([1;31mx :> x[0m)
+  7 [2m│[0m 
+
+  Type string is not a subtype of x

--- a/jscomp/build_tests/super_errors/fixtures/variant_coercion_string_to_variant_no_payload.res
+++ b/jscomp/build_tests/super_errors/fixtures/variant_coercion_string_to_variant_no_payload.res
@@ -1,0 +1,6 @@
+@unboxed
+type x = One | Two
+
+let x = "one"
+
+let y = (x :> x)

--- a/jscomp/ml/ctype.ml
+++ b/jscomp/ml/ctype.ml
@@ -3951,6 +3951,25 @@ let rec subtype_rec env trace t1 t2 cstrs =
         end
     | (Tconstr(p1, _, _), _) when generic_private_abbrev env p1 ->
         subtype_rec env trace (expand_abbrev_opt env t1) t2 cstrs
+    | (Tconstr(path, [], _), Tconstr(_, [], _)) when Path.same path Predef.path_string && 
+        extract_concrete_typedecl env t2 |> Variant_coercion.can_try_coerce_variant_to_primitive |> Option.is_some
+        ->
+      (* type coercion for strings to elgible unboxed variants:
+         - must be unboxed
+         - must coercable to string
+         - must have a constructor case with a string payload *)
+      (match Variant_coercion.can_try_coerce_variant_to_primitive (extract_concrete_typedecl env t2) with
+      | Some (constructors, true) -> 
+        if constructors |> Variant_coercion.can_coerce_variant ~path ~unboxed:true 
+          && constructors |> List.exists(fun (c: constructor_declaration) -> 
+            match c.cd_args with 
+            | Cstr_tuple [{desc=Tconstr (p, [], _)}] when Path.same p Predef.path_string -> true 
+            | _ -> false) 
+        then
+          cstrs
+        else 
+          (trace, t1, t2, !univar_pairs)::cstrs
+      | _ -> (trace, t1, t2, !univar_pairs)::cstrs)
     | (Tconstr(_, [], _), Tconstr(path, [], _)) when Variant_coercion.can_coerce_path path && 
         extract_concrete_typedecl env t1 |> Variant_coercion.can_try_coerce_variant_to_primitive |> Option.is_some
         ->

--- a/jscomp/ml/ctype.ml
+++ b/jscomp/ml/ctype.ml
@@ -3956,16 +3956,10 @@ let rec subtype_rec env trace t1 t2 cstrs =
         ->
       (* type coercion for strings to elgible unboxed variants:
          - must be unboxed
-         - must coercable to string
          - must have a constructor case with a string payload *)
       (match Variant_coercion.can_try_coerce_variant_to_primitive (extract_concrete_typedecl env t2) with
       | Some (constructors, true) -> 
-        if constructors |> Variant_coercion.variant_has_same_runtime_representation_as_target ~targetPath:path ~unboxed:true 
-          && constructors |> List.exists(fun (c: constructor_declaration) -> 
-            match c.cd_args with 
-            | Cstr_tuple [{desc=Tconstr (p, [], _)}] when Path.same p Predef.path_string -> true 
-            | _ -> false) 
-        then
+        if constructors |> Variant_coercion.variant_has_catch_all_string_case then
           cstrs
         else 
           (trace, t1, t2, !univar_pairs)::cstrs

--- a/jscomp/ml/ctype.ml
+++ b/jscomp/ml/ctype.ml
@@ -3960,7 +3960,7 @@ let rec subtype_rec env trace t1 t2 cstrs =
          - must have a constructor case with a string payload *)
       (match Variant_coercion.can_try_coerce_variant_to_primitive (extract_concrete_typedecl env t2) with
       | Some (constructors, true) -> 
-        if constructors |> Variant_coercion.can_coerce_variant ~path ~unboxed:true 
+        if constructors |> Variant_coercion.variant_has_same_runtime_representation_as_target ~targetPath:path ~unboxed:true 
           && constructors |> List.exists(fun (c: constructor_declaration) -> 
             match c.cd_args with 
             | Cstr_tuple [{desc=Tconstr (p, [], _)}] when Path.same p Predef.path_string -> true 

--- a/jscomp/ml/variant_coercion.ml
+++ b/jscomp/ml/variant_coercion.ml
@@ -9,6 +9,17 @@ let can_coerce_path (path : Path.t) =
 let check_paths_same p1 p2 target_path =
   Path.same p1 target_path && Path.same p2 target_path
 
+let variant_has_catch_all_string_case (constructors : Types.constructor_declaration list) =
+  let has_catch_all_string_case (c : Types.constructor_declaration) =
+    let args = c.cd_args in
+    match args with
+    | Cstr_tuple [{desc = Tconstr (p, [], _)}] ->
+      Path.same p Predef.path_string
+    | _ -> false
+  in
+
+  constructors |> List.exists has_catch_all_string_case 
+
 (* Checks if every case of the variant has the same runtime representation as the target type. *)
 let variant_has_same_runtime_representation_as_target ~(targetPath : Path.t)
     ~unboxed (constructors : Types.constructor_declaration list) =

--- a/jscomp/test/VariantCoercion.js
+++ b/jscomp/test/VariantCoercion.js
@@ -29,7 +29,18 @@ var CoerceWithPayload = {
   dd: 2
 };
 
-var a$1 = "Three";
+var a$1 = "hello";
+
+var aa = "First";
+
+var CoerceFromStringToVariant = {
+  a: a$1,
+  aa: aa,
+  b: a$1,
+  bb: aa
+};
+
+var a$2 = "Three";
 
 var b = "Three";
 
@@ -41,7 +52,7 @@ var ii = 1.1;
 
 var dd = 1.1;
 
-exports.a = a$1;
+exports.a = a$2;
 exports.b = b;
 exports.i = i;
 exports.d = d;
@@ -49,4 +60,5 @@ exports.ii = ii;
 exports.dd = dd;
 exports.CoerceVariants = CoerceVariants;
 exports.CoerceWithPayload = CoerceWithPayload;
+exports.CoerceFromStringToVariant = CoerceFromStringToVariant;
 /* No side effect */

--- a/jscomp/test/VariantCoercion.js
+++ b/jscomp/test/VariantCoercion.js
@@ -33,11 +33,15 @@ var a$1 = "hello";
 
 var aa = "First";
 
+var c$1 = "Hi";
+
 var CoerceFromStringToVariant = {
   a: a$1,
   aa: aa,
   b: a$1,
-  bb: aa
+  bb: aa,
+  c: c$1,
+  cc: c$1
 };
 
 var a$2 = "Three";

--- a/jscomp/test/VariantCoercion.res
+++ b/jscomp/test/VariantCoercion.res
@@ -44,3 +44,11 @@ module CoerceWithPayload = {
   let d: float = (c :> float)
   let dd: float = (cc :> float)
 }
+
+module CoerceFromStringToVariant = {
+  @unboxed type strings = String(string) | First | Second | Third
+  let a = "hello"
+  let aa = "First"
+  let b: strings = (a :> strings)
+  let bb: strings = (aa :> strings)
+}

--- a/jscomp/test/VariantCoercion.res
+++ b/jscomp/test/VariantCoercion.res
@@ -51,4 +51,8 @@ module CoerceFromStringToVariant = {
   let aa = "First"
   let b: strings = (a :> strings)
   let bb: strings = (aa :> strings)
+
+  @unboxed type mixed = String(string) | @as(1) One | @as(null) Null | Two
+  let c = "Hi"
+  let cc: mixed = (c :> mixed)
 }


### PR DESCRIPTION
Adds support for a very specific (but useful) coercion - from `string` to an unboxed (elgible) variant:
```rescript
@unboxed
type x = One | Two | Other(string)

let x = "Hello"

let y = (x :> x)

let f = switch y {
| One => "hollo"
| _ => "bollo"
}
```

This works because the variant is unboxed, and because there's a "catch all" unboxed `string` constructor in the variant, that will catch any provided string that doesn't map to `One` or `Two`.

Criteria for this coercion to work:
- Variant must be unboxed
- All variant construtors must be coercable to string (criterion for this is covered elsewhere)
- There must be a constructor case with a string payload. This acts as a "catch all" (because it's unboxed) and is what makes the variant cover all possible cases of `string`