### PR TITLE
Playground: implicitly opened modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Allow coercing unboxed variants with only strings (now including with a single payload of string) to the primitive string. https://github.com/rescript-lang/rescript-compiler/pull/6441
 - Allow coercing strings to unboxed variants that has a catch-all unboxed string case. https://github.com/rescript-lang/rescript-compiler/pull/6443
 - Allow coercing `int` to `float`. https://github.com/rescript-lang/rescript-compiler/pull/6448
+- Playground: Add support for implicitly opened modules. https://github.com/rescript-lang/rescript-compiler/pull/6446
 
 #### :bug: Bug Fix
 

--- a/playground/playground_test.js
+++ b/playground/playground_test.js
@@ -5,10 +5,10 @@ require("./packages/@rescript/core/cmij.js")
 
 let compiler = rescript_compiler.make()
 
+compiler.setOpenModules(["RescriptCore"])
+
 let result = compiler.rescript.compile(`
   @@jsxConfig({ version: 4, mode: "automatic" })
-
-  open RescriptCore
 
   module A = {
     @react.component


### PR DESCRIPTION
This one is a prerequisite for the v11 docs so that we do not need to have `open RescriptCore` in every example.
See also: https://github.com/rescript-association/rescript-lang.org/issues/718