### PR TITLE
Fix forwardRef in uncurried mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fix issue where GenType was not supporting `@tag` on ordinary variatns https://github.com/rescript-lang/rescript-compiler/pull/6437
 - Fix using dynamic import of module in block instead of async function https://github.com/rescript-lang/rescript-compiler/pull/6434
 - Fix issue with using dynamic import of module in uncurried mode https://github.com/rescript-lang/rescript-compiler/pull/6434
+- Fix build error where JSX v4 transformation of the discouraged forwardRef in uncurried mode https://github.com/rescript-lang/rescript-compiler/pull/6447
 
 #### :nail_care: Polish
 

--- a/jscomp/syntax/src/reactjs_jsx_v4.ml
+++ b/jscomp/syntax/src/reactjs_jsx_v4.ml
@@ -968,7 +968,8 @@ let mapBinding ~config ~emptyLoc ~pstr_loc ~fileName ~recFlag binding =
     let fullExpression =
       if !Config.uncurried = Uncurried then
         fullExpression
-        |> Ast_uncurried.uncurriedFun ~loc:fullExpression.pexp_loc ~arity:1
+        |> Ast_uncurried.uncurriedFun ~loc:fullExpression.pexp_loc
+             ~arity:(if hasForwardRef then 2 else 1)
       else fullExpression
     in
     let fullExpression =


### PR DESCRIPTION
This PR fixes JSX v4 in the build error of the discouraged forward ref usage, e.g. https://rescript-lang.org/docs/react/latest/forwarding-refs#discouraged-reactforwardref
