### PR TITLE
Make `unsafe_await` ghost location.

### DIFF
--- a/jscomp/ml/ast_await.ml
+++ b/jscomp/ml/ast_await.ml
@@ -2,7 +2,7 @@ let is_await : Parsetree.attribute -> bool =
   fun ({txt}, _) -> txt = "await" || txt = "res.await"
 
 let create_await_expression (e : Parsetree.expression) =
-  let loc = e.pexp_loc in
+  let loc = {e.pexp_loc with loc_ghost = true} in
   let unsafe_await =
     Ast_helper.Exp.ident ~loc
       {txt = Ldot (Ldot (Lident "Js", "Promise"), "unsafe_await"); loc}


### PR DESCRIPTION
So it does not cover the rest on hover.

https://github.com/rescript-lang/rescript-vscode/issues/838