### PR TITLE
Proposal: allow opening files from the current project globally

### DIFF
--- a/jscomp/core/js_implementation.ml
+++ b/jscomp/core/js_implementation.ml
@@ -64,7 +64,7 @@ let after_parsing_sig ppf outputprefix ast =
     else
       let modulename = module_of_filename outputprefix in
       Lam_compile_env.reset ();
-      let initial_env = Res_compmisc.initial_env () in
+      let initial_env = Res_compmisc.initial_env ~modulename () in
       Env.set_unit_name modulename;
       let tsg = Typemod.transl_signature initial_env ast in
       if !Clflags.dump_typedtree then
@@ -149,7 +149,7 @@ let after_parsing_impl ppf outputprefix (ast : Parsetree.structure) =
     else
       let modulename = Ext_filename.module_name outputprefix in
       Lam_compile_env.reset ();
-      let env = Res_compmisc.initial_env () in
+      let env = Res_compmisc.initial_env ~modulename () in
       Env.set_unit_name modulename;
       let typedtree, coercion, _, _ =
         Typemod.type_implementation_more

--- a/jscomp/core/res_compmisc.ml
+++ b/jscomp/core/res_compmisc.ml
@@ -41,8 +41,13 @@ let open_implicit_module m env =
   in
   snd (Typemod.type_open_ Override env lid.loc lid)
 
-let initial_env () =
+let initial_env ?(modulename) () =
   Ident.reinit ();
+  let open_modules = (match modulename with 
+  | None -> !Clflags.open_modules 
+  | Some modulename -> 
+    !Clflags.open_modules |> List.filter(fun m -> m <> modulename)
+  ) in
   let initial = Env.initial_safe_string in
   let env =
     if !Clflags.nopervasives then initial
@@ -51,4 +56,4 @@ let initial_env () =
   List.fold_left
     (fun env m -> open_implicit_module m env)
     env
-    (List.rev !Clflags.open_modules)
+    (List.rev open_modules)

--- a/jscomp/core/res_compmisc.mli
+++ b/jscomp/core/res_compmisc.mli
@@ -24,4 +24,4 @@
 
 val init_path : unit -> unit
 
-val initial_env : unit -> Env.t
+val initial_env : ?modulename : string -> unit -> Env.t


### PR DESCRIPTION
This is for discussion/a proposal.

We have a situation right now where you can use `-open` in `bsc-flags` to open modules globally. This is quite useful in many cases. However, you're only able to open modules from external dependencies, not modules from your current project, as that would create a circular dependency as it'd also be opened in itself. This PR changes that so that the globally opened module won't be opened in itself.

I'm not sure if this is something we want to allow, nor what the consequences would be. But, it would be useful in many scenarios given that you could put together your own globally available little "stdlib". The usefulness might be a bit negated by the fact that it'd be quite restricted - you couldn't reference other files in your project as _those_ would get the open injected, and by that create a circular dep. It might also cause excessive compilation times when you change your globally opened file, as all project files will now depend on that.

So, unclear if the upsides beat the downsides.

Comments and discussion welcome!