### PR TITLE
Fix issue where an inline record with attributes did not parse.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 - Allow empty inline records in variants. https://github.com/rescript-lang/rescript-compiler/pull/6494
 - Allow empty record patterns in pattern matching. https://github.com/rescript-lang/rescript-compiler/pull/6494
 
+#### :bug: Bug Fix
+- Fix issue where an inline record with attributes did not parse. https://github.com/rescript-lang/rescript-compiler/pull/6499
+
 # 11.0.0-rc.6
 
 #### :rocket: New Feature

--- a/jscomp/syntax/src/res_core.ml
+++ b/jscomp/syntax/src/res_core.ml
@@ -4675,12 +4675,15 @@ and parseConstrDeclArgs p =
                   let attrs =
                     if optional then optionalAttr :: attrs else attrs
                   in
-                  Parser.expect Comma p;
                   {field with Parsetree.pld_attributes = attrs}
                 in
-                first
-                :: parseCommaDelimitedRegion ~grammar:Grammar.FieldDeclarations
-                     ~closing:Rbrace ~f:parseFieldDeclarationRegion p
+                if p.token = Rbrace then [first]
+                else (
+                  Parser.expect Comma p;
+                  first
+                  :: parseCommaDelimitedRegion
+                       ~grammar:Grammar.FieldDeclarations ~closing:Rbrace
+                       ~f:parseFieldDeclarationRegion p)
             in
             Parser.expect Rbrace p;
             Parser.optional p Comma |> ignore;

--- a/jscomp/syntax/tests/parsing/grammar/expressions/expected/record.res.txt
+++ b/jscomp/syntax/tests/parsing/grammar/expressions/expected/record.res.txt
@@ -43,3 +43,6 @@ type nonrec multipleWithAttrs = {
   y: string [@res.optional ][@attr ]}
 type nonrec singleWithAttrs = {
   y: string [@res.optional ][@attr ]}
+type nonrec inlineWithAttrs =
+  | A of {
+  value: string [@as {js|VALUE|js}]} 

--- a/jscomp/syntax/tests/parsing/grammar/expressions/record.res
+++ b/jscomp/syntax/tests/parsing/grammar/expressions/record.res
@@ -50,3 +50,5 @@ type ttt = {x:int, y?: string}
 type multipleWithAttrs = {x:int, @attr y?: string}
 
 type singleWithAttrs = {@attr y?: string}
+
+type inlineWithAttrs = | A({@as("VALUE") value: string})


### PR DESCRIPTION
This did not parse without a `,` after the field:

```res
type inlineWithAttrs = | A({@as("VALUE") value: string})
```

Fixes https://github.com/rescript-lang/rescript-compiler/issues/6497