### PR TITLE
Fix issue with uncurried function with 1 arg being a variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 #### :bug: Bug Fix
 - Fix issue where an inline record with attributes did not parse. https://github.com/rescript-lang/rescript-compiler/pull/6499
+- Fix issue with uncurried function with 1 arg being a variable where an undefined variable could be emitted. https://github.com/rescript-lang/rescript-compiler/pull/6507
 
 # 11.0.0-rc.6
 

--- a/jscomp/core/lam_pass_alpha_conversion.ml
+++ b/jscomp/core/lam_pass_alpha_conversion.ml
@@ -71,7 +71,7 @@ let alpha_conversion (meta : Lam_stats.t) (lam : Lam.t) : Lam.t =
         | None -> Lam.prim ~primitive ~args:[ simpl arg ] loc)
     | Lprim { primitive = Pjs_fn_make_unit; args = [ arg ]; loc } ->
       let arg = match arg with
-      | Lfunction ({arity=1; params=[x]; attr; body}) ->
+      | Lfunction ({arity=1; params=[x]; attr; body}) when Ident.name x = "param" (* "()" *) ->
         Lam.function_ ~params:[x] ~attr:{attr with oneUnitArg=true} ~body ~arity:1
       | _ -> arg in
       simpl arg

--- a/jscomp/test/UncurriedAlways.js
+++ b/jscomp/test/UncurriedAlways.js
@@ -158,12 +158,32 @@ var OptMixed = {
   c3: c3
 };
 
+function fn(cb) {
+  return cb();
+}
+
+((function (s) {
+        console.log({
+              NAME: "foo",
+              VAL: s
+            });
+      })());
+
+function fn1(a, b, param) {
+  return a() + b | 0;
+}
+
+function a$1(__x) {
+  return fn1((function () {
+                return 1;
+              }), 2, __x);
+}
+
 exports.foo = foo;
 exports.z = z;
 exports.bar = bar;
 exports.b = b;
 exports.w = w;
-exports.a = a;
 exports.ptl = ptl;
 exports.foo2 = foo2;
 exports.bar2 = bar2;
@@ -175,4 +195,7 @@ exports.inl2 = inl2;
 exports.AllLabels = AllLabels;
 exports.OptAtEnd = OptAtEnd;
 exports.OptMixed = OptMixed;
+exports.fn = fn;
+exports.fn1 = fn1;
+exports.a = a$1;
 /*  Not a pure module */

--- a/jscomp/test/UncurriedAlways.res
+++ b/jscomp/test/UncurriedAlways.res
@@ -65,3 +65,13 @@ module OptMixed = {
   let c3 = ptl(~x="x", ~z="z", ~d2="d2<-200", ~d4="d4<-400")
   Js.log2("c3:", c3)
 }
+
+let fn = cb => {
+  cb()
+}
+
+fn(s => Js.log(#foo(s)))
+
+let fn1 = (a, b, ()) => a() + b 
+
+let a = fn1(() => 1, 2, _)


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-compiler/issues/6504

Uncurried functions with 1 unit argument are emitted without the parameter. This leaves a possible undefined id in the emitted code if the parameter is a variable. This PR limits the optimization to cases where the parameter is explicitly `()`, as opposed to e.g. a variable whose type is inferred to be unit.