### PR TITLE
Gentype: make output DCE-friendly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 - GenType: support mutual recursive types inside modules. https://github.com/rescript-lang/rescript-compiler/pull/6528
 - Workaround for `@as`in labels in uncurried externals, which was broken. https://github.com/rescript-lang/rescript-compiler/pull/6527
 
+#### :nail_care: Polish
+
+- GenType: make outputs DCE-friendly. https://github.com/rescript-lang/rescript-compiler/pull/6508
+
 # 11.0.0-rc.7
 
 #### :rocket: New Feature

--- a/jscomp/gentype/EmitJs.ml
+++ b/jscomp/gentype/EmitJs.ml
@@ -206,7 +206,7 @@ let emitCodeItem ~config ~emitters ~moduleItemsEmitter ~env ~fileName
     in
     let valueNameTypeChecked = valueName ^ "TypeChecked" in
     let emitters =
-      (importedAsName ^ restOfPath) ^ ";"
+      importedAsName ^ restOfPath
       |> EmitType.emitExportConst ~config
            ~comment:
              ("In case of type error, check the type of '" ^ valueName
@@ -224,9 +224,8 @@ let emitCodeItem ~config ~emitters ~moduleItemsEmitter ~env ~fileName
       | false -> valueName
     in
     let emitters =
-      (valueNameTypeChecked
-      |> EmitType.emitTypeCast ~config ~type_ ~typeNameIsInterface)
-      ^ ";"
+      valueNameTypeChecked
+      |> EmitType.emitTypeCast ~config ~type_ ~typeNameIsInterface
       |> EmitType.emitExportConst
            ~comment:
              ("Export '" ^ valueNameNotDefault
@@ -359,10 +358,9 @@ let emitCodeItem ~config ~emitters ~moduleItemsEmitter ~env ~fileName
       | _ -> emitters
     in
     let emitters =
-      ((fileNameBs |> ModuleName.toString)
+      (fileNameBs |> ModuleName.toString)
       ^ "."
-      ^ (moduleAccessPath |> Runtime.emitModuleAccessPath ~config))
-      ^ ";"
+      ^ (moduleAccessPath |> Runtime.emitModuleAccessPath ~config)
       |> EmitType.emitExportConst ~config ~docString ~early:false ~emitters
            ~name ~type_ ~typeNameIsInterface
     in

--- a/jscomp/gentype_tests/typescript-react-example/src/Comments.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/Comments.gen.tsx
@@ -3,8 +3,7 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as CommentsBS__Es6Import from './Comments.bs';
-const CommentsBS: any = CommentsBS__Es6Import;
+import * as CommentsBS from './Comments.bs';
 
 export type DecideSubject_payload = { 
 /** A hint to use as a guide when thinking of your poem. */
@@ -24,8 +23,8 @@ export type DecideSubject_output = {
 };
 
 /** Decide on a subject matter for a poem. */
-export const DecideSubject__placeholder: (run:string, times:number) => void = CommentsBS.DecideSubject._placeholder;
+export const DecideSubject__placeholder: (run:string, times:number) => void = CommentsBS.DecideSubject._placeholder as any;
 
 export const DecideSubject: { 
 /** Decide on a subject matter for a poem. */
-_placeholder: (run:string, times:number) => void } = CommentsBS.DecideSubject
+_placeholder: (run:string, times:number) => void } = CommentsBS.DecideSubject as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/Core.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/Core.gen.tsx
@@ -8,16 +8,16 @@ import {someFunWithNullThenOptionalArgs as someFunWithNullThenOptionalArgsNotChe
 import {someFunWithNullUndefinedArg as someFunWithNullUndefinedArgNotChecked} from './CoreTS';
 
 // In case of type error, check the type of 'someFunWithNullThenOptionalArgs' in 'Core.res' and './CoreTS'.
-export const someFunWithNullThenOptionalArgsTypeChecked: (_1:(null | string), _2:(undefined | string)) => string = someFunWithNullThenOptionalArgsNotChecked;
+export const someFunWithNullThenOptionalArgsTypeChecked: (_1:(null | string), _2:(undefined | string)) => string = someFunWithNullThenOptionalArgsNotChecked as any;
 
 // Export 'someFunWithNullThenOptionalArgs' early to allow circular import from the '.bs.js' file.
-export const someFunWithNullThenOptionalArgs: unknown = someFunWithNullThenOptionalArgsTypeChecked as (_1:(null | string), _2:(undefined | string)) => string;
+export const someFunWithNullThenOptionalArgs: unknown = someFunWithNullThenOptionalArgsTypeChecked as (_1:(null | string), _2:(undefined | string)) => string as any;
 
 // In case of type error, check the type of 'someFunWithNullUndefinedArg' in 'Core.res' and './CoreTS'.
-export const someFunWithNullUndefinedArgTypeChecked: (_1:(null | undefined | string), _2:number) => string = someFunWithNullUndefinedArgNotChecked;
+export const someFunWithNullUndefinedArgTypeChecked: (_1:(null | undefined | string), _2:number) => string = someFunWithNullUndefinedArgNotChecked as any;
 
 // Export 'someFunWithNullUndefinedArg' early to allow circular import from the '.bs.js' file.
-export const someFunWithNullUndefinedArg: unknown = someFunWithNullUndefinedArgTypeChecked as (_1:(null | undefined | string), _2:number) => string;
+export const someFunWithNullUndefinedArg: unknown = someFunWithNullUndefinedArgTypeChecked as (_1:(null | undefined | string), _2:number) => string as any;
 
 const CoreBS = require('./Core.bs');
 
@@ -27,46 +27,46 @@ export type t1 = { readonly x?: string };
 
 export type t2 = { readonly x: (undefined | string) };
 
-export const null0: (x:(null | number)) => (null | number) = CoreBS.null0;
+export const null0: (x:(null | number)) => (null | number) = CoreBS.null0 as any;
 
-export const null1: (x:(null | number)) => (null | number) = CoreBS.null1;
+export const null1: (x:(null | number)) => (null | number) = CoreBS.null1 as any;
 
-export const nullable0: (x:(null | undefined | number)) => (null | undefined | number) = CoreBS.nullable0;
+export const nullable0: (x:(null | undefined | number)) => (null | undefined | number) = CoreBS.nullable0 as any;
 
-export const nullable1: (x:(null | undefined | number)) => (null | undefined | number) = CoreBS.nullable1;
+export const nullable1: (x:(null | undefined | number)) => (null | undefined | number) = CoreBS.nullable1 as any;
 
-export const undefined0: (x:(undefined | number)) => (undefined | number) = CoreBS.undefined0;
+export const undefined0: (x:(undefined | number)) => (undefined | number) = CoreBS.undefined0 as any;
 
-export const undefined1: (x:(undefined | number)) => (undefined | number) = CoreBS.undefined1;
+export const undefined1: (x:(undefined | number)) => (undefined | number) = CoreBS.undefined1 as any;
 
-export const dict0: (x:{[id: string]: string}) => {[id: string]: string} = CoreBS.dict0;
+export const dict0: (x:{[id: string]: string}) => {[id: string]: string} = CoreBS.dict0 as any;
 
-export const dict1: (x:{[id: string]: string}) => {[id: string]: string} = CoreBS.dict1;
+export const dict1: (x:{[id: string]: string}) => {[id: string]: string} = CoreBS.dict1 as any;
 
-export const promise0: (x:Promise<string>) => Promise<string> = CoreBS.promise0;
+export const promise0: (x:Promise<string>) => Promise<string> = CoreBS.promise0 as any;
 
-export const promise1: (x:Promise<string>) => Promise<string> = CoreBS.promise1;
+export const promise1: (x:Promise<string>) => Promise<string> = CoreBS.promise1 as any;
 
-export const date0: (x:Date) => Date = CoreBS.date0;
+export const date0: (x:Date) => Date = CoreBS.date0 as any;
 
-export const date1: (x:Date) => Date = CoreBS.date1;
+export const date1: (x:Date) => Date = CoreBS.date1 as any;
 
-export const bigint0: (x:BigInt) => BigInt = CoreBS.bigint0;
+export const bigint0: (x:BigInt) => BigInt = CoreBS.bigint0 as any;
 
-export const bigint1: (x:BigInt) => BigInt = CoreBS.bigint1;
+export const bigint1: (x:BigInt) => BigInt = CoreBS.bigint1 as any;
 
-export const regexp0: (x:RegExp) => RegExp = CoreBS.regexp0;
+export const regexp0: (x:RegExp) => RegExp = CoreBS.regexp0 as any;
 
-export const regexp1: (x:RegExp) => RegExp = CoreBS.regexp1;
+export const regexp1: (x:RegExp) => RegExp = CoreBS.regexp1 as any;
 
-export const map1: (x:Map<string,number>) => Map<string,number> = CoreBS.map1;
+export const map1: (x:Map<string,number>) => Map<string,number> = CoreBS.map1 as any;
 
-export const weakmap1: (x:WeakMap<number[],number>) => WeakMap<number[],number> = CoreBS.weakmap1;
+export const weakmap1: (x:WeakMap<number[],number>) => WeakMap<number[],number> = CoreBS.weakmap1 as any;
 
-export const set1: (x:Set<string>) => Set<string> = CoreBS.set1;
+export const set1: (x:Set<string>) => Set<string> = CoreBS.set1 as any;
 
-export const weakset1: (x:WeakSet<number[]>) => WeakSet<number[]> = CoreBS.weakset1;
+export const weakset1: (x:WeakSet<number[]>) => WeakSet<number[]> = CoreBS.weakset1 as any;
 
-export const option0: (x:(undefined | string)) => (undefined | string) = CoreBS.option0;
+export const option0: (x:(undefined | string)) => (undefined | string) = CoreBS.option0 as any;
 
-export const option1: (x:(undefined | variant)) => (undefined | variant) = CoreBS.option1;
+export const option1: (x:(undefined | variant)) => (undefined | variant) = CoreBS.option1 as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/Docstrings.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/Docstrings.gen.tsx
@@ -3,47 +3,46 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as DocstringsBS__Es6Import from './Docstrings.bs';
-const DocstringsBS: any = DocstringsBS__Es6Import;
+import * as DocstringsBS from './Docstrings.bs';
 
 export type t = "A" | "B";
 
 /** hello */
-export const flat: number = DocstringsBS.flat;
+export const flat: number = DocstringsBS.flat as any;
 
 /** \n  * Sign a message with a key.\n  *\n  * @param message - A message to be signed\n  * @param key - The key with which to sign the message\n  * @returns A signed message\n */
-export const signMessage: (message:string, key:number) => string = DocstringsBS.signMessage;
+export const signMessage: (message:string, key:number) => string = DocstringsBS.signMessage as any;
 
-export const one: (a:number) => number = DocstringsBS.one;
+export const one: (a:number) => number = DocstringsBS.one as any;
 
-export const two: (a:number, b:number) => number = DocstringsBS.two;
+export const two: (a:number, b:number) => number = DocstringsBS.two as any;
 
-export const tree: (a:number, b:number, c:number) => number = DocstringsBS.tree;
+export const tree: (a:number, b:number, c:number) => number = DocstringsBS.tree as any;
 
-export const oneU: (a:number) => number = DocstringsBS.oneU;
+export const oneU: (a:number) => number = DocstringsBS.oneU as any;
 
-export const twoU: (a:number, b:number) => number = DocstringsBS.twoU;
+export const twoU: (a:number, b:number) => number = DocstringsBS.twoU as any;
 
-export const treeU: (a:number, b:number, c:number) => number = DocstringsBS.treeU;
+export const treeU: (a:number, b:number, c:number) => number = DocstringsBS.treeU as any;
 
-export const useParam: (param:number) => number = DocstringsBS.useParam;
+export const useParam: (param:number) => number = DocstringsBS.useParam as any;
 
-export const useParamU: (param:number) => number = DocstringsBS.useParamU;
+export const useParamU: (param:number) => number = DocstringsBS.useParamU as any;
 
-export const unnamed1: (param:number) => number = DocstringsBS.unnamed1;
+export const unnamed1: (param:number) => number = DocstringsBS.unnamed1 as any;
 
-export const unnamed1U: (param:number) => number = DocstringsBS.unnamed1U;
+export const unnamed1U: (param:number) => number = DocstringsBS.unnamed1U as any;
 
-export const unnamed2: (param_0:number, param_1:number) => number = DocstringsBS.unnamed2;
+export const unnamed2: (param_0:number, param_1:number) => number = DocstringsBS.unnamed2 as any;
 
-export const unnamed2U: (param_0:number, param_1:number) => number = DocstringsBS.unnamed2U;
+export const unnamed2U: (param_0:number, param_1:number) => number = DocstringsBS.unnamed2U as any;
 
-export const grouped: (x:number, y:number, a:number, b:number, c:number, z:number) => number = DocstringsBS.grouped;
+export const grouped: (x:number, y:number, a:number, b:number, c:number, z:number) => number = DocstringsBS.grouped as any;
 
-export const unitArgWithoutConversion: () => string = DocstringsBS.unitArgWithoutConversion;
+export const unitArgWithoutConversion: () => string = DocstringsBS.unitArgWithoutConversion as any;
 
-export const unitArgWithoutConversionU: () => string = DocstringsBS.unitArgWithoutConversionU;
+export const unitArgWithoutConversionU: () => string = DocstringsBS.unitArgWithoutConversionU as any;
 
-export const unitArgWithConversion: () => t = DocstringsBS.unitArgWithConversion;
+export const unitArgWithConversion: () => t = DocstringsBS.unitArgWithConversion as any;
 
-export const unitArgWithConversionU: () => t = DocstringsBS.unitArgWithConversionU;
+export const unitArgWithConversionU: () => t = DocstringsBS.unitArgWithConversionU as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/EmitModuleIfNoConversion.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/EmitModuleIfNoConversion.gen.tsx
@@ -3,17 +3,16 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as EmitModuleIfNoConversionBS__Es6Import from './EmitModuleIfNoConversion.bs';
-const EmitModuleIfNoConversionBS: any = EmitModuleIfNoConversionBS__Es6Import;
+import * as EmitModuleIfNoConversionBS from './EmitModuleIfNoConversion.bs';
 
 export type t = "A" | { TAG: "B"; readonly name: string };
 
-export const X_foo: (t:t) => void = EmitModuleIfNoConversionBS.X.foo;
+export const X_foo: (t:t) => void = EmitModuleIfNoConversionBS.X.foo as any;
 
-export const X_x: number = EmitModuleIfNoConversionBS.X.x;
+export const X_x: number = EmitModuleIfNoConversionBS.X.x as any;
 
-export const Y_x: string = EmitModuleIfNoConversionBS.Y.x;
+export const Y_x: string = EmitModuleIfNoConversionBS.Y.x as any;
 
-export const Y: { x: string } = EmitModuleIfNoConversionBS.Y
+export const Y: { x: string } = EmitModuleIfNoConversionBS.Y as any;
 
-export const X: { x: number; foo: (t:t) => void } = EmitModuleIfNoConversionBS.X
+export const X: { x: number; foo: (t:t) => void } = EmitModuleIfNoConversionBS.X as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/ExportWithRename.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/ExportWithRename.gen.tsx
@@ -5,9 +5,8 @@
 
 import * as React from 'react';
 
-import * as ExportWithRenameBS__Es6Import from './ExportWithRename.bs';
-const ExportWithRenameBS: any = ExportWithRenameBS__Es6Import;
+import * as ExportWithRenameBS from './ExportWithRename.bs';
 
 export type Props = { readonly s: string };
 
-export const Renamed: React.ComponentType<{ readonly s: string }> = ExportWithRenameBS.make;
+export const Renamed: React.ComponentType<{ readonly s: string }> = ExportWithRenameBS.make as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/FirstClassModules.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/FirstClassModules.gen.tsx
@@ -3,8 +3,7 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as FirstClassModulesBS__Es6Import from './FirstClassModules.bs';
-const FirstClassModulesBS: any = FirstClassModulesBS__Es6Import;
+import * as FirstClassModulesBS from './FirstClassModules.bs';
 
 export type MT_t = number;
 
@@ -24,7 +23,7 @@ export type firstClassModule = {
   readonly y: string
 };
 
-export const firstClassModule: firstClassModule = FirstClassModulesBS.firstClassModule;
+export const firstClassModule: firstClassModule = FirstClassModulesBS.firstClassModule as any;
 
 export const testConvert: (m:{
   readonly x: number; 
@@ -50,7 +49,7 @@ export const testConvert: (m:{
   }; 
   readonly Z: unknown; 
   readonly y: string
-} = FirstClassModulesBS.testConvert;
+} = FirstClassModulesBS.testConvert as any;
 
 export const someFunctorAsFunction: (x:{
   readonly x: number; 
@@ -64,4 +63,4 @@ export const someFunctorAsFunction: (x:{
   }; 
   readonly Z: unknown; 
   readonly y: string
-}) => { readonly ww: string } = FirstClassModulesBS.someFunctorAsFunction;
+}) => { readonly ww: string } = FirstClassModulesBS.someFunctorAsFunction as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/Hooks.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/Hooks.gen.tsx
@@ -5,8 +5,7 @@
 
 import * as React from 'react';
 
-import * as HooksBS__Es6Import from './Hooks.bs';
-const HooksBS: any = HooksBS__Es6Import;
+import * as HooksBS from './Hooks.bs';
 
 import type {TypedArray2_Uint8Array_t as Js_TypedArray2_Uint8Array_t} from '../src/shims/Js.shim';
 
@@ -28,35 +27,35 @@ export type testDomRef2 = React.Ref<unknown>;
 
 export type Props = { readonly vehicle: vehicle };
 
-export const $$default: React.ComponentType<{ readonly vehicle: vehicle }> = HooksBS.default;
+export const $$default: React.ComponentType<{ readonly vehicle: vehicle }> = HooksBS.default as any;
 
 export default $$default;
 
 export type Another_anotherComponent_Props = { readonly callback: () => void; readonly vehicle: vehicle };
 
-export const Another_anotherComponent: React.ComponentType<{ readonly callback: () => void; readonly vehicle: vehicle }> = HooksBS.Another.anotherComponent;
+export const Another_anotherComponent: React.ComponentType<{ readonly callback: () => void; readonly vehicle: vehicle }> = HooksBS.Another.anotherComponent as any;
 
 export type Inner_make_Props = { readonly vehicle: vehicle };
 
-export const Inner_make: React.ComponentType<{ readonly vehicle: vehicle }> = HooksBS.Inner.make;
+export const Inner_make: React.ComponentType<{ readonly vehicle: vehicle }> = HooksBS.Inner.make as any;
 
 export type Inner_Another_anotherComponent_Props = { readonly vehicle: vehicle };
 
-export const Inner_Another_anotherComponent: React.ComponentType<{ readonly vehicle: vehicle }> = HooksBS.Inner.Another.anotherComponent;
+export const Inner_Another_anotherComponent: React.ComponentType<{ readonly vehicle: vehicle }> = HooksBS.Inner.Another.anotherComponent as any;
 
 export type Inner_Inner2_make_Props = { readonly vehicle: vehicle };
 
-export const Inner_Inner2_make: React.ComponentType<{ readonly vehicle: vehicle }> = HooksBS.Inner.Inner2.make;
+export const Inner_Inner2_make: React.ComponentType<{ readonly vehicle: vehicle }> = HooksBS.Inner.Inner2.make as any;
 
 export type Inner_Inner2_Another_anotherComponent_Props = { readonly vehicle: vehicle };
 
-export const Inner_Inner2_Another_anotherComponent: React.ComponentType<{ readonly vehicle: vehicle }> = HooksBS.Inner.Inner2.Another.anotherComponent;
+export const Inner_Inner2_Another_anotherComponent: React.ComponentType<{ readonly vehicle: vehicle }> = HooksBS.Inner.Inner2.Another.anotherComponent as any;
 
 export type NoProps_make_Props = {};
 
-export const NoProps_make: React.ComponentType<{}> = HooksBS.NoProps.make;
+export const NoProps_make: React.ComponentType<{}> = HooksBS.NoProps.make as any;
 
-export const functionWithRenamedArgs: (_to:vehicle, _Type:vehicle, cb:cb) => string = HooksBS.functionWithRenamedArgs;
+export const functionWithRenamedArgs: (_to:vehicle, _Type:vehicle, cb:cb) => string = HooksBS.functionWithRenamedArgs as any;
 
 export type WithRename_componentWithRenamedArgs_Props = {
   readonly _Type: vehicle; 
@@ -68,39 +67,39 @@ export const WithRename_componentWithRenamedArgs: React.ComponentType<{
   readonly _Type: vehicle; 
   readonly _to: vehicle; 
   readonly cb: cb
-}> = HooksBS.WithRename.componentWithRenamedArgs;
+}> = HooksBS.WithRename.componentWithRenamedArgs as any;
 
-export const WithRef_makeWithRef: (_1:{ readonly vehicle: vehicle }, _2:(null | undefined | any)) => JSX.Element = HooksBS.WithRef.makeWithRef;
+export const WithRef_makeWithRef: (_1:{ readonly vehicle: vehicle }, _2:(null | undefined | any)) => JSX.Element = HooksBS.WithRef.makeWithRef as any;
 
 export type testForwardRef_Props = { readonly vehicle: vehicle };
 
-export const testForwardRef: React.ComponentType<{ readonly vehicle: vehicle }> = HooksBS.testForwardRef;
+export const testForwardRef: React.ComponentType<{ readonly vehicle: vehicle }> = HooksBS.testForwardRef as any;
 
 export type ForwardRef_input_Props = { readonly r: r };
 
-export const ForwardRef_input: React.ComponentType<{ readonly r: r }> = HooksBS.ForwardRef.input;
+export const ForwardRef_input: React.ComponentType<{ readonly r: r }> = HooksBS.ForwardRef.input as any;
 
 export type Poly_polymorphicComponent_Props<T1> = { readonly p: [vehicle, T1] };
 
-export const Poly_polymorphicComponent: React.ComponentType<{ readonly p: [vehicle, any] }> = HooksBS.Poly.polymorphicComponent;
+export const Poly_polymorphicComponent: React.ComponentType<{ readonly p: [vehicle, any] }> = HooksBS.Poly.polymorphicComponent as any;
 
 export type Fun_functionReturningReactElement_Props = { readonly name: string };
 
-export const Fun_functionReturningReactElement: React.ComponentType<{ readonly name: string }> = HooksBS.Fun.functionReturningReactElement;
+export const Fun_functionReturningReactElement: React.ComponentType<{ readonly name: string }> = HooksBS.Fun.functionReturningReactElement as any;
 
 export type RenderPropRequiresConversion_make_Props = { readonly renderVehicle: React.ComponentType<{ readonly number: number; readonly vehicle: vehicle }> };
 
-export const RenderPropRequiresConversion_make: React.ComponentType<{ readonly renderVehicle: React.ComponentType<{ readonly number: number; readonly vehicle: vehicle }> }> = HooksBS.RenderPropRequiresConversion.make;
+export const RenderPropRequiresConversion_make: React.ComponentType<{ readonly renderVehicle: React.ComponentType<{ readonly number: number; readonly vehicle: vehicle }> }> = HooksBS.RenderPropRequiresConversion.make as any;
 
 export type WithChildren_aComponentWithChildren_Props = { readonly children: React.ReactNode; readonly vehicle: vehicle };
 
-export const WithChildren_aComponentWithChildren: React.ComponentType<{ readonly children: React.ReactNode; readonly vehicle: vehicle }> = HooksBS.WithChildren.aComponentWithChildren;
+export const WithChildren_aComponentWithChildren: React.ComponentType<{ readonly children: React.ReactNode; readonly vehicle: vehicle }> = HooksBS.WithChildren.aComponentWithChildren as any;
 
 export type DD_make_Props = { readonly array: Js_TypedArray2_Uint8Array_t; readonly name: string };
 
-export const DD_make: React.ComponentType<{ readonly array: Js_TypedArray2_Uint8Array_t; readonly name: string }> = HooksBS.DD.make;
+export const DD_make: React.ComponentType<{ readonly array: Js_TypedArray2_Uint8Array_t; readonly name: string }> = HooksBS.DD.make as any;
 
-export const NoProps: { make: React.ComponentType<{}> } = HooksBS.NoProps
+export const NoProps: { make: React.ComponentType<{}> } = HooksBS.NoProps as any;
 
 export const Inner: {
   Inner2: {
@@ -121,26 +120,26 @@ export const Inner: {
   make: React.ComponentType<{
     readonly vehicle: vehicle
   }>
-} = HooksBS.Inner
+} = HooksBS.Inner as any;
 
-export const RenderPropRequiresConversion: { make: React.ComponentType<{ readonly renderVehicle: React.ComponentType<{ readonly number: number; readonly vehicle: vehicle }> }> } = HooksBS.RenderPropRequiresConversion
+export const RenderPropRequiresConversion: { make: React.ComponentType<{ readonly renderVehicle: React.ComponentType<{ readonly number: number; readonly vehicle: vehicle }> }> } = HooksBS.RenderPropRequiresConversion as any;
 
 export const WithRename: { componentWithRenamedArgs: React.ComponentType<{
   readonly _Type: vehicle; 
   readonly _to: vehicle; 
   readonly cb: cb
-}> } = HooksBS.WithRename
+}> } = HooksBS.WithRename as any;
 
-export const ForwardRef: { input: React.ComponentType<{ readonly r: r }> } = HooksBS.ForwardRef
+export const ForwardRef: { input: React.ComponentType<{ readonly r: r }> } = HooksBS.ForwardRef as any;
 
-export const Fun: { functionReturningReactElement: React.ComponentType<{ readonly name: string }> } = HooksBS.Fun
+export const Fun: { functionReturningReactElement: React.ComponentType<{ readonly name: string }> } = HooksBS.Fun as any;
 
-export const WithRef: { makeWithRef: (_1:{ readonly vehicle: vehicle }, _2:(null | undefined | any)) => JSX.Element } = HooksBS.WithRef
+export const WithRef: { makeWithRef: (_1:{ readonly vehicle: vehicle }, _2:(null | undefined | any)) => JSX.Element } = HooksBS.WithRef as any;
 
-export const WithChildren: { aComponentWithChildren: React.ComponentType<{ readonly children: React.ReactNode; readonly vehicle: vehicle }> } = HooksBS.WithChildren
+export const WithChildren: { aComponentWithChildren: React.ComponentType<{ readonly children: React.ReactNode; readonly vehicle: vehicle }> } = HooksBS.WithChildren as any;
 
-export const DD: { make: React.ComponentType<{ readonly array: Js_TypedArray2_Uint8Array_t; readonly name: string }> } = HooksBS.DD
+export const DD: { make: React.ComponentType<{ readonly array: Js_TypedArray2_Uint8Array_t; readonly name: string }> } = HooksBS.DD as any;
 
-export const Another: { anotherComponent: React.ComponentType<{ readonly callback: () => void; readonly vehicle: vehicle }> } = HooksBS.Another
+export const Another: { anotherComponent: React.ComponentType<{ readonly callback: () => void; readonly vehicle: vehicle }> } = HooksBS.Another as any;
 
-export const Poly: { polymorphicComponent: React.ComponentType<{ readonly p: [vehicle, any] }> } = HooksBS.Poly
+export const Poly: { polymorphicComponent: React.ComponentType<{ readonly p: [vehicle, any] }> } = HooksBS.Poly as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/ImportHookDefault.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/ImportHookDefault.gen.tsx
@@ -12,28 +12,28 @@ export const makeTypeChecked: React.ComponentType<{
   readonly person: person; 
   readonly children: React.ReactNode; 
   readonly renderMe: ImportHooks_renderMe<string>
-}> = makeNotChecked;
+}> = makeNotChecked as any;
 
 // Export 'make' early to allow circular import from the '.bs.js' file.
 export const make: unknown = makeTypeChecked as React.ComponentType<{
   readonly person: person; 
   readonly children: React.ReactNode; 
   readonly renderMe: ImportHooks_renderMe<string>
-}>;
+}> as any;
 
 // In case of type error, check the type of 'default' in 'ImportHookDefault.res' and './hookExample'.
 export const defaultTypeChecked: React.ComponentType<{
   readonly person: person; 
   readonly children: React.ReactNode; 
   readonly renderMe: ImportHooks_renderMe<string>
-}> = defaultNotChecked;
+}> = defaultNotChecked as any;
 
 // Export '$$default' early to allow circular import from the '.bs.js' file.
 export const $$default: unknown = defaultTypeChecked as React.ComponentType<{
   readonly person: person; 
   readonly children: React.ReactNode; 
   readonly renderMe: ImportHooks_renderMe<string>
-}>;
+}> as any;
 
 import type {renderMe as ImportHooks_renderMe} from './ImportHooks.gen';
 

--- a/jscomp/gentype_tests/typescript-react-example/src/ImportHooks.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/ImportHooks.gen.tsx
@@ -13,7 +13,7 @@ export const makeRenamedTypeChecked: React.ComponentType<{
   readonly person: person; 
   readonly children: React.ReactNode; 
   readonly renderMe: renderMe<any>
-}> = makeRenamedNotChecked;
+}> = makeRenamedNotChecked as any;
 
 // Export 'makeRenamed' early to allow circular import from the '.bs.js' file.
 export const makeRenamed: unknown = makeRenamedTypeChecked as React.ComponentType<{
@@ -21,13 +21,13 @@ export const makeRenamed: unknown = makeRenamedTypeChecked as React.ComponentTyp
   readonly person: person; 
   readonly children: React.ReactNode; 
   readonly renderMe: renderMe<any>
-}>;
+}> as any;
 
 // In case of type error, check the type of 'foo' in 'ImportHooks.res' and './hookExample'.
-export const fooTypeChecked: (person:person) => string = fooNotChecked;
+export const fooTypeChecked: (person:person) => string = fooNotChecked as any;
 
 // Export 'foo' early to allow circular import from the '.bs.js' file.
-export const foo: unknown = fooTypeChecked as (person:person) => string;
+export const foo: unknown = fooTypeChecked as (person:person) => string as any;
 
 export type person = { readonly name: string; readonly age: number };
 

--- a/jscomp/gentype_tests/typescript-react-example/src/ImportIndex.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/ImportIndex.gen.tsx
@@ -6,9 +6,9 @@
 import {default as defaultNotChecked} from './';
 
 // In case of type error, check the type of 'default' in 'ImportIndex.res' and './'.
-export const defaultTypeChecked: React.ComponentType<{ readonly method?: "push" | "replace" }> = defaultNotChecked;
+export const defaultTypeChecked: React.ComponentType<{ readonly method?: "push" | "replace" }> = defaultNotChecked as any;
 
 // Export '$$default' early to allow circular import from the '.bs.js' file.
-export const $$default: unknown = defaultTypeChecked as React.ComponentType<{ readonly method?: "push" | "replace" }>;
+export const $$default: unknown = defaultTypeChecked as React.ComponentType<{ readonly method?: "push" | "replace" }> as any;
 
 export default $$default;

--- a/jscomp/gentype_tests/typescript-react-example/src/ImportJsValue.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/ImportJsValue.gen.tsx
@@ -22,58 +22,58 @@ import {polymorphic as polymorphicNotChecked} from './MyMath';
 import {default as defaultNotChecked} from './MyMath';
 
 // In case of type error, check the type of 'round' in 'ImportJsValue.res' and './MyMath'.
-export const roundTypeChecked: (_1:number) => number = roundNotChecked;
+export const roundTypeChecked: (_1:number) => number = roundNotChecked as any;
 
 // Export 'round' early to allow circular import from the '.bs.js' file.
-export const round: unknown = roundTypeChecked as (_1:number) => number;
+export const round: unknown = roundTypeChecked as (_1:number) => number as any;
 
 // In case of type error, check the type of 'round2' in 'ImportJsValue.res' and './MyMath'.
-export const round2TypeChecked: (_1:number) => number = round2NotChecked;
+export const round2TypeChecked: (_1:number) => number = round2NotChecked as any;
 
 // Export 'round2' early to allow circular import from the '.bs.js' file.
-export const round2: unknown = round2TypeChecked as (_1:number) => number;
+export const round2: unknown = round2TypeChecked as (_1:number) => number as any;
 
 // In case of type error, check the type of 'area' in 'ImportJsValue.res' and './MyMath'.
-export const areaTypeChecked: (_1:point) => number = areaNotChecked;
+export const areaTypeChecked: (_1:point) => number = areaNotChecked as any;
 
 // Export 'area' early to allow circular import from the '.bs.js' file.
-export const area: unknown = areaTypeChecked as (_1:point) => number;
+export const area: unknown = areaTypeChecked as (_1:point) => number as any;
 
 // In case of type error, check the type of 'returnMixedArray' in 'ImportJsValue.res' and './MyMath'.
-export const returnMixedArrayTypeChecked: () => numberOrString[] = returnMixedArrayNotChecked;
+export const returnMixedArrayTypeChecked: () => numberOrString[] = returnMixedArrayNotChecked as any;
 
 // Export 'returnMixedArray' early to allow circular import from the '.bs.js' file.
-export const returnMixedArray: unknown = returnMixedArrayTypeChecked as () => numberOrString[];
+export const returnMixedArray: unknown = returnMixedArrayTypeChecked as () => numberOrString[] as any;
 
 // In case of type error, check the type of 'useColor' in 'ImportJsValue.res' and './MyMath'.
-export const useColorTypeChecked: (_1:color) => number = useColorNotChecked;
+export const useColorTypeChecked: (_1:color) => number = useColorNotChecked as any;
 
 // Export 'useColor' early to allow circular import from the '.bs.js' file.
-export const useColor: unknown = useColorTypeChecked as (_1:color) => number;
+export const useColor: unknown = useColorTypeChecked as (_1:color) => number as any;
 
 // In case of type error, check the type of 'higherOrder' in 'ImportJsValue.res' and './MyMath'.
-export const higherOrderTypeChecked: (_1:((_1:number, _2:number) => number)) => number = higherOrderNotChecked;
+export const higherOrderTypeChecked: (_1:((_1:number, _2:number) => number)) => number = higherOrderNotChecked as any;
 
 // Export 'higherOrder' early to allow circular import from the '.bs.js' file.
-export const higherOrder: unknown = higherOrderTypeChecked as (_1:((_1:number, _2:number) => number)) => number;
+export const higherOrder: unknown = higherOrderTypeChecked as (_1:((_1:number, _2:number) => number)) => number as any;
 
 // In case of type error, check the type of 'convertVariant' in 'ImportJsValue.res' and './MyMath'.
-export const convertVariantTypeChecked: (_1:variant) => variant = convertVariantNotChecked;
+export const convertVariantTypeChecked: (_1:variant) => variant = convertVariantNotChecked as any;
 
 // Export 'convertVariant' early to allow circular import from the '.bs.js' file.
-export const convertVariant: unknown = convertVariantTypeChecked as (_1:variant) => variant;
+export const convertVariant: unknown = convertVariantTypeChecked as (_1:variant) => variant as any;
 
 // In case of type error, check the type of 'polymorphic' in 'ImportJsValue.res' and './MyMath'.
-export const polymorphicTypeChecked: <a>(_1:a) => a = polymorphicNotChecked;
+export const polymorphicTypeChecked: <a>(_1:a) => a = polymorphicNotChecked as any;
 
 // Export 'polymorphic' early to allow circular import from the '.bs.js' file.
-export const polymorphic: unknown = polymorphicTypeChecked as <a>(_1:a) => a;
+export const polymorphic: unknown = polymorphicTypeChecked as <a>(_1:a) => a as any;
 
 // In case of type error, check the type of 'default' in 'ImportJsValue.res' and './MyMath'.
-export const defaultTypeChecked: number = defaultNotChecked;
+export const defaultTypeChecked: number = defaultNotChecked as any;
 
 // Export '$$default' early to allow circular import from the '.bs.js' file.
-export const $$default: unknown = defaultTypeChecked as number;
+export const $$default: unknown = defaultTypeChecked as number as any;
 
 const ImportJsValueBS = require('./ImportJsValue.bs');
 
@@ -109,14 +109,14 @@ export type myNum = $$myNum;
 
 export type polyType<a> = $$polyType<a>;
 
-export const roundedNumber: number = ImportJsValueBS.roundedNumber;
+export const roundedNumber: number = ImportJsValueBS.roundedNumber as any;
 
-export const areaValue: number = ImportJsValueBS.areaValue;
+export const areaValue: number = ImportJsValueBS.areaValue as any;
 
-export const useGetProp: (x:AbsoluteValue_t) => number = ImportJsValueBS.useGetProp;
+export const useGetProp: (x:AbsoluteValue_t) => number = ImportJsValueBS.useGetProp as any;
 
-export const useGetAbs: (x:AbsoluteValue_t) => number = ImportJsValueBS.useGetAbs;
+export const useGetAbs: (x:AbsoluteValue_t) => number = ImportJsValueBS.useGetAbs as any;
 
-export const returnedFromHigherOrder: number = ImportJsValueBS.returnedFromHigherOrder;
+export const returnedFromHigherOrder: number = ImportJsValueBS.returnedFromHigherOrder as any;
 
 export default $$default;

--- a/jscomp/gentype_tests/typescript-react-example/src/InnerModuleSignature.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/InnerModuleSignature.gen.tsx
@@ -3,11 +3,10 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as InnerModuleSignatureBS__Es6Import from './InnerModuleSignature.bs';
-const InnerModuleSignatureBS: any = InnerModuleSignatureBS__Es6Import;
+import * as InnerModuleSignatureBS from './InnerModuleSignature.bs';
 
 export type InnerModule_t = string;
 
-export const InnerModule_make: (_1:InnerModule_t) => string = InnerModuleSignatureBS.InnerModule.make;
+export const InnerModule_make: (_1:InnerModule_t) => string = InnerModuleSignatureBS.InnerModule.make as any;
 
-export const InnerModule: { make: (_1:InnerModule_t) => string } = InnerModuleSignatureBS.InnerModule
+export const InnerModule: { make: (_1:InnerModule_t) => string } = InnerModuleSignatureBS.InnerModule as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/JSXV4.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/JSXV4.gen.tsx
@@ -13,7 +13,7 @@ export const makeTypeChecked: React.ComponentType<{
   readonly person: person; 
   readonly children: React.ReactNode; 
   readonly renderMe: renderMe<any>
-}> = makeNotChecked;
+}> = makeNotChecked as any;
 
 // Export 'make' early to allow circular import from the '.bs.js' file.
 export const make: unknown = makeTypeChecked as React.ComponentType<{
@@ -21,7 +21,7 @@ export const make: unknown = makeTypeChecked as React.ComponentType<{
   readonly person: person; 
   readonly children: React.ReactNode; 
   readonly renderMe: renderMe<any>
-}>;
+}> as any;
 
 const JSXV4BS = require('./JSXV4.bs');
 
@@ -38,12 +38,12 @@ export type props<actions,person,children,renderMe> = {
   readonly renderMe: renderMe
 };
 
-export const CompV4_make: React.ComponentType<{ readonly x: string; readonly y: string }> = JSXV4BS.CompV4.make;
+export const CompV4_make: React.ComponentType<{ readonly x: string; readonly y: string }> = JSXV4BS.CompV4.make as any;
 
 export type Props = { readonly x: string; readonly y: string };
 
-export const CompV3_make: React.ComponentType<{ readonly x: string; readonly y: string }> = JSXV4BS.CompV3.make;
+export const CompV3_make: React.ComponentType<{ readonly x: string; readonly y: string }> = JSXV4BS.CompV3.make as any;
 
-export const CompV3: { make: React.ComponentType<{ readonly x: string; readonly y: string }> } = JSXV4BS.CompV3
+export const CompV3: { make: React.ComponentType<{ readonly x: string; readonly y: string }> } = JSXV4BS.CompV3 as any;
 
-export const CompV4: { make: React.ComponentType<{ readonly x: string; readonly y: string }> } = JSXV4BS.CompV4
+export const CompV4: { make: React.ComponentType<{ readonly x: string; readonly y: string }> } = JSXV4BS.CompV4 as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/LabeledFun.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/LabeledFun.gen.tsx
@@ -3,7 +3,6 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as LabeledFunBS__Es6Import from './LabeledFun.bs';
-const LabeledFunBS: any = LabeledFunBS__Es6Import;
+import * as LabeledFunBS from './LabeledFun.bs';
 
-export const labelled: (a:number, b:(undefined | number), c:number, _4:number, e:number, f:number) => number = LabeledFunBS.labelled;
+export const labelled: (a:number, b:(undefined | number), c:number, _4:number, e:number, f:number) => number = LabeledFunBS.labelled as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/LetPrivate.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/LetPrivate.gen.tsx
@@ -3,7 +3,6 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as LetPrivateBS__Es6Import from './LetPrivate.bs';
-const LetPrivateBS: any = LetPrivateBS__Es6Import;
+import * as LetPrivateBS from './LetPrivate.bs';
 
-export const y: number = LetPrivateBS.y;
+export const y: number = LetPrivateBS.y as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/Machine.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/Machine.gen.tsx
@@ -3,9 +3,8 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as MachineBS__Es6Import from './Machine.bs';
-const MachineBS: any = MachineBS__Es6Import;
+import * as MachineBS from './Machine.bs';
 
 export type aa = { TAG: "A"; _0: number };
 
-export const a: aa = MachineBS.a;
+export const a: aa = MachineBS.a as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/ModuleAliases.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/ModuleAliases.gen.tsx
@@ -3,8 +3,7 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as ModuleAliasesBS__Es6Import from './ModuleAliases.bs';
-const ModuleAliasesBS: any = ModuleAliasesBS__Es6Import;
+import * as ModuleAliasesBS from './ModuleAliases.bs';
 
 export type Outer_Inner_innerT = { readonly inner: string };
 
@@ -20,8 +19,8 @@ export type Outer2Alias_Inner2_OuterInnerAlias2_innerT = Outer2_Inner2_OuterInne
 
 export type InnerNestedAlias_t = Outer2_Inner2_InnerNested_t;
 
-export const testNested: (x:InnerNestedAlias_t) => InnerNestedAlias_t = ModuleAliasesBS.testNested;
+export const testNested: (x:InnerNestedAlias_t) => InnerNestedAlias_t = ModuleAliasesBS.testNested as any;
 
-export const testInner: (x:Outer2Alias_OuterInnerAlias_innerT) => Outer2Alias_OuterInnerAlias_innerT = ModuleAliasesBS.testInner;
+export const testInner: (x:Outer2Alias_OuterInnerAlias_innerT) => Outer2Alias_OuterInnerAlias_innerT = ModuleAliasesBS.testInner as any;
 
-export const testInner2: (x:Outer2Alias_Inner2_OuterInnerAlias2_innerT) => Outer2Alias_Inner2_OuterInnerAlias2_innerT = ModuleAliasesBS.testInner2;
+export const testInner2: (x:Outer2Alias_Inner2_OuterInnerAlias2_innerT) => Outer2Alias_Inner2_OuterInnerAlias2_innerT = ModuleAliasesBS.testInner2 as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/MoreVariants.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/MoreVariants.gen.tsx
@@ -3,13 +3,12 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as MoreVariantsBS__Es6Import from './MoreVariants.bs';
-const MoreVariantsBS: any = MoreVariantsBS__Es6Import;
+import * as MoreVariantsBS from './MoreVariants.bs';
 
 export type withRenaming = "type_" | "b";
 
 export type withoutRenaming = "type_" | "b";
 
-export const testWithRenaming: (x:withRenaming) => withRenaming = MoreVariantsBS.testWithRenaming;
+export const testWithRenaming: (x:withRenaming) => withRenaming = MoreVariantsBS.testWithRenaming as any;
 
-export const testWithoutRenaming: (x:withoutRenaming) => withoutRenaming = MoreVariantsBS.testWithoutRenaming;
+export const testWithoutRenaming: (x:withoutRenaming) => withoutRenaming = MoreVariantsBS.testWithoutRenaming as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/MyInput.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/MyInput.gen.tsx
@@ -6,10 +6,10 @@
 import {default as defaultNotChecked} from './MyInput';
 
 // In case of type error, check the type of 'default' in 'MyInput.res' and './MyInput'.
-export const defaultTypeChecked: React.ComponentType<{ readonly onFocus?: (_1:inputFocusEvent) => void }> = defaultNotChecked;
+export const defaultTypeChecked: React.ComponentType<{ readonly onFocus?: (_1:inputFocusEvent) => void }> = defaultNotChecked as any;
 
 // Export '$$default' early to allow circular import from the '.bs.js' file.
-export const $$default: unknown = defaultTypeChecked as React.ComponentType<{ readonly onFocus?: (_1:inputFocusEvent) => void }>;
+export const $$default: unknown = defaultTypeChecked as React.ComponentType<{ readonly onFocus?: (_1:inputFocusEvent) => void }> as any;
 
 import type {inputFocusEvent as $$inputFocusEvent} from './shims/ReactEvent.shim';
 

--- a/jscomp/gentype_tests/typescript-react-example/src/MyModule.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/MyModule.gen.tsx
@@ -3,9 +3,8 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as MyModuleBS__Es6Import from './MyModule.bs';
-const MyModuleBS: any = MyModuleBS__Es6Import;
+import * as MyModuleBS from './MyModule.bs';
 
 export type t = number;
 
-export const add: (a:t, b:t) => t = MyModuleBS.add;
+export const add: (a:t, b:t) => t = MyModuleBS.add as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/NestedModules.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/NestedModules.gen.tsx
@@ -3,8 +3,7 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as NestedModulesBS__Es6Import from './NestedModules.bs';
-const NestedModulesBS: any = NestedModulesBS__Es6Import;
+import * as NestedModulesBS from './NestedModules.bs';
 
 export type Universe_nestedType = string[];
 
@@ -14,19 +13,19 @@ export type Universe_Nested2_Nested3_nested3Type = Array<Array<string[]>>;
 
 export type Universe_variant = "A" | { TAG: "B"; _0: string };
 
-export const notNested: number = NestedModulesBS.notNested;
+export const notNested: number = NestedModulesBS.notNested as any;
 
-export const Universe_theAnswer: number = NestedModulesBS.Universe.theAnswer;
+export const Universe_theAnswer: number = NestedModulesBS.Universe.theAnswer as any;
 
-export const Universe_Nested2_nested2Value: number = NestedModulesBS.Universe.Nested2.nested2Value;
+export const Universe_Nested2_nested2Value: number = NestedModulesBS.Universe.Nested2.nested2Value as any;
 
-export const Universe_Nested2_Nested3_nested3Value: string = NestedModulesBS.Universe.Nested2.Nested3.nested3Value;
+export const Universe_Nested2_Nested3_nested3Value: string = NestedModulesBS.Universe.Nested2.Nested3.nested3Value as any;
 
-export const Universe_Nested2_Nested3_nested3Function: (x:Universe_Nested2_nested2Type) => Universe_Nested2_nested2Type = NestedModulesBS.Universe.Nested2.Nested3.nested3Function;
+export const Universe_Nested2_Nested3_nested3Function: (x:Universe_Nested2_nested2Type) => Universe_Nested2_nested2Type = NestedModulesBS.Universe.Nested2.Nested3.nested3Function as any;
 
-export const Universe_Nested2_nested2Function: (x:Universe_Nested2_Nested3_nested3Type) => Universe_Nested2_Nested3_nested3Type = NestedModulesBS.Universe.Nested2.nested2Function;
+export const Universe_Nested2_nested2Function: (x:Universe_Nested2_Nested3_nested3Type) => Universe_Nested2_Nested3_nested3Type = NestedModulesBS.Universe.Nested2.nested2Function as any;
 
-export const Universe_someString: string = NestedModulesBS.Universe.someString;
+export const Universe_someString: string = NestedModulesBS.Universe.someString as any;
 
 export const Universe: {
   theAnswer: number; 
@@ -39,4 +38,4 @@ export const Universe: {
     }
   }; 
   someString: string
-} = NestedModulesBS.Universe
+} = NestedModulesBS.Universe as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/NestedModulesInSignature.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/NestedModulesInSignature.gen.tsx
@@ -3,9 +3,8 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as NestedModulesInSignatureBS__Es6Import from './NestedModulesInSignature.bs';
-const NestedModulesInSignatureBS: any = NestedModulesInSignatureBS__Es6Import;
+import * as NestedModulesInSignatureBS from './NestedModulesInSignature.bs';
 
-export const Universe_theAnswer: number = NestedModulesInSignatureBS.Universe.theAnswer;
+export const Universe_theAnswer: number = NestedModulesInSignatureBS.Universe.theAnswer as any;
 
-export const Universe: { theAnswer: number } = NestedModulesInSignatureBS.Universe
+export const Universe: { theAnswer: number } = NestedModulesInSignatureBS.Universe as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/NestedVariants.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/NestedVariants.gen.tsx
@@ -3,8 +3,7 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as NestedVariantsBS__Es6Import from './NestedVariants.bs';
-const NestedVariantsBS: any = NestedVariantsBS__Es6Import;
+import * as NestedVariantsBS from './NestedVariants.bs';
 
 export type typeL = 
     { TAG: "NonUnary"; _0: number; _1: number };
@@ -44,28 +43,28 @@ export type inline =
   | { TAG: "J"; readonly i: number; readonly j: number }
   | { TAG: "K"; _0: number; _1: number };
 
-export const makeVariant: () => typeL = NestedVariantsBS.makeVariant;
+export const makeVariant: () => typeL = NestedVariantsBS.makeVariant as any;
 
-export const makeABC: () => typeA<typeB> = NestedVariantsBS.makeABC;
+export const makeABC: () => typeA<typeB> = NestedVariantsBS.makeABC as any;
 
-export const makeBC: () => typeB = NestedVariantsBS.makeBC;
+export const makeBC: () => typeB = NestedVariantsBS.makeBC as any;
 
-export const makeAC: () => typeA<typeC> = NestedVariantsBS.makeAC;
+export const makeAC: () => typeA<typeC> = NestedVariantsBS.makeAC as any;
 
-export const makeAD: () => typeA<typeD> = NestedVariantsBS.makeAD;
+export const makeAD: () => typeA<typeD> = NestedVariantsBS.makeAD as any;
 
-export const makeAE: () => typeA<typeE> = NestedVariantsBS.makeAE;
+export const makeAE: () => typeA<typeE> = NestedVariantsBS.makeAE as any;
 
-export const makeFD: () => typeF<typeD> = NestedVariantsBS.makeFD;
+export const makeFD: () => typeF<typeD> = NestedVariantsBS.makeFD as any;
 
-export const makeHD: () => typeH = NestedVariantsBS.makeHD;
+export const makeHD: () => typeH = NestedVariantsBS.makeHD as any;
 
-export const makeJ: () => typeJ = NestedVariantsBS.makeJ;
+export const makeJ: () => typeJ = NestedVariantsBS.makeJ as any;
 
-export const makeK: () => typeK = NestedVariantsBS.makeK;
+export const makeK: () => typeK = NestedVariantsBS.makeK as any;
 
-export const testBoxedBinary: (param:boxedBinary) => number = NestedVariantsBS.testBoxedBinary;
+export const testBoxedBinary: (param:boxedBinary) => number = NestedVariantsBS.testBoxedBinary as any;
 
-export const testUnboxedBinary: (param:unboxedBinary) => number = NestedVariantsBS.testUnboxedBinary;
+export const testUnboxedBinary: (param:unboxedBinary) => number = NestedVariantsBS.testUnboxedBinary as any;
 
-export const testInline: (x:inline) => inline = NestedVariantsBS.testInline;
+export const testInline: (x:inline) => inline = NestedVariantsBS.testInline as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/OnClick2.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/OnClick2.gen.tsx
@@ -5,9 +5,8 @@
 
 import * as React from 'react';
 
-import * as OnClick2BS__Es6Import from './OnClick2.bs';
-const OnClick2BS: any = OnClick2BS__Es6Import;
+import * as OnClick2BS from './OnClick2.bs';
 
 export type Props = { readonly onClick: (_1:MouseEvent) => void };
 
-export const make: React.ComponentType<{ readonly onClick: (_1:MouseEvent) => void }> = OnClick2BS.make;
+export const make: React.ComponentType<{ readonly onClick: (_1:MouseEvent) => void }> = OnClick2BS.make as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/Opaque.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/Opaque.gen.tsx
@@ -3,8 +3,7 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as OpaqueBS__Es6Import from './Opaque.bs';
-const OpaqueBS: any = OpaqueBS__Es6Import;
+import * as OpaqueBS from './Opaque.bs';
 
 import type {business as Records_business} from './Records.gen';
 
@@ -12,6 +11,6 @@ export abstract class opaqueFromRecords { protected opaque!: any }; /* simulate 
 
 export type pair = [opaqueFromRecords, opaqueFromRecords];
 
-export const noConversion: (x:opaqueFromRecords) => opaqueFromRecords = OpaqueBS.noConversion;
+export const noConversion: (x:opaqueFromRecords) => opaqueFromRecords = OpaqueBS.noConversion as any;
 
-export const testConvertNestedRecordFromOtherFile: (x:Records_business) => Records_business = OpaqueBS.testConvertNestedRecordFromOtherFile;
+export const testConvertNestedRecordFromOtherFile: (x:Records_business) => Records_business = OpaqueBS.testConvertNestedRecordFromOtherFile as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/Records.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/Records.gen.tsx
@@ -3,8 +3,7 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as RecordsBS__Es6Import from './Records.bs';
-const RecordsBS: any = RecordsBS__Es6Import;
+import * as RecordsBS from './Records.bs';
 
 import type {list} from '../src/shims/RescriptPervasives.shim';
 
@@ -58,52 +57,52 @@ export type myRecBsAs = {
   readonly "1number": string
 };
 
-export const origin: coord = RecordsBS.origin;
+export const origin: coord = RecordsBS.origin as any;
 
-export const computeArea: (param:coord) => number = RecordsBS.computeArea;
+export const computeArea: (param:coord) => number = RecordsBS.computeArea as any;
 
-export const coord2d: (x:number, y:number) => coord = RecordsBS.coord2d;
+export const coord2d: (x:number, y:number) => coord = RecordsBS.coord2d as any;
 
-export const findAddress: (business:business) => list<string> = RecordsBS.findAddress;
+export const findAddress: (business:business) => list<string> = RecordsBS.findAddress as any;
 
-export const someBusiness: business = RecordsBS.someBusiness;
+export const someBusiness: business = RecordsBS.someBusiness as any;
 
-export const findAllAddresses: (businesses:business[]) => string[] = RecordsBS.findAllAddresses;
+export const findAllAddresses: (businesses:business[]) => string[] = RecordsBS.findAllAddresses as any;
 
-export const getPayload: <T1>(param:payload<T1>) => T1 = RecordsBS.getPayload;
+export const getPayload: <T1>(param:payload<T1>) => T1 = RecordsBS.getPayload as any;
 
-export const getPayloadRecord: (param:payload<record>) => record = RecordsBS.getPayloadRecord;
+export const getPayloadRecord: (param:payload<record>) => record = RecordsBS.getPayloadRecord as any;
 
-export const recordValue: record = RecordsBS.recordValue;
+export const recordValue: record = RecordsBS.recordValue as any;
 
-export const payloadValue: payload<record> = RecordsBS.payloadValue;
+export const payloadValue: payload<record> = RecordsBS.payloadValue as any;
 
-export const getPayloadRecordPlusOne: (param:payload<record>) => record = RecordsBS.getPayloadRecordPlusOne;
+export const getPayloadRecordPlusOne: (param:payload<record>) => record = RecordsBS.getPayloadRecordPlusOne as any;
 
-export const findAddress2: (business:business2) => list<string> = RecordsBS.findAddress2;
+export const findAddress2: (business:business2) => list<string> = RecordsBS.findAddress2 as any;
 
-export const someBusiness2: business2 = RecordsBS.someBusiness2;
+export const someBusiness2: business2 = RecordsBS.someBusiness2 as any;
 
 export const computeArea3: (o:{
   readonly x: number; 
   readonly y: number; 
   readonly z: (null | undefined | number)
-}) => number = RecordsBS.computeArea3;
+}) => number = RecordsBS.computeArea3 as any;
 
 export const computeArea4: (o:{
   readonly x: number; 
   readonly y: number; 
   readonly z?: number
-}) => number = RecordsBS.computeArea4;
+}) => number = RecordsBS.computeArea4 as any;
 
-export const testMyRec: (x:myRec) => string = RecordsBS.testMyRec;
+export const testMyRec: (x:myRec) => string = RecordsBS.testMyRec as any;
 
-export const testMyRec2: (x:myRec) => myRec = RecordsBS.testMyRec2;
+export const testMyRec2: (x:myRec) => myRec = RecordsBS.testMyRec2 as any;
 
-export const testMyObj: (x:myObj) => string = RecordsBS.testMyObj;
+export const testMyObj: (x:myObj) => string = RecordsBS.testMyObj as any;
 
-export const testMyObj2: (x:myObj) => myObj = RecordsBS.testMyObj2;
+export const testMyObj2: (x:myObj) => myObj = RecordsBS.testMyObj2 as any;
 
-export const testMyRecBsAs: (x:myRecBsAs) => string[] = RecordsBS.testMyRecBsAs;
+export const testMyRecBsAs: (x:myRecBsAs) => string[] = RecordsBS.testMyRecBsAs as any;
 
-export const testMyRecBsAs2: (x:myRecBsAs) => myRecBsAs = RecordsBS.testMyRecBsAs2;
+export const testMyRecBsAs2: (x:myRecBsAs) => myRecBsAs = RecordsBS.testMyRecBsAs2 as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/References.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/References.gen.tsx
@@ -3,8 +3,7 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as ReferencesBS__Es6Import from './References.bs';
-const ReferencesBS: any = ReferencesBS__Es6Import;
+import * as ReferencesBS from './References.bs';
 
 export abstract class R_t<a> { protected opaque!: a }; /* simulate opaque types */
 
@@ -12,18 +11,18 @@ export type t<a> = R_t<a>;
 
 export type requiresConversion = { readonly x: number };
 
-export const create: (x:number) => { contents: number } = ReferencesBS.create;
+export const create: (x:number) => { contents: number } = ReferencesBS.create as any;
 
-export const access: (r:{ contents: number }) => number = ReferencesBS.access;
+export const access: (r:{ contents: number }) => number = ReferencesBS.access as any;
 
-export const update: (r:{ contents: number }) => void = ReferencesBS.update;
+export const update: (r:{ contents: number }) => void = ReferencesBS.update as any;
 
-export const get: <T1>(_1:R_t<T1>) => T1 = ReferencesBS.get;
+export const get: <T1>(_1:R_t<T1>) => T1 = ReferencesBS.get as any;
 
-export const make: <T1>(_1:T1) => R_t<T1> = ReferencesBS.make;
+export const make: <T1>(_1:T1) => R_t<T1> = ReferencesBS.make as any;
 
-export const set: <T1>(_1:R_t<T1>, _2:T1) => void = ReferencesBS.set;
+export const set: <T1>(_1:R_t<T1>, _2:T1) => void = ReferencesBS.set as any;
 
-export const destroysRefIdentity: (x:{ contents: requiresConversion }) => { contents: requiresConversion } = ReferencesBS.destroysRefIdentity;
+export const destroysRefIdentity: (x:{ contents: requiresConversion }) => { contents: requiresConversion } = ReferencesBS.destroysRefIdentity as any;
 
-export const preserveRefIdentity: (x:R_t<requiresConversion>) => R_t<requiresConversion> = ReferencesBS.preserveRefIdentity;
+export const preserveRefIdentity: (x:R_t<requiresConversion>) => R_t<requiresConversion> = ReferencesBS.preserveRefIdentity as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/Shadow.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/Shadow.gen.tsx
@@ -3,7 +3,6 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as ShadowBS__Es6Import from './Shadow.bs';
-const ShadowBS: any = ShadowBS__Es6Import;
+import * as ShadowBS from './Shadow.bs';
 
-export const test: () => string = ShadowBS.test;
+export const test: () => string = ShadowBS.test as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/TestEmitInnerModules.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/TestEmitInnerModules.gen.tsx
@@ -3,15 +3,14 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as TestEmitInnerModulesBS__Es6Import from './TestEmitInnerModules.bs';
-const TestEmitInnerModulesBS: any = TestEmitInnerModulesBS__Es6Import;
+import * as TestEmitInnerModulesBS from './TestEmitInnerModules.bs';
 
-export const Inner_x: number = TestEmitInnerModulesBS.Inner.x;
+export const Inner_x: number = TestEmitInnerModulesBS.Inner.x as any;
 
-export const Inner_y: string = TestEmitInnerModulesBS.Inner.y;
+export const Inner_y: string = TestEmitInnerModulesBS.Inner.y as any;
 
-export const Outer_Medium_Inner_y: number = TestEmitInnerModulesBS.Outer.Medium.Inner.y;
+export const Outer_Medium_Inner_y: number = TestEmitInnerModulesBS.Outer.Medium.Inner.y as any;
 
-export const Inner: { x: number; y: string } = TestEmitInnerModulesBS.Inner
+export const Inner: { x: number; y: string } = TestEmitInnerModulesBS.Inner as any;
 
-export const Outer: { Medium: { Inner: { y: number } } } = TestEmitInnerModulesBS.Outer
+export const Outer: { Medium: { Inner: { y: number } } } = TestEmitInnerModulesBS.Outer as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/TestFirstClassModules.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/TestFirstClassModules.gen.tsx
@@ -3,8 +3,7 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as TestFirstClassModulesBS__Es6Import from './TestFirstClassModules.bs';
-const TestFirstClassModulesBS: any = TestFirstClassModulesBS__Es6Import;
+import * as TestFirstClassModulesBS from './TestFirstClassModules.bs';
 
 import type {firstClassModule as FirstClassModulesInterface_firstClassModule} from './FirstClassModulesInterface.gen';
 
@@ -14,10 +13,10 @@ import type {record as FirstClassModulesInterface_record} from './FirstClassModu
 
 export type firstClassModuleWithTypeEquations<i,o> = { readonly out: (_1:o) => o; readonly Inner: { readonly inn: (_1:i) => i } };
 
-export const convert: (x:FirstClassModules_firstClassModule) => FirstClassModules_firstClassModule = TestFirstClassModulesBS.convert;
+export const convert: (x:FirstClassModules_firstClassModule) => FirstClassModules_firstClassModule = TestFirstClassModulesBS.convert as any;
 
-export const convertInterface: (x:FirstClassModulesInterface_firstClassModule) => FirstClassModulesInterface_firstClassModule = TestFirstClassModulesBS.convertInterface;
+export const convertInterface: (x:FirstClassModulesInterface_firstClassModule) => FirstClassModulesInterface_firstClassModule = TestFirstClassModulesBS.convertInterface as any;
 
-export const convertRecord: (x:FirstClassModulesInterface_record) => FirstClassModulesInterface_record = TestFirstClassModulesBS.convertRecord;
+export const convertRecord: (x:FirstClassModulesInterface_record) => FirstClassModulesInterface_record = TestFirstClassModulesBS.convertRecord as any;
 
-export const convertFirstClassModuleWithTypeEquations: <T1,T2>(x:{ readonly out: ((_1:T1) => T1); readonly Inner: { readonly inn: ((_1:T2) => T2) } }) => { readonly out: (_1:T1) => T1; readonly Inner: { readonly inn: (_1:T2) => T2 } } = TestFirstClassModulesBS.convertFirstClassModuleWithTypeEquations;
+export const convertFirstClassModuleWithTypeEquations: <T1,T2>(x:{ readonly out: ((_1:T1) => T1); readonly Inner: { readonly inn: ((_1:T2) => T2) } }) => { readonly out: (_1:T1) => T1; readonly Inner: { readonly inn: (_1:T2) => T2 } } = TestFirstClassModulesBS.convertFirstClassModuleWithTypeEquations as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/TestImmutableArray.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/TestImmutableArray.gen.tsx
@@ -3,7 +3,6 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as TestImmutableArrayBS__Es6Import from './TestImmutableArray.bs';
-const TestImmutableArrayBS: any = TestImmutableArrayBS__Es6Import;
+import * as TestImmutableArrayBS from './TestImmutableArray.bs';
 
-export const testImmutableArrayGet: <T1>(arr:ReadonlyArray<T1>) => (undefined | T1) = TestImmutableArrayBS.testImmutableArrayGet;
+export const testImmutableArrayGet: <T1>(arr:ReadonlyArray<T1>) => (undefined | T1) = TestImmutableArrayBS.testImmutableArrayGet as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/TestModuleAliases.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/TestModuleAliases.gen.tsx
@@ -3,8 +3,7 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as TestModuleAliasesBS__Es6Import from './TestModuleAliases.bs';
-const TestModuleAliasesBS: any = TestModuleAliasesBS__Es6Import;
+import * as TestModuleAliasesBS from './TestModuleAliases.bs';
 
 import type {InnerAlias_inner as ModuleAliases2_InnerAlias_inner} from './ModuleAliases2.gen';
 
@@ -30,10 +29,10 @@ export type inner1 = ModuleAliases2_InnerAlias_inner;
 
 export type inner2 = ModuleAliases2_Outer_Inner_inner;
 
-export const testInner1: (x:inner1) => inner1 = TestModuleAliasesBS.testInner1;
+export const testInner1: (x:inner1) => inner1 = TestModuleAliasesBS.testInner1 as any;
 
-export const testInner1Expanded: (x:ModuleAliases2_InnerAlias_inner) => ModuleAliases2_InnerAlias_inner = TestModuleAliasesBS.testInner1Expanded;
+export const testInner1Expanded: (x:ModuleAliases2_InnerAlias_inner) => ModuleAliases2_InnerAlias_inner = TestModuleAliasesBS.testInner1Expanded as any;
 
-export const testInner2: (x:inner2) => inner2 = TestModuleAliasesBS.testInner2;
+export const testInner2: (x:inner2) => inner2 = TestModuleAliasesBS.testInner2 as any;
 
-export const testInner2Expanded: (x:ModuleAliases2_Outer_Inner_inner) => ModuleAliases2_Outer_Inner_inner = TestModuleAliasesBS.testInner2Expanded;
+export const testInner2Expanded: (x:ModuleAliases2_Outer_Inner_inner) => ModuleAliases2_Outer_Inner_inner = TestModuleAliasesBS.testInner2Expanded as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/TestPromise.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/TestPromise.gen.tsx
@@ -3,8 +3,7 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as TestPromiseBS__Es6Import from './TestPromise.bs';
-const TestPromiseBS: any = TestPromiseBS__Es6Import;
+import * as TestPromiseBS from './TestPromise.bs';
 
 export type promise<a> = Promise<a>;
 
@@ -12,6 +11,6 @@ export type fromPayload = { readonly x: number; readonly s: string };
 
 export type toPayload = { readonly result: string };
 
-export const convert: (_1:Promise<fromPayload>) => Promise<toPayload> = TestPromiseBS.convert;
+export const convert: (_1:Promise<fromPayload>) => Promise<toPayload> = TestPromiseBS.convert as any;
 
-export const barx: (x:(undefined | Promise<(undefined | string)>), _2:void) => boolean = TestPromiseBS.barx;
+export const barx: (x:(undefined | Promise<(undefined | string)>), _2:void) => boolean = TestPromiseBS.barx as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/TransitiveType1.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/TransitiveType1.gen.tsx
@@ -3,13 +3,12 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as TransitiveType1BS__Es6Import from './TransitiveType1.bs';
-const TransitiveType1BS: any = TransitiveType1BS__Es6Import;
+import * as TransitiveType1BS from './TransitiveType1.bs';
 
 import type {t2Alias as TransitiveType2_t2Alias} from './TransitiveType2.gen';
 
 import type {t2 as TransitiveType2_t2} from './TransitiveType2.gen';
 
-export const convert: (x:TransitiveType2_t2) => TransitiveType2_t2 = TransitiveType1BS.convert;
+export const convert: (x:TransitiveType2_t2) => TransitiveType2_t2 = TransitiveType1BS.convert as any;
 
-export const convertAlias: (x:TransitiveType2_t2Alias) => TransitiveType2_t2Alias = TransitiveType1BS.convertAlias;
+export const convertAlias: (x:TransitiveType2_t2Alias) => TransitiveType2_t2Alias = TransitiveType1BS.convertAlias as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/TransitiveType3.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/TransitiveType3.gen.tsx
@@ -3,9 +3,8 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as TransitiveType3BS__Es6Import from './TransitiveType3.bs';
-const TransitiveType3BS: any = TransitiveType3BS__Es6Import;
+import * as TransitiveType3BS from './TransitiveType3.bs';
 
 export type t3 = { readonly i: number; readonly s: string };
 
-export const convertT3: (x:t3) => t3 = TransitiveType3BS.convertT3;
+export const convertT3: (x:t3) => t3 = TransitiveType3BS.convertT3 as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/TypeParams3.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/TypeParams3.gen.tsx
@@ -3,13 +3,12 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as TypeParams3BS__Es6Import from './TypeParams3.bs';
-const TypeParams3BS: any = TypeParams3BS__Es6Import;
+import * as TypeParams3BS from './TypeParams3.bs';
 
 import type {items2 as TypeParams2_items2} from './TypeParams2.gen';
 
 import type {items as TypeParams2_items} from './TypeParams2.gen';
 
-export const test: (x:TypeParams2_items) => TypeParams2_items = TypeParams3BS.test;
+export const test: (x:TypeParams2_items) => TypeParams2_items = TypeParams3BS.test as any;
 
-export const test2: (x:TypeParams2_items2) => TypeParams2_items2 = TypeParams3BS.test2;
+export const test2: (x:TypeParams2_items2) => TypeParams2_items2 = TypeParams3BS.test2 as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/Unboxed.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/Unboxed.gen.tsx
@@ -3,8 +3,7 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as UnboxedBS__Es6Import from './Unboxed.bs';
-const UnboxedBS: any = UnboxedBS__Es6Import;
+import * as UnboxedBS from './Unboxed.bs';
 
 export type v1 = number;
 
@@ -18,12 +17,12 @@ export type t = number[] | number | ((_1:number) => number);
 
 export type tabIndex = "0" | "1" | 0;
 
-export const testV1: (x:v1) => v1 = UnboxedBS.testV1;
+export const testV1: (x:v1) => v1 = UnboxedBS.testV1 as any;
 
-export const r2Test: (x:r2) => r2 = UnboxedBS.r2Test;
+export const r2Test: (x:r2) => r2 = UnboxedBS.r2Test as any;
 
-export const a: tabIndex = UnboxedBS.a;
+export const a: tabIndex = UnboxedBS.a as any;
 
-export const b: tabIndex = UnboxedBS.b;
+export const b: tabIndex = UnboxedBS.b as any;
 
-export const zero: 0 = UnboxedBS.zero;
+export const zero: 0 = UnboxedBS.zero as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/Uncurried.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/Uncurried.gen.tsx
@@ -3,8 +3,7 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as UncurriedBS__Es6Import from './Uncurried.bs';
-const UncurriedBS: any = UncurriedBS__Es6Import;
+import * as UncurriedBS from './Uncurried.bs';
 
 export type u0 = () => string;
 
@@ -18,26 +17,26 @@ export type auth = { readonly login: () => string };
 
 export type authU = { readonly loginU: () => string };
 
-export const uncurried0: () => string = UncurriedBS.uncurried0;
+export const uncurried0: () => string = UncurriedBS.uncurried0 as any;
 
-export const uncurried1: (x:number) => string = UncurriedBS.uncurried1;
+export const uncurried1: (x:number) => string = UncurriedBS.uncurried1 as any;
 
-export const uncurried2: (x:number, y:string) => string = UncurriedBS.uncurried2;
+export const uncurried2: (x:number, y:string) => string = UncurriedBS.uncurried2 as any;
 
-export const uncurried3: (x:number, y:string, z:number) => string = UncurriedBS.uncurried3;
+export const uncurried3: (x:number, y:string, z:number) => string = UncurriedBS.uncurried3 as any;
 
-export const curried3: (x:number, y:string, z:number) => string = UncurriedBS.curried3;
+export const curried3: (x:number, y:string, z:number) => string = UncurriedBS.curried3 as any;
 
-export const callback: (cb:(() => number)) => string = UncurriedBS.callback;
+export const callback: (cb:(() => number)) => string = UncurriedBS.callback as any;
 
-export const callback2: (auth:auth) => string = UncurriedBS.callback2;
+export const callback2: (auth:auth) => string = UncurriedBS.callback2 as any;
 
-export const callback2U: (auth:authU) => string = UncurriedBS.callback2U;
+export const callback2U: (auth:authU) => string = UncurriedBS.callback2U as any;
 
-export const sumU: (n:number, m:number) => void = UncurriedBS.sumU;
+export const sumU: (n:number, m:number) => void = UncurriedBS.sumU as any;
 
-export const sumU2: (n:number) => (_1:number) => void = UncurriedBS.sumU2;
+export const sumU2: (n:number) => (_1:number) => void = UncurriedBS.sumU2 as any;
 
-export const sumCurried: (n:number, _2:number) => void = UncurriedBS.sumCurried;
+export const sumCurried: (n:number, _2:number) => void = UncurriedBS.sumCurried as any;
 
-export const sumLblCurried: (s:string, n:number, m:number) => void = UncurriedBS.sumLblCurried;
+export const sumLblCurried: (s:string, n:number, m:number) => void = UncurriedBS.sumLblCurried as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/Usage.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/Usage.gen.tsx
@@ -3,9 +3,8 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as UsageBS__Es6Import from './Usage.bs';
-const UsageBS: any = UsageBS__Es6Import;
+import * as UsageBS from './Usage.bs';
 
 import type {MyModuleAlias_t as Wrapper_MyModuleAlias_t} from './Wrapper.gen';
 
-export const b: Wrapper_MyModuleAlias_t = UsageBS.b;
+export const b: Wrapper_MyModuleAlias_t = UsageBS.b as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/UseImportJsValue.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/UseImportJsValue.gen.tsx
@@ -3,13 +3,12 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as UseImportJsValueBS__Es6Import from './UseImportJsValue.bs';
-const UseImportJsValueBS: any = UseImportJsValueBS__Es6Import;
+import * as UseImportJsValueBS from './UseImportJsValue.bs';
 
 import type {AbsoluteValue_t as ImportJsValue_AbsoluteValue_t} from './ImportJsValue.gen';
 
 import type {stringFunction as ImportJsValue_stringFunction} from './ImportJsValue.gen';
 
-export const useGetProp: (x:ImportJsValue_AbsoluteValue_t) => number = UseImportJsValueBS.useGetProp;
+export const useGetProp: (x:ImportJsValue_AbsoluteValue_t) => number = UseImportJsValueBS.useGetProp as any;
 
-export const useTypeImportedInOtherModule: (x:ImportJsValue_stringFunction) => ImportJsValue_stringFunction = UseImportJsValueBS.useTypeImportedInOtherModule;
+export const useTypeImportedInOtherModule: (x:ImportJsValue_stringFunction) => ImportJsValue_stringFunction = UseImportJsValueBS.useTypeImportedInOtherModule as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/Variants.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/Variants.gen.tsx
@@ -3,8 +3,7 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as VariantsBS__Es6Import from './Variants.bs';
-const VariantsBS: any = VariantsBS__Es6Import;
+import * as VariantsBS from './Variants.bs';
 
 import type {list} from '../src/shims/RescriptPervasives.shim';
 
@@ -46,40 +45,40 @@ export type result3<a,b> =
     { TAG: "Ok"; _0: a }
   | { TAG: "Error"; _0: b };
 
-export const isWeekend: (x:weekday) => boolean = VariantsBS.isWeekend;
+export const isWeekend: (x:weekday) => boolean = VariantsBS.isWeekend as any;
 
-export const monday: "monday" = VariantsBS.monday;
+export const monday: "monday" = VariantsBS.monday as any;
 
-export const saturday: "saturday" = VariantsBS.saturday;
+export const saturday: "saturday" = VariantsBS.saturday as any;
 
-export const sunday: "sunday" = VariantsBS.sunday;
+export const sunday: "sunday" = VariantsBS.sunday as any;
 
-export const onlySunday: (param:"sunday") => void = VariantsBS.onlySunday;
+export const onlySunday: (param:"sunday") => void = VariantsBS.onlySunday as any;
 
-export const swap: (x:"saturday" | "sunday") => "saturday" | "sunday" = VariantsBS.swap;
+export const swap: (x:"saturday" | "sunday") => "saturday" | "sunday" = VariantsBS.swap as any;
 
-export const testConvert: (x:testGenTypeAs) => testGenTypeAs = VariantsBS.testConvert;
+export const testConvert: (x:testGenTypeAs) => testGenTypeAs = VariantsBS.testConvert as any;
 
-export const fortytwoOK: testGenTypeAs = VariantsBS.fortytwoOK;
+export const fortytwoOK: testGenTypeAs = VariantsBS.fortytwoOK as any;
 
-export const fortytwoBAD: "fortytwo" = VariantsBS.fortytwoBAD;
+export const fortytwoBAD: "fortytwo" = VariantsBS.fortytwoBAD as any;
 
-export const testConvert2: (x:testGenTypeAs2) => testGenTypeAs2 = VariantsBS.testConvert2;
+export const testConvert2: (x:testGenTypeAs2) => testGenTypeAs2 = VariantsBS.testConvert2 as any;
 
-export const testConvert3: (x:testGenTypeAs3) => testGenTypeAs3 = VariantsBS.testConvert3;
+export const testConvert3: (x:testGenTypeAs3) => testGenTypeAs3 = VariantsBS.testConvert3 as any;
 
-export const testConvert2to3: (x:testGenTypeAs2) => testGenTypeAs3 = VariantsBS.testConvert2to3;
+export const testConvert2to3: (x:testGenTypeAs2) => testGenTypeAs3 = VariantsBS.testConvert2to3 as any;
 
-export const id1: (x:x1) => x1 = VariantsBS.id1;
+export const id1: (x:x1) => x1 = VariantsBS.id1 as any;
 
-export const id2: (x:x2) => x2 = VariantsBS.id2;
+export const id2: (x:x2) => x2 = VariantsBS.id2 as any;
 
 export const polyWithOpt: (foo:string) => (undefined | (
     { NAME: "One"; VAL: string }
-  | { NAME: "Two"; VAL: number })) = VariantsBS.polyWithOpt;
+  | { NAME: "Two"; VAL: number })) = VariantsBS.polyWithOpt as any;
 
-export const restResult1: (x:result1<number,string>) => result1<number,string> = VariantsBS.restResult1;
+export const restResult1: (x:result1<number,string>) => result1<number,string> = VariantsBS.restResult1 as any;
 
-export const restResult2: (x:result2<number,string>) => result2<number,string> = VariantsBS.restResult2;
+export const restResult2: (x:result2<number,string>) => result2<number,string> = VariantsBS.restResult2 as any;
 
-export const restResult3: (x:result3<number,string>) => result3<number,string> = VariantsBS.restResult3;
+export const restResult3: (x:result3<number,string>) => result3<number,string> = VariantsBS.restResult3 as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/VariantsWithPayload.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/VariantsWithPayload.gen.tsx
@@ -3,8 +3,7 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as VariantsWithPayloadBS__Es6Import from './VariantsWithPayload.bs';
-const VariantsWithPayloadBS: any = VariantsWithPayloadBS__Es6Import;
+import * as VariantsWithPayloadBS from './VariantsWithPayload.bs';
 
 export type payload = { readonly x: number; readonly y?: string };
 
@@ -34,20 +33,20 @@ export type variant1Int = { TAG: "R"; _0: number };
 
 export type variant1Object = { TAG: "R"; _0: payload };
 
-export const testWithPayload: (x:withPayload) => withPayload = VariantsWithPayloadBS.testWithPayload;
+export const testWithPayload: (x:withPayload) => withPayload = VariantsWithPayloadBS.testWithPayload as any;
 
-export const printVariantWithPayload: (x:withPayload) => void = VariantsWithPayloadBS.printVariantWithPayload;
+export const printVariantWithPayload: (x:withPayload) => void = VariantsWithPayloadBS.printVariantWithPayload as any;
 
-export const testManyPayloads: (x:manyPayloads) => manyPayloads = VariantsWithPayloadBS.testManyPayloads;
+export const testManyPayloads: (x:manyPayloads) => manyPayloads = VariantsWithPayloadBS.testManyPayloads as any;
 
-export const printManyPayloads: (x:manyPayloads) => void = VariantsWithPayloadBS.printManyPayloads;
+export const printManyPayloads: (x:manyPayloads) => void = VariantsWithPayloadBS.printManyPayloads as any;
 
-export const testSimpleVariant: (x:simpleVariant) => simpleVariant = VariantsWithPayloadBS.testSimpleVariant;
+export const testSimpleVariant: (x:simpleVariant) => simpleVariant = VariantsWithPayloadBS.testSimpleVariant as any;
 
-export const testVariantWithPayloads: (x:variantWithPayloads) => variantWithPayloads = VariantsWithPayloadBS.testVariantWithPayloads;
+export const testVariantWithPayloads: (x:variantWithPayloads) => variantWithPayloads = VariantsWithPayloadBS.testVariantWithPayloads as any;
 
-export const printVariantWithPayloads: (x:variantWithPayloads) => void = VariantsWithPayloadBS.printVariantWithPayloads;
+export const printVariantWithPayloads: (x:variantWithPayloads) => void = VariantsWithPayloadBS.printVariantWithPayloads as any;
 
-export const testVariant1Int: (x:variant1Int) => variant1Int = VariantsWithPayloadBS.testVariant1Int;
+export const testVariant1Int: (x:variant1Int) => variant1Int = VariantsWithPayloadBS.testVariant1Int as any;
 
-export const testVariant1Object: (x:variant1Object) => variant1Object = VariantsWithPayloadBS.testVariant1Object;
+export const testVariant1Object: (x:variant1Object) => variant1Object = VariantsWithPayloadBS.testVariant1Object as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/Warnings.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/Warnings.gen.tsx
@@ -3,7 +3,6 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as WarningsBS__Es6Import from './Warnings.bs';
-const WarningsBS: any = WarningsBS__Es6Import;
+import * as WarningsBS from './Warnings.bs';
 
-export const ddd: number = WarningsBS.x;
+export const ddd: number = WarningsBS.x as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/Wrapper.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/Wrapper.gen.tsx
@@ -3,11 +3,10 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as WrapperBS__Es6Import from './Wrapper.bs';
-const WrapperBS: any = WrapperBS__Es6Import;
+import * as WrapperBS from './Wrapper.bs';
 
 export type MyModuleAlias_t = number;
 
-export const MyModuleAlias_add: (_1:MyModuleAlias_t, _2:MyModuleAlias_t) => MyModuleAlias_t = WrapperBS.MyModuleAlias.add;
+export const MyModuleAlias_add: (_1:MyModuleAlias_t, _2:MyModuleAlias_t) => MyModuleAlias_t = WrapperBS.MyModuleAlias.add as any;
 
-export const MyModuleAlias: { add: (_1:MyModuleAlias_t, _2:MyModuleAlias_t) => MyModuleAlias_t } = WrapperBS.MyModuleAlias
+export const MyModuleAlias: { add: (_1:MyModuleAlias_t, _2:MyModuleAlias_t) => MyModuleAlias_t } = WrapperBS.MyModuleAlias as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/counter.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/counter.gen.tsx
@@ -3,9 +3,8 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as counterBS__Es6Import from './counter.bs';
-const counterBS: any = counterBS__Es6Import;
+import * as counterBS from './counter.bs';
 
 import type {aa as Machine_aa} from './Machine.gen';
 
-export const b: Machine_aa = counterBS.b;
+export const b: Machine_aa = counterBS.b as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/nested/Tuples.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/nested/Tuples.gen.tsx
@@ -3,8 +3,7 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as TuplesBS__Es6Import from './Tuples.bs';
-const TuplesBS: any = TuplesBS__Es6Import;
+import * as TuplesBS from './Tuples.bs';
 
 export type coord = [number, number, (undefined | number)];
 
@@ -14,20 +13,20 @@ export type person = { readonly name: string; readonly age: number };
 
 export type couple = [person, person];
 
-export const testTuple: (param:[number, number]) => number = TuplesBS.testTuple;
+export const testTuple: (param:[number, number]) => number = TuplesBS.testTuple as any;
 
-export const origin: [number, number, (undefined | number)] = TuplesBS.origin;
+export const origin: [number, number, (undefined | number)] = TuplesBS.origin as any;
 
-export const computeArea: (param:[number, number, (undefined | number)]) => number = TuplesBS.computeArea;
+export const computeArea: (param:[number, number, (undefined | number)]) => number = TuplesBS.computeArea as any;
 
-export const computeAreaWithIdent: (param:coord) => number = TuplesBS.computeAreaWithIdent;
+export const computeAreaWithIdent: (param:coord) => number = TuplesBS.computeAreaWithIdent as any;
 
-export const computeAreaNoConverters: (param:[number, number]) => number = TuplesBS.computeAreaNoConverters;
+export const computeAreaNoConverters: (param:[number, number]) => number = TuplesBS.computeAreaNoConverters as any;
 
-export const coord2d: <T1,T2,T3>(x:T1, y:T2) => [T1, T2, (undefined | T3)] = TuplesBS.coord2d;
+export const coord2d: <T1,T2,T3>(x:T1, y:T2) => [T1, T2, (undefined | T3)] = TuplesBS.coord2d as any;
 
-export const getFirstName: (param:couple) => string = TuplesBS.getFirstName;
+export const getFirstName: (param:couple) => string = TuplesBS.getFirstName as any;
 
-export const marry: (first:person, second:person) => couple = TuplesBS.marry;
+export const marry: (first:person, second:person) => couple = TuplesBS.marry as any;
 
-export const changeSecondAge: (param:couple) => couple = TuplesBS.changeSecondAge;
+export const changeSecondAge: (param:couple) => couple = TuplesBS.changeSecondAge as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/nested/Types.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/nested/Types.gen.tsx
@@ -3,8 +3,7 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as TypesBS__Es6Import from './Types.bs';
-const TypesBS: any = TypesBS__Es6Import;
+import * as TypesBS from './Types.bs';
 
 import type {Json_t as Js_Json_t} from '../../src/shims/Js.shim';
 
@@ -83,38 +82,38 @@ export type ObjectId_t = number;
 
 export type tPrimed = [TypeNameSanitize_t_, TypeNameSanitize_M_t__];
 
-export const someIntList: list<number> = TypesBS.someIntList;
+export const someIntList: list<number> = TypesBS.someIntList as any;
 
-export const map: <T1,T2>(_1:((_1:T1) => T2), _2:list<T1>) => list<T2> = TypesBS.map;
+export const map: <T1,T2>(_1:((_1:T1) => T2), _2:list<T1>) => list<T2> = TypesBS.map as any;
 
-export const swap: (tree:tree) => tree = TypesBS.swap;
+export const swap: (tree:tree) => tree = TypesBS.swap as any;
 
-export const selfRecursiveConverter: (param:selfRecursive) => selfRecursive = TypesBS.selfRecursiveConverter;
+export const selfRecursiveConverter: (param:selfRecursive) => selfRecursive = TypesBS.selfRecursiveConverter as any;
 
-export const mutuallyRecursiveConverter: (param:mutuallyRecursiveA) => mutuallyRecursiveB = TypesBS.mutuallyRecursiveConverter;
+export const mutuallyRecursiveConverter: (param:mutuallyRecursiveA) => mutuallyRecursiveB = TypesBS.mutuallyRecursiveConverter as any;
 
-export const testFunctionOnOptionsAsArgument: <T1,a>(a:(undefined | a), foo:((_1:(undefined | a)) => T1)) => T1 = TypesBS.testFunctionOnOptionsAsArgument;
+export const testFunctionOnOptionsAsArgument: <T1,a>(a:(undefined | a), foo:((_1:(undefined | a)) => T1)) => T1 = TypesBS.testFunctionOnOptionsAsArgument as any;
 
-export const stringT: string = TypesBS.stringT;
+export const stringT: string = TypesBS.stringT as any;
 
-export const jsStringT: string = TypesBS.jsStringT;
+export const jsStringT: string = TypesBS.jsStringT as any;
 
-export const jsString2T: string = TypesBS.jsString2T;
+export const jsString2T: string = TypesBS.jsString2T as any;
 
-export const jsonStringify: (_1:Js_Json_t) => string = TypesBS.jsonStringify;
+export const jsonStringify: (_1:Js_Json_t) => string = TypesBS.jsonStringify as any;
 
-export const testConvertNull: (x:(null | record)) => (null | record) = TypesBS.testConvertNull;
+export const testConvertNull: (x:(null | record)) => (null | record) = TypesBS.testConvertNull as any;
 
-export const testConvertLocation: (x:Location_t) => Location_t = TypesBS.testConvertLocation;
+export const testConvertLocation: (x:Location_t) => Location_t = TypesBS.testConvertLocation as any;
 
-export const testMarshalFields: marshalFields = TypesBS.testMarshalFields;
+export const testMarshalFields: marshalFields = TypesBS.testMarshalFields as any;
 
-export const setMatch: (x:marshalMutableField) => void = TypesBS.setMatch;
+export const setMatch: (x:marshalMutableField) => void = TypesBS.setMatch as any;
 
-export const testInstantiateTypeParameter: (x:instantiateTypeParameter) => instantiateTypeParameter = TypesBS.testInstantiateTypeParameter;
+export const testInstantiateTypeParameter: (x:instantiateTypeParameter) => instantiateTypeParameter = TypesBS.testInstantiateTypeParameter as any;
 
-export const currentTime: Date = TypesBS.currentTime;
+export const currentTime: Date = TypesBS.currentTime as any;
 
-export const i64Const: i64B = TypesBS.i64Const;
+export const i64Const: i64B = TypesBS.i64Const as any;
 
-export const optFunction: (undefined | (() => number)) = TypesBS.optFunction;
+export const optFunction: (undefined | (() => number)) = TypesBS.optFunction as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/strange_file_names/404.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/strange_file_names/404.gen.tsx
@@ -3,7 +3,6 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as _404BS__Es6Import from './404.bs';
-const _404BS: any = _404BS__Es6Import;
+import * as _404BS from './404.bs';
 
-export const x: number = _404BS.x;
+export const x: number = _404BS.x as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/strange_file_names/AppModal.web.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/strange_file_names/AppModal.web.gen.tsx
@@ -3,7 +3,6 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as AppModal_webBS__Es6Import from './AppModal.web.bs';
-const AppModal_webBS: any = AppModal_webBS__Es6Import;
+import * as AppModal_webBS from './AppModal.web.bs';
 
-export const x: number = AppModal_webBS.x;
+export const x: number = AppModal_webBS.x as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/strange_file_names/_under.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/strange_file_names/_under.gen.tsx
@@ -3,7 +3,6 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as _underBS__Es6Import from './_under.bs';
-const _underBS: any = _underBS__Es6Import;
+import * as _underBS from './_under.bs';
 
-export const x: number = _underBS.x;
+export const x: number = _underBS.x as any;

--- a/jscomp/gentype_tests/typescript-react-example/src/strange_file_names/with_underscore.gen.tsx
+++ b/jscomp/gentype_tests/typescript-react-example/src/strange_file_names/with_underscore.gen.tsx
@@ -3,7 +3,6 @@
 /* eslint-disable */
 /* tslint:disable */
 
-import * as with_underscoreBS__Es6Import from './with_underscore.bs';
-const with_underscoreBS: any = with_underscoreBS__Es6Import;
+import * as with_underscoreBS from './with_underscore.bs';
 
-export const x: number = with_underscoreBS.x;
+export const x: number = with_underscoreBS.x as any;

--- a/jscomp/runtime/release.ninja
+++ b/jscomp/runtime/release.ninja
@@ -21,7 +21,7 @@ o runtime/caml_bytes.cmj : cc_cmi runtime/caml_bytes.res | runtime/caml_bytes.cm
 o runtime/caml_bytes.cmi : cc runtime/caml_bytes.resi | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 o runtime/caml_float.cmj : cc_cmi runtime/caml_float.res | runtime/caml_float.cmi runtime/caml_float_extern.cmj
 o runtime/caml_float.cmi : cc runtime/caml_float.resi | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
-o runtime/caml_format.cmj : cc_cmi runtime/caml_format.ml | runtime/caml.cmj runtime/caml_float.cmj runtime/caml_float_extern.cmj runtime/caml_format.cmi runtime/caml_int64.cmj runtime/caml_int64_extern.cmj runtime/caml_nativeint_extern.cmj runtime/caml_string_extern.cmj
+o runtime/caml_format.cmj : cc_cmi runtime/caml_format.ml | runtime/caml_float.cmj runtime/caml_float_extern.cmj runtime/caml_format.cmi runtime/caml_int64.cmj runtime/caml_int64_extern.cmj runtime/caml_nativeint_extern.cmj runtime/caml_string_extern.cmj
 o runtime/caml_format.cmi : cc runtime/caml_format.mli | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 o runtime/caml_hash.cmj : cc_cmi runtime/caml_hash.res | runtime/caml_hash.cmi runtime/caml_hash_primitive.cmj runtime/caml_nativeint_extern.cmj runtime/js.cmj
 o runtime/caml_hash.cmi : cc runtime/caml_hash.resi | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
@@ -37,7 +37,7 @@ o runtime/caml_md5.cmj : cc_cmi runtime/caml_md5.res | runtime/caml_array_extern
 o runtime/caml_md5.cmi : cc runtime/caml_md5.resi | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 o runtime/caml_module.cmj : cc_cmi runtime/caml_module.res | runtime/caml_array_extern.cmj runtime/caml_module.cmi runtime/caml_obj.cmj
 o runtime/caml_module.cmi : cc runtime/caml_module.resi | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
-o runtime/caml_obj.cmj : cc_cmi runtime/caml_obj.res | runtime/caml.cmj runtime/caml_array_extern.cmj runtime/caml_obj.cmi runtime/caml_option.cmj runtime/js.cmj
+o runtime/caml_obj.cmj : cc_cmi runtime/caml_obj.res | runtime/caml_array_extern.cmj runtime/caml_obj.cmi runtime/caml_option.cmj runtime/js.cmj
 o runtime/caml_obj.cmi : cc runtime/caml_obj.resi | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 o runtime/caml_option.cmj : cc_cmi runtime/caml_option.res | runtime/caml_option.cmi runtime/caml_undefined_extern.cmj runtime/js.cmj
 o runtime/caml_option.cmi : cc runtime/caml_option.resi | runtime/bs_stdlib_mini.cmi runtime/caml_undefined_extern.cmj runtime/js.cmi runtime/js.cmj
@@ -54,7 +54,7 @@ o runtime/caml_exceptions.cmi runtime/caml_exceptions.cmj : cc runtime/caml_exce
 o runtime/caml_external_polyfill.cmi runtime/caml_external_polyfill.cmj : cc runtime/caml_external_polyfill.res | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 o runtime/caml_float_extern.cmi runtime/caml_float_extern.cmj : cc runtime/caml_float_extern.res | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 o runtime/caml_int64_extern.cmi runtime/caml_int64_extern.cmj : cc runtime/caml_int64_extern.res | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
-o runtime/caml_js_exceptions.cmi runtime/caml_js_exceptions.cmj : cc runtime/caml_js_exceptions.res | runtime/bs_stdlib_mini.cmi runtime/caml_exceptions.cmj runtime/caml_option.cmj runtime/js.cmi runtime/js.cmj
+o runtime/caml_js_exceptions.cmi runtime/caml_js_exceptions.cmj : cc runtime/caml_js_exceptions.res | runtime/bs_stdlib_mini.cmi runtime/caml_exceptions.cmj runtime/js.cmi runtime/js.cmj
 o runtime/caml_nativeint_extern.cmi runtime/caml_nativeint_extern.cmj : cc runtime/caml_nativeint_extern.res | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 o runtime/caml_string_extern.cmi runtime/caml_string_extern.cmj : cc runtime/caml_string_extern.res | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj
 o runtime/caml_undefined_extern.cmi runtime/caml_undefined_extern.cmj : cc runtime/caml_undefined_extern.res | runtime/bs_stdlib_mini.cmi runtime/js.cmi runtime/js.cmj


### PR DESCRIPTION
<details>
<summary>Background</summary>

I recently discovered a problem while using gentype.

When using ES6 output, gentype assigns an imported namespace to a variable.

```ts
import * as ModuleBS__Es6Import from './Module.bs';
const ModuleBS: any = ModuleBS__Es6Import;
```

This harms DCE. ESM bundlers optimize module dependencies when they can be statically analyzed. However, if indirection such as alias variables is added, it will be deopted.

For example:

```js
// Dep1.js
export function fn1() {
  console.log('Dep1.fn1');
}
export function fn2() {
  console.log('Dep1.fn2');
}
```

```js
// Dep2.js
export function fn1() {
  console.log('Dep2.fn1');
}
export function fn2() {
  console.log('Dep2.fn2');
}
```

```js
// Module.js
import * as Dep1 from './Dep1.js';

import * as Dep2_Import from './Dep2.js';
const Dep2 = Dep2_Import;

Dep1.fn1();
Dep2.fn1();
```

When exec `esbuild src/Module.js --bundle --format=esm --target=node18 --outfile=bundle.js`

```js
// bundle.js
var __defProp = Object.defineProperty;
var __export = (target, all) => {
  for (var name in all)
    __defProp(target, name, { get: all[name], enumerable: true });
};

// src/Dep1.js
function fn1() {
  console.log("Dep1.fn1");
}

// src/Dep2.js
var Dep2_exports = {};
__export(Dep2_exports, {
  fn1: () => fn12,
  fn2: () => fn2
});
function fn12() {
  console.log("Dep2.fn1");
}
function fn2() {
  console.log("Dep2.fn2");
}

// src/Module.js
var Dep2 = Dep2_exports;
fn1();
Dep2.fn1();
```

esbuild doesn't do DCE for `Dep2.js` module.

</details>

This change makes gentype output to be more friendly with bundlers.

- Q. What is `const ModuleBS: any = ModuleBS__Es6Import;` anyway?
  - IDK exactly, I guess it was for suppressing type errors from untyped modules. But regardless of this, users get an error in the import statement. if there are no `allowJs: true`.

- Q. Why `as any` is needed for every binding?
  - Because depending on the strictness settings, TypeScript attempts basic type inference in JS as well. And it may fail for string literals, abstract data types, etc. Even if it is safe.

- Q. Why are new errors reported in `make test-gentype` after making changes?
  - They are actually existing bugs in the gentype's "runtime mode" features. Could not be found while suppressing type errors in the entire module.