### PR TITLE
Downgrade setup-ocaml to 2.1.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
           chmod +x _build/install/default/bin/*
 
       - name: Use OCaml ${{matrix.ocaml_compiler}}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v2.1.7
         if: matrix.os != 'windows-latest'
         with:
           ocaml-compiler: ${{matrix.ocaml_compiler}}
@@ -150,7 +150,7 @@ jobs:
           opam-depext: false
 
       - name: Use OCaml ${{matrix.ocaml_compiler}} (Win)
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v2.1.7
         if: matrix.os == 'windows-latest'
         with:
           ocaml-compiler: ${{matrix.ocaml_compiler}}


### PR DESCRIPTION
Currently getting the error

```
Unable to locate executable file: brew. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.
```

for macOS ARM builds.

I suspect this was caused by a change in the recently released setup-ocaml@2.1.8.