### PR TITLE
Check the runtime representation of variants matches implementation a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### :bug: Bug Fix
 
 - Fix accidental removal of `Belt.Result.Ok` and `Belt.Result.Error` constructors in rc.5 https://github.com/rescript-lang/rescript-compiler/pull/6514
+- Add missing check that the runtime representation of variants matches implementation and interface. https://github.com/rescript-lang/rescript-compiler/pull/6513/files
 
 # 11.0.0-rc.7
 

--- a/jscomp/ml/includecore.mli
+++ b/jscomp/ml/includecore.mli
@@ -35,6 +35,8 @@ type type_mismatch =
   | Record_representation of record_representation * record_representation
   | Unboxed_representation of bool
   | Immediate
+  | Tag_name
+  | Variant_representation of Ident.t
 
 val value_descriptions:
   loc:Location.t -> Env.t -> Ident.t ->


### PR DESCRIPTION
…nd interface.

```
// module M : {
//   @tag("abc")
//   type t = | A(int)
// } =
// {
//   type t = | A(int)
// }

module M : {
  type t = | @as("abc") A
} =
{
  type t = | A
}
```