### PR TITLE
Restored belt Ok and Error constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 #### :bug: Bug Fix
 
-- Fix accidental removal of `Belt.Result.Ok` and `Belt.Result.Error` constructors in rc.5
+- Fix accidental removal of `Belt.Result.Ok` and `Belt.Result.Error` constructors in rc.5 https://github.com/rescript-lang/rescript-compiler/pull/6514
 
 # 11.0.0-rc.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 # 11.0.0-rc.8 (Unreleased)
 
+#### :bug: Bug Fix
+
+- Fix accidental removal of `Belt.Result.Ok` and `Belt.Result.Error` constructors in rc.5
+
 # 11.0.0-rc.7
 
 #### :rocket: New Feature

--- a/jscomp/others/belt_Result.res
+++ b/jscomp/others/belt_Result.res
@@ -22,7 +22,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. */
 
-type t<'a, 'b> = result<'a, 'b>
+type t<'a, 'b> = result<'a, 'b> =
+  | Ok('a)
+  | Error('b)
 
 let getExn = x =>
   switch x {

--- a/jscomp/others/belt_Result.resi
+++ b/jscomp/others/belt_Result.resi
@@ -29,7 +29,9 @@
   This module gives you useful utilities to create and combine `Result` data.
 */
 
-type t<'a, 'b> = result<'a, 'b>
+type t<'a, 'b> = result<'a, 'b> =
+  | Ok('a)
+  | Error('b)
 
 /**
   `getExn(res)`: when `res` is `Ok(n)`, returns `n` when `res` is `Error(m)`, raise an exception


### PR DESCRIPTION
As discussed in https://github.com/rescript-lang/rescript-compiler/pull/6450#issuecomment-1843838255

This was a breaking change, there's no harm in restoring the type alias.