### PR TITLE
playground: fix bug when printing recursive polyvariant types

### DIFF
--- a/jscomp/jsoo/jsoo_playground_main.ml
+++ b/jscomp/jsoo/jsoo_playground_main.ml
@@ -304,6 +304,7 @@ let rescript_parse ~filename src =
 module Printer = struct
   let printExpr typ =
     Printtyp.reset_names();
+    Printtyp.reset_and_mark_loops typ;
     Res_doc.toString
       ~width:60 (Res_outcome_printer.printOutTypeDoc (Printtyp.tree_of_typexp false typ))
 


### PR DESCRIPTION
Fixes the issue reported here: https://github.com/rescript-association/rescript-lang.org/issues/716
Applies the same fix as here: https://github.com/rescript-lang/rescript-vscode/pull/851