### PR TITLE
Upgrade playground dependencies

### DIFF
--- a/packages/playground-bundling/package-lock.json
+++ b/packages/playground-bundling/package-lock.json
@@ -9,22 +9,22 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@rescript/core": "^0.3.0",
-        "@rescript/react": "^0.11.0"
+        "@rescript/core": "^0.6.0",
+        "@rescript/react": "^0.12.0-alpha.3"
       }
     },
     "node_modules/@rescript/core": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@rescript/core/-/core-0.3.0.tgz",
-      "integrity": "sha512-/m6bx01K40FO4lIHiZX9DB+R28qQfWCPCCbkDXFIMEUek2myiNAcf4iHwzlDLD3MVoionQvqln32Tu1ASPk51A==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@rescript/core/-/core-0.6.0.tgz",
+      "integrity": "sha512-D4ykxSpbmxbQa99kCg6/DztwCNt1tV3t11BLSOvJPHNLSIuQxfAU3ddgRruaH9LQSKOrMUjxQS9z6RdG5iFPoA==",
       "peerDependencies": {
-        "rescript": ">= 10.1.0"
+        "rescript": "^10.1.0 || ^11.0.0-alpha.0 || next"
       }
     },
     "node_modules/@rescript/react": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.11.0.tgz",
-      "integrity": "sha512-RzoAO+3cJwXE2D7yodMo4tBO2EkeDYCN/I/Sj/yRweI3S1CY1ZBOF/GMcVtjeIurJJt7KMveqQXTaRrqoGZBBg==",
+      "version": "0.12.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.12.0-alpha.3.tgz",
+      "integrity": "sha512-/S1uj77RPDzuLg3Ofb8KKU3Vppqy97/vF6bBdBZ+saIO9bpHVlsmmJyJG8QXjGZKE+aMynrrR3Tj4+9+5OzLdw==",
       "peerDependencies": {
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
@@ -98,15 +98,15 @@
   },
   "dependencies": {
     "@rescript/core": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@rescript/core/-/core-0.3.0.tgz",
-      "integrity": "sha512-/m6bx01K40FO4lIHiZX9DB+R28qQfWCPCCbkDXFIMEUek2myiNAcf4iHwzlDLD3MVoionQvqln32Tu1ASPk51A==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@rescript/core/-/core-0.6.0.tgz",
+      "integrity": "sha512-D4ykxSpbmxbQa99kCg6/DztwCNt1tV3t11BLSOvJPHNLSIuQxfAU3ddgRruaH9LQSKOrMUjxQS9z6RdG5iFPoA==",
       "requires": {}
     },
     "@rescript/react": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.11.0.tgz",
-      "integrity": "sha512-RzoAO+3cJwXE2D7yodMo4tBO2EkeDYCN/I/Sj/yRweI3S1CY1ZBOF/GMcVtjeIurJJt7KMveqQXTaRrqoGZBBg==",
+      "version": "0.12.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.12.0-alpha.3.tgz",
+      "integrity": "sha512-/S1uj77RPDzuLg3Ofb8KKU3Vppqy97/vF6bBdBZ+saIO9bpHVlsmmJyJG8QXjGZKE+aMynrrR3Tj4+9+5OzLdw==",
       "requires": {}
     },
     "js-tokens": {

--- a/packages/playground-bundling/package.json
+++ b/packages/playground-bundling/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@rescript/core": "^0.3.0",
-    "@rescript/react": "^0.11.0"
+    "@rescript/core": "^0.6.0",
+    "@rescript/react": "^0.12.0-alpha.3"
   }
 }


### PR DESCRIPTION
Right now there is no `Array.toSorted` available in the playground for instance, which has been added to rescript-core in version 0.4.0