### PR TITLE
Github actions: upgrade some actions to v4 to fix deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{matrix.os}}
 
     container:
-      image: ghcr.io/rescript-lang/rescript-ci-build:v1.1.0
+      image: ghcr.io/rescript-lang/rescript-ci-build:v1.2.0
 
     steps:
       # See https://github.com/actions/runner/issues/801#issuecomment-1374967227.
@@ -115,7 +115,7 @@ jobs:
             ubuntu-latest,
             windows-latest,
           ]
-        ocaml_compiler: [4.14.0]
+        ocaml_compiler: [4.14.1]
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: sed -i "s:ID=alpine:ID=NotpineForGHA:" /etc/os-release
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build compiler binaries
         run: opam exec -- dune build --display quiet --profile static
@@ -55,7 +55,7 @@ jobs:
         run: python3 configure.py --bootstrap --verbose
 
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: static-binaries-linux-${{runner.arch}}
           path: |
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download static linux binaries
         if: runner.os == 'Linux'
@@ -87,7 +87,7 @@ jobs:
           chmod +x _build/install/default/bin/*
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -98,7 +98,7 @@ jobs:
         run: node .github/workflows/get_artifact_info.js
 
       - name: "Upload artifacts: binaries"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.artifact_name }}
           path: ${{ env.artifact_path }}
@@ -130,7 +130,7 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2 # to be able to check for changes in subfolder jscomp/syntax later
 
@@ -173,7 +173,7 @@ jobs:
         run: opam exec -- dune build --display quiet --profile release
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -262,14 +262,14 @@ jobs:
         run: node .github/workflows/get_artifact_info.js
 
       - name: "Upload artifacts: binaries"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.artifact_name }}
           path: ${{ env.artifact_path }}
 
       - name: "Upload artifacts: lib/ocaml"
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: lib-ocaml
           path: lib/ocaml
@@ -280,10 +280,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -314,7 +314,7 @@ jobs:
         run: node .github/workflows/prepare_package_upload.js ${{ github.event.pull_request.head.sha }}
 
       - name: "Upload artifact: npm packages"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: npm-packages
           path: |
@@ -341,10 +341,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -373,10 +373,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org # Needed to make auth work for publishing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 - Fix issue with async and newtype in uncurried mode. https://github.com/rescript-lang/rescript-compiler/pull/6601
 
+#### :house: Internal
+
+- Use OCaml 4.14.1 (+ Alpine 3.19 container) for CI build. https://github.com/rescript-lang/rescript-compiler/pull/6600
+
 # 11.1.0-rc.1
 
 #### :rocket: New Feature

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Make sure you have [opam](https://opam.ocaml.org/doc/Install.html) installed on 
 opam init
 
 # Any recent OCaml version works as a development compiler
-opam switch create 4.14.0 # can also create local switch with opam switch create . 4.14.0
+opam switch create 4.14.1 # can also create local switch with opam switch create . 4.14.1
 
 # Install dev dependencies from OPAM
 opam install . --deps-only


### PR DESCRIPTION
Upgrade `actions/checkout`, `actions/setup-node` and `actions/upload-artifact` to v4 to fix deprecation warnings.

`actions/upload-artifact@v4` also brings significant performance improvements according to its documentation.