### PR TITLE
Github actions: upgrade some actions to v4 to fix deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build compiler binaries
         uses: docker://ghcr.io/rescript-lang/rescript-ci-build:alpine-3.19-ocaml-4.14.1-02
@@ -44,13 +44,11 @@ jobs:
 
       - name: Build ninja binary
         uses: docker://ghcr.io/rescript-lang/rescript-ci-build:alpine-3.19-ocaml-4.14.1-02
-        env:
-          LDFLAGS: -static
         with:
           args: sh -c "cd ninja && LDFLAGS=-static python3 configure.py --bootstrap"
 
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: static-binaries-linux-${{runner.arch}}
           path: |
@@ -67,11 +65,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download static linux binaries
         if: runner.os == 'Linux'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: static-binaries-linux-${{ runner.arch }}
 
@@ -82,7 +80,7 @@ jobs:
           chmod +x _build/install/default/bin/*
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -93,7 +91,7 @@ jobs:
         run: node .github/workflows/get_artifact_info.js
 
       - name: "Upload artifacts: binaries"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.artifact_name }}
           path: ${{ env.artifact_path }}
@@ -125,13 +123,13 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2 # to be able to check for changes in subfolder jscomp/syntax later
 
       - name: Download static linux binaries
         if: runner.os == 'Linux'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: static-binaries-linux-${{ runner.arch }}
 
@@ -168,7 +166,7 @@ jobs:
         run: opam exec -- dune build --display quiet --profile release
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -177,7 +175,7 @@ jobs:
 
       - name: "Windows: Use MSVC for ninja build"
         if: runner.os == 'Windows'
-        uses: TheMrMilchmann/setup-msvc-dev@v2
+        uses: TheMrMilchmann/setup-msvc-dev@v3
         with:
           arch: x64
 
@@ -257,14 +255,14 @@ jobs:
         run: node .github/workflows/get_artifact_info.js
 
       - name: "Upload artifacts: binaries"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.artifact_name }}
           path: ${{ env.artifact_path }}
 
       - name: "Upload artifacts: lib/ocaml"
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: lib-ocaml
           path: lib/ocaml
@@ -275,10 +273,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -286,7 +284,7 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Move artifacts
         run: ./scripts/moveArtifacts.sh
@@ -309,7 +307,7 @@ jobs:
         run: node .github/workflows/prepare_package_upload.js ${{ github.event.pull_request.head.sha }}
 
       - name: "Upload artifact: npm packages"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: npm-packages
           path: |
@@ -336,15 +334,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: npm-packages
           path: packages/test
@@ -368,16 +366,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org # Needed to make auth work for publishing
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: npm-packages
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,26 +33,21 @@ jobs:
 
     runs-on: ${{matrix.os}}
 
-    container:
-      image: ghcr.io/rescript-lang/rescript-ci-build:alpine-3.19-ocaml-4.14.1-02
-
     steps:
-      # See https://github.com/actions/runner/issues/801#issuecomment-1374967227.
-      - name: Workaround for Github actions runner on Alpine arm64
-        if: runner.arch	== 'ARM64'
-        run: sed -i "s:ID=alpine:ID=NotpineForGHA:" /etc/os-release
-
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Build compiler binaries
-        run: opam exec -- dune build --display quiet --profile static
+        uses: docker://ghcr.io/rescript-lang/rescript-ci-build:alpine-3.19-ocaml-4.14.1-02
+        with:
+          args: opam exec -- dune build --display quiet --profile static
 
       - name: Build ninja binary
-        working-directory: ninja
+        uses: docker://ghcr.io/rescript-lang/rescript-ci-build:alpine-3.19-ocaml-4.14.1-02
         env:
           LDFLAGS: -static
-        run: python3 configure.py --bootstrap --verbose
+        with:
+          args: sh -c "cd ninja && LDFLAGS=-static python3 configure.py --bootstrap"
 
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

> Node 16 has reached its [end of life](https://github.com/nodejs/Release/#end-of-life-releases), prompting us to initiate its deprecation process for GitHub Actions. Our plan is to transition all actions to run on Node 20 by Spring 2024.

* Alpine build: run individual steps in Docker container (and not the whole job). This allows us to get rid of a workaround and do the checkout on the host instead of in the container, which is required because checkout@v4 doesn't work in Alpine containers anymore.
* Upgrade `actions/checkout`, `actions/setup-node`, `actions/upload-artifact` and `actions/download-artifact` to v4 to fix deprecation warnings. `actions/upload-artifact@v4` also brings significant performance improvements according to its documentation.