### PR TITLE
Generic JSX transform fixes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 #### :bug: Bug Fix
 
 - Fix issue with async and newtype in uncurried mode. https://github.com/rescript-lang/rescript-compiler/pull/6601
+- Generic JSX transform: Rename expected module name for lowercase JSX to `Elements` from `DOM`. https://github.com/rescript-lang/rescript-compiler/pull/6606
+- Generic JSX transform: Set default config params for `jsxConfig`. https://github.com/rescript-lang/rescript-compiler/pull/6606
+- Generic JSX transform: Handle namespaced names. https://github.com/rescript-lang/rescript-compiler/pull/6606
 
 #### :house: Internal
 

--- a/jscomp/bsc/rescript_compiler_main.ml
+++ b/jscomp/bsc/rescript_compiler_main.ml
@@ -251,7 +251,14 @@ let buckle_script_flags : (string * Bsc_args.spec * string) array =
     "*internal* Set jsx version";
 
     "-bs-jsx-module", string_call (fun i ->
-      Js_config.jsx_module := Js_config.jsx_module_of_string i),
+      let isGeneric = match i |> String.lowercase_ascii with
+      | "react" -> false
+      | _ -> true in
+      Js_config.jsx_module := Js_config.jsx_module_of_string i;
+      if isGeneric then (
+        Js_config.jsx_mode := Automatic;
+        Js_config.jsx_version := Some Jsx_v4
+      )),
     "*internal* Set jsx module";
 
     "-bs-jsx-mode", string_call (fun i ->


### PR DESCRIPTION
- Rename the expected module name for lowercase JSX elements to `Elements` from `DOM`. This was just left out, but `Elements` is what's actually documented.
- Set default config params for jsxConfig when using the generic JSX transform.
- Handle potentially namespaced/submodules in the generic module path.