### PR TITLE
allow hyphens in JSX tag names and props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 #### :rocket: New Feature
 
+- Add support for array spread. https://github.com/rescript-lang/rescript-compiler/pull/6608
 - Support import attributes (https://github.com/tc39/proposal-import-attributes) in `@module()`. https://github.com/rescript-lang/rescript-compiler/pull/6599
 - allow hyphens in jsx tag names (e.g. `<mj-column>`). https://github.com/rescript-lang/rescript-compiler/pull/6609
 
@@ -37,7 +38,6 @@
 - Experimental support of tagged template literals, e.g. ```sql`select * from ${table}```. https://github.com/rescript-lang/rescript-compiler/pull/6250
 - Experimental support for generic/custom JSX transforms. https://github.com/rescript-lang/rescript-compiler/pull/6565
 - `dict` is now a builtin type. https://github.com/rescript-lang/rescript-compiler/pull/6590
-- Add support for array spread. https://github.com/rescript-lang/rescript-compiler/pull/6608
 
 #### :bug: Bug Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### :rocket: New Feature
 
 - Support import attributes (https://github.com/tc39/proposal-import-attributes) in `@module()`. https://github.com/rescript-lang/rescript-compiler/pull/6599
+- allow hyphens in jsx tag names (e.g. `<mj-column>`). https://github.com/rescript-lang/rescript-compiler/pull/6609
 
 #### :bug: Bug Fix
 

--- a/jscomp/syntax/src/res_printer.ml
+++ b/jscomp/syntax/src/res_printer.ml
@@ -421,7 +421,7 @@ let printLongident = function
 
 type identifierStyle = ExoticIdent | NormalIdent
 
-let classifyIdentContent ?(allowUident = false) txt =
+let classifyIdentContent ?(allowUident = false) ?(allowHyphen = false) txt =
   if Token.isKeywordTxt txt then ExoticIdent
   else
     let len = String.length txt in
@@ -431,16 +431,18 @@ let classifyIdentContent ?(allowUident = false) txt =
         match String.unsafe_get txt i with
         | 'A' .. 'Z' when allowUident -> loop (i + 1)
         | 'a' .. 'z' | '_' -> loop (i + 1)
+        | '-' when allowHyphen -> loop (i + 1)
         | _ -> ExoticIdent
       else
         match String.unsafe_get txt i with
         | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '\'' | '_' -> loop (i + 1)
+        | '-' when allowHyphen -> loop (i + 1)
         | _ -> ExoticIdent
     in
     loop 0
 
-let printIdentLike ?allowUident txt =
-  match classifyIdentContent ?allowUident txt with
+let printIdentLike ?allowUident ?allowHyphen txt =
+  match classifyIdentContent ?allowUident ?allowHyphen txt with
   | ExoticIdent -> Doc.concat [Doc.text "\\\""; Doc.text txt; Doc.text "\""]
   | NormalIdent -> Doc.text txt
 
@@ -4462,7 +4464,7 @@ and printJsxProp ~state arg cmtTbl =
  * Navabar.createElement -> Navbar
  * Staff.Users.createElement -> Staff.Users *)
 and printJsxName {txt = lident} =
-  let printIdent = printIdentLike ~allowUident:true in
+  let printIdent = printIdentLike ~allowUident:true ~allowHyphen:true in
   let rec flatten acc lident =
     match lident with
     | Longident.Lident txt -> printIdent txt :: acc

--- a/jscomp/syntax/src/res_scanner.ml
+++ b/jscomp/syntax/src/res_scanner.ml
@@ -182,8 +182,11 @@ let digitValue ch =
 let scanIdentifier scanner =
   let startOff = scanner.offset in
   let rec skipGoodChars scanner =
-    match scanner.ch with
-    | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' | '\'' ->
+    match (scanner.ch, inJsxMode scanner) with
+    | ('A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' | '\''), false ->
+      next scanner;
+      skipGoodChars scanner
+    | ('A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' | '\'' | '-'), true ->
       next scanner;
       skipGoodChars scanner
     | _ -> ()

--- a/jscomp/syntax/tests/parsing/errors/expressions/expected/jsx.res.txt
+++ b/jscomp/syntax/tests/parsing/errors/expressions/expected/jsx.res.txt
@@ -1,15 +1,5 @@
 
   Syntax error!
-  tests/parsing/errors/expressions/jsx.res:1:12
-
-  1 │ let x = <di-v />
-  2 │ let x = <Unclosed >;
-  3 │ let x = <Foo.Bar></Free.Will>;
-
-  I'm not sure what to parse here when looking at "-".
-
-
-  Syntax error!
   tests/parsing/errors/expressions/jsx.res:2:20
 
   1 │ let x = <di-v />
@@ -66,7 +56,7 @@
 
   I'm not sure what to parse here when looking at ".".
 
-let x = ((di ~children:[] ())[@JSX ]) - (v / ([%rescript.exprhole ]))
+let x = ((di-v ~children:[] ())[@JSX ])
 let x = ((Unclosed.createElement ~children:[] ())[@JSX ])
 let x =
   ((Foo.Bar.createElement ~children:[] ())[@JSX ]) > ([%rescript.exprhole ])

--- a/jscomp/syntax/tests/printer/expr/expected/jsx.res.txt
+++ b/jscomp/syntax/tests/printer/expr/expected/jsx.res.txt
@@ -5,6 +5,7 @@ let x = <Foo.Bar.Baz className="container" />
 let x = <Foo.bar className="container" />
 let x = <Foo.baz className="multiline" />
 let x = <custom-tag className="container" />
+let x = <Foo.custom-tag className="container" />
 
 // https://github.com/rescript-lang/syntax/issues/570
 let x =
@@ -41,6 +42,11 @@ let x =
     {a}
     <B />
   </custom-tag>
+let x =
+  <Foo.custom-tag className="container">
+    {a}
+    <B />
+  </Foo.custom-tag>
 
 let x = <div className="container" className2="container2" className3="container3" onClick />
 

--- a/jscomp/syntax/tests/printer/expr/expected/jsx.res.txt
+++ b/jscomp/syntax/tests/printer/expr/expected/jsx.res.txt
@@ -4,8 +4,7 @@ let x = <Foo.Bar className="container" />
 let x = <Foo.Bar.Baz className="container" />
 let x = <Foo.bar className="container" />
 let x = <Foo.baz className="multiline" />
-let x = <\"custom-tag" className="container" />
-let x = <Foo.\"custom-tag" className="container" />
+let x = <custom-tag className="container" />
 
 // https://github.com/rescript-lang/syntax/issues/570
 let x =
@@ -38,15 +37,10 @@ let x =
     {b}
   </A>
 let x =
-  <\"custom-tag" className="container">
+  <custom-tag className="container">
     {a}
     <B />
-  </\"custom-tag">
-let x =
-  <Foo.\"custom-tag" className="container">
-    {a}
-    <B />
-  </Foo.\"custom-tag">
+  </custom-tag>
 
 let x = <div className="container" className2="container2" className3="container3" onClick />
 

--- a/jscomp/syntax/tests/printer/expr/jsx.res
+++ b/jscomp/syntax/tests/printer/expr/jsx.res
@@ -6,8 +6,7 @@ let x = <Foo.bar className="container" />
 let x = <Foo.baz
  className="multiline"
 />
-let x = <\"custom-tag" className="container" />
-let x = <Foo.\"custom-tag" className="container" />
+let x = <custom-tag className="container" />
 
 // https://github.com/rescript-lang/syntax/issues/570
 let x = <A> <B> <C> <D /> <E /> </C> <F> <G /> <H /> </F> </B> </A>
@@ -15,8 +14,7 @@ let x = <A> {children} <B/> </A>
 let x = <A> <B/> {children} </A>
 let x = <A> {a} </A>
 let x = <A> {a} {b} </A>
-let x = <\"custom-tag" className="container" > {a} <B/> </\"custom-tag">
-let x = <Foo.\"custom-tag" className="container" > {a} <B/> </Foo.\"custom-tag">
+let x = <custom-tag className="container" > {a} <B/> </custom-tag>
 
 let x =
   <div

--- a/jscomp/syntax/tests/printer/expr/jsx.res
+++ b/jscomp/syntax/tests/printer/expr/jsx.res
@@ -7,6 +7,7 @@ let x = <Foo.baz
  className="multiline"
 />
 let x = <custom-tag className="container" />
+let x = <Foo.custom-tag className="container" />
 
 // https://github.com/rescript-lang/syntax/issues/570
 let x = <A> <B> <C> <D /> <E /> </C> <F> <G /> <H /> </F> </B> </A>
@@ -15,6 +16,7 @@ let x = <A> <B/> {children} </A>
 let x = <A> {a} </A>
 let x = <A> {a} {b} </A>
 let x = <custom-tag className="container" > {a} <B/> </custom-tag>
+let x = <Foo.custom-tag className="container" > {a} <B/> </Foo.custom-tag>
 
 let x =
   <div


### PR DESCRIPTION
~remaining:~
~- [ ] hyphens in prop names~

Edit: We don't actually need to allow hyphens in prop names since we can use `@as` for them.

The current situation where scanner.mode is a list is not ideal, you end up pushing multiple times to this list, you never know what's the mode once you popped up, etc. I tried using GADT so you could restrict some functions to a given mode, but it doesn't play well with the rest of the interface (mutable fields everywhere). Meanwhile it could maybe just be replaced with just a value instead of a list. What's is even Diamond mode by the way?