### PR TITLE
Relax build schema JSX version constraint

### DIFF
--- a/docs/docson/build-schema.json
+++ b/docs/docson/build-schema.json
@@ -335,8 +335,7 @@
           "description": "Build the given dependencies in JSX V3 compatibility mode."
         }
       },
-      "additionalProperties": false,
-      "required": ["version"]
+      "additionalProperties": false
     },
     "bsc-flags": {
       "oneOf": [


### PR DESCRIPTION
JSX version is not required to be set anymore given the generic JSX transform.