### PR TITLE
Fix playground upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
         env:
           KEYCDN_USER: ${{ secrets.KEYCDN_USER }}
           KEYCDN_PASSWORD: ${{ secrets.KEYCDN_PASSWORD }}
-        run: sh playground/upload_bundle.sh
+        run: bash playground/upload_bundle.sh
 
       - name: Prepare artifact upload
         run: node .github/workflows/get_artifact_info.js

--- a/playground/upload_bundle.sh
+++ b/playground/upload_bundle.sh
@@ -1,4 +1,4 @@
-#/usr/bin/sh
+#!/bin/bash
 
 # This script will publish the compiler.js bundle / packages cmij.js files to our KeyCDN server.
 # The target folder on KeyCDN will be the compiler.js' version number.
@@ -29,7 +29,7 @@ if [ ! -f "${NETRC_FILE}" ]; then
   echo "machine ${KEYCDN_SRV} login $KEYCDN_USER password $KEYCDN_PASSWORD" > "${NETRC_FILE}"
 fi
 
-PACKAGES=( "compiler-builtins" "@rescript/react" "@rescript/core")
+PACKAGES=("compiler-builtins" "@rescript/react" "@rescript/core")
 
 echo "Uploading compiler.js file..."
 curl --ftp-create-dirs -T "${SCRIPT_DIR}/compiler.js" --ssl --netrc-file $NETRC_FILE ftp://${KEYCDN_SRV}/v${VERSION}/compiler.js
@@ -45,7 +45,3 @@ do
 
   curl --ftp-create-dirs -T "${SOURCE}/cmij.js" --ssl --netrc-file $NETRC_FILE "${TARGET}/cmij.js"
 done
-   
-
-
-


### PR DESCRIPTION
The script seems to work when run with bash, but not when run with sh.
This is weird, I don't know why it used to work before.