### PR TITLE
Remove more "bs."

### DIFF
--- a/jscomp/build_tests/cmd/input.js
+++ b/jscomp/build_tests/cmd/input.js
@@ -7,9 +7,9 @@ var bsc_exe_path = require("../../../scripts/bin_path").bsc_exe;
 var react = `
 type u 
 
-external a : u = "react" [@@bs.module]
+external a : u = "react" [@@module]
 
-external b : unit -> int = "bool" [@@bs.module "react"]
+external b : unit -> int = "bool" [@@module "react"]
 
 let v = a
 let h = b ()
@@ -19,9 +19,9 @@ var foo_react = `
 type bla
 
 
-external foo : bla = "foo.react" [@@bs.module]
+external foo : bla = "foo.react" [@@module]
 
-external bar : unit -> bla  = "bar" [@@bs.val] [@@bs.module "foo.react"]
+external bar : unit -> bla  = "bar" [@@bs.val] [@@module "foo.react"]
 
 let c = foo 
 

--- a/jscomp/frontend/ast_attributes.ml
+++ b/jscomp/frontend/ast_attributes.ml
@@ -88,7 +88,7 @@ let process_attributes_rev (attrs : t) : attr_kind * t =
         (Uncurry attr, acc) (* TODO: warn unused/duplicated attribute *)
       | ("bs.this" | "this"), (Nothing | Meth_callback _) ->
         (Meth_callback attr, acc)
-      | ("bs.meth" | "meth"), (Nothing | Method _) -> (Method attr, acc)
+      | "meth", (Nothing | Method _) -> (Method attr, acc)
       | ("bs" | "bs.this" | "this"), _ ->
         Bs_syntaxerr.err loc Conflict_bs_bs_this_bs_meth
       | _, _ -> (st, attr :: acc))
@@ -154,8 +154,7 @@ let rs_externals (attrs : t) pval_prim =
         || Ext_array.exists external_attrs (fun (x : string) -> txt = x))
     || prims_to_be_encoded pval_prim
 
-let is_inline : attr -> bool =
- fun ({txt}, _) -> txt = "bs.inline" || txt = "inline"
+let is_inline : attr -> bool = fun ({txt}, _) -> txt = "inline"
 
 let has_inline_payload (attrs : t) = Ext_list.find_first attrs is_inline
 
@@ -223,8 +222,8 @@ let iter_process_bs_string_int_unwrap_uncurry (attrs : t) =
   Ext_list.iter attrs (fun (({txt; loc = _}, (payload : _)) as attr) ->
       match txt with
       | "bs.string" | "string" -> assign `String attr
-      | "bs.int" | "int" -> assign `Int attr
-      | "bs.ignore" | "ignore" -> assign `Ignore attr
+      | "int" -> assign `Int attr
+      | "ignore" -> assign `Ignore attr
       | "bs.unwrap" | "unwrap" -> assign `Unwrap attr
       | "bs.uncurry" | "uncurry" ->
         assign (`Uncurry (Ast_payload.is_single_int payload)) attr

--- a/jscomp/frontend/ast_external_process.ml
+++ b/jscomp/frontend/ast_external_process.ml
@@ -266,7 +266,7 @@ let parse_external_attributes (no_arguments : bool) (prim_name_check : string)
                 st with
                 call_name = Some (name_from_payload_or_prim ~loc payload);
               }
-          | "bs.module" | "module" -> (
+          | "module" -> (
             match payload with
             | PStr
                 [
@@ -391,7 +391,7 @@ let parse_external_attributes (no_arguments : bool) (prim_name_check : string)
             {st with set_name = Some (name_from_payload_or_prim ~loc payload)}
           | "get" ->
             {st with get_name = Some (name_from_payload_or_prim ~loc payload)}
-          | "bs.new" | "new" ->
+          | "new" ->
             {st with new_name = Some (name_from_payload_or_prim ~loc payload)}
           | "set_index" ->
             if String.length prim_name_check <> 0 then

--- a/jscomp/frontend/external_arg_spec.mli
+++ b/jscomp/frontend/external_arg_spec.mli
@@ -29,7 +29,7 @@ type cst = private Arg_int_lit of int | Arg_string_lit of string * delim
 type attr =
   | Poly_var_string of {descr: (string * string) list}
   | Poly_var of {descr: (string * string) list option}
-  | Int of (string * int) list (* ([`a | `b ] [@bs.int])*)
+  | Int of (string * int) list (* ([`a | `b ] [@int])*)
   | Arg_cst of cst
   | Fn_uncurry_arity of
       int (* annotated with [@bs.uncurry ] or [@bs.uncurry 2]*)

--- a/jscomp/frontend/typemod_hide.ml
+++ b/jscomp/frontend/typemod_hide.ml
@@ -46,7 +46,7 @@ let no_type_defined (x : Parsetree.structure_item) =
      generated code from:
      {[
        external %private x : int -> int =  "x"
-       [@@bs.module "./x"]
+       [@@module "./x"]
      ]}
   *)
   | _ -> false

--- a/jscomp/gentype/Annotation.ml
+++ b/jscomp/gentype/Annotation.ml
@@ -20,7 +20,7 @@ let toString annotation =
 let tagIsGenType s = s = "genType" || s = "gentype"
 let tagIsGenTypeAs s = s = "genType.as" || s = "gentype.as"
 let tagIsAs s = s = "as"
-let tagIsInt s = s = "bs.int" || s = "int"
+let tagIsInt s = s = "int"
 let tagIsString s = s = "bs.string" || s = "string"
 
 let tagIsTag s = s = "tag"

--- a/jscomp/gentype/TranslateStructure.ml
+++ b/jscomp/gentype/TranslateStructure.ml
@@ -293,7 +293,7 @@ and translateStructureItem ~config ~outputFileRelative ~resolver ~typeEnv
     |> Translation.combine
   | {
    str_desc =
-     (* ReScript's encoding of bs.module: include with constraint. *)
+     (* ReScript's encoding of @module: include with constraint. *)
      Tstr_include
        {
          incl_mod =

--- a/jscomp/gentype/Translation.ml
+++ b/jscomp/gentype/Translation.ml
@@ -112,7 +112,7 @@ let translateValue ~attributes ~config ~docString ~outputFileRelative ~resolver
 
 (**
  [@genType]
- [@bs.module] external myBanner : ReasonReact.reactClass = "./MyBanner";
+ [@module] external myBanner : ReasonReact.reactClass = "./MyBanner";
 *)
 let translatePrimitive ~config ~outputFileRelative ~resolver ~typeEnv
     (valueDescription : Typedtree.value_description) : t =

--- a/jscomp/ml/oprint.ml
+++ b/jscomp/ml/oprint.ml
@@ -288,7 +288,7 @@ and print_simple_out_type ppf =
           Otyp_arrow ("", Otyp_constr (Oide_ident "unit", []),tyl)
         else tyl
       in 
-      fprintf ppf "@[<0>(%a@ [@bs.meth])@]" print_out_type_1 res
+      fprintf ppf "@[<0>(%a@ [@meth])@]" print_out_type_1 res
   | Otyp_constr (Oide_dot (Oide_dot (Oide_ident "Js_OO", "Callback" ), _),
                  [tyl])
     -> 

--- a/jscomp/runtime/caml_sys.res
+++ b/jscomp/runtime/caml_sys.res
@@ -68,7 +68,7 @@ let sys_time = () =>
 
 /*
 type spawnResult
-external spawnSync : string -> spawnResult = "spawnSync" [@@bs.module "child_process"]
+external spawnSync : string -> spawnResult = "spawnSync" [@@module "child_process"]
 
 external readAs : spawnResult -> 
   < 

--- a/jscomp/syntax/benchmarks/data/Napkinscript.ml
+++ b/jscomp/syntax/benchmarks/data/Napkinscript.ml
@@ -11476,7 +11476,7 @@ end
 module JsFfi = struct
   type scope =
     | Global
-    | Module of string (* bs.module("path") *)
+    | Module of string (* module("path") *)
     | Scope of Longident.t (* bs.scope(/"window", "location"/) *)
 
   type label_declaration = {

--- a/jscomp/syntax/benchmarks/data/Napkinscript.res
+++ b/jscomp/syntax/benchmarks/data/Napkinscript.res
@@ -11843,7 +11843,7 @@ module Scanner = {
 module JsFfi = {
   type scope =
     | Global
-    | Module(string) /* bs.module("path") */
+    | Module(string) /* module("path") */
     | Scope(Longident.t) /* bs.scope(/"window", "location"/) */
 
   type label_declaration = {

--- a/jscomp/syntax/tests/idempotency/genType/src/Runtime.res
+++ b/jscomp/syntax/tests/idempotency/genType/src/Runtime.res
@@ -176,7 +176,7 @@ module Mangle = {
   keywords |> Array.iter(x => Hashtbl.add(table, "_" ++ x, x))
 
   /*
-     Apply bucklescript's mangling rules for object field names:
+     Apply ReScript's mangling rules for object field names:
      Remove trailing "__" if present.
      Otherwise remove leading "_" when followed by an uppercase letter, or keyword.
  */

--- a/jscomp/syntax/tests/idempotency/genType/src/TranslateStructure.res
+++ b/jscomp/syntax/tests/idempotency/genType/src/TranslateStructure.res
@@ -347,7 +347,7 @@ and translateStructureItem = (
     |> Translation.combine
 
   | {
-      /* Bucklescript's encoding of bs.module: include with constraint. */
+      /* ReScript's encoding of @module: include with constraint. */
       Typedtree.str_desc: Tstr_include({
         incl_mod: {
           mod_desc: Tmod_constraint(

--- a/jscomp/syntax/tests/idempotency/genType/src/TranslateTypeExprFromTypes.res
+++ b/jscomp/syntax/tests/idempotency/genType/src/TranslateTypeExprFromTypes.res
@@ -552,7 +552,7 @@ and translateTypeExprFromTypes_ = (
       {dependencies: list{}, type_: type_}
 
     | {noPayloads: list{}, payloads: list{(_label, t)}, unknowns: list{}} =>
-      /* Handle bucklescript's "Arity_" encoding in first argument of Js.Internal.fn(_,_) for uncurried functions.
+      /* Handle ReScript's "Arity_" encoding in first argument of Js.Internal.fn(_,_) for uncurried functions.
        Return the argument tuple. */
       t |> translateTypeExprFromTypes_(
         ~config,

--- a/jscomp/syntax/tests/idempotency/genType/src/Translation.res
+++ b/jscomp/syntax/tests/idempotency/genType/src/Translation.res
@@ -276,7 +276,7 @@ let translateComponent = (
 
 @ocaml.doc("
  * [@genType]
- * [@bs.module] external myBanner : ReasonReact.reactClass = \"./MyBanner\";
+ * [@module] external myBanner : ReasonReact.reactClass = \"./MyBanner\";
  ")
 let translatePrimitive = (
   ~config,

--- a/jscomp/syntax/tests/idempotency/wildcards-world-ui/BN.res
+++ b/jscomp/syntax/tests/idempotency/wildcards-world-ui/BN.res
@@ -18,6 +18,6 @@ type t
 @new @module("bn.js") external new_: string => t = "default"
 @new @module("bn.js") external newInt_: int => t = "default"
 
-// [@bs.module "@polkadot/util"] external tSqrt: (. t) => t = "tSqrt";
+// [@module "@polkadot/util"] external tSqrt: (. t) => t = "tSqrt";
 
 // let test = tSqrt(. new_("50"));

--- a/jscomp/syntax/tests/idempotency/wildcards-world-ui/Web3.res
+++ b/jscomp/syntax/tests/idempotency/wildcards-world-ui/Web3.res
@@ -49,7 +49,7 @@ module Contract = {
 
   type dai
 
-  // [@bs.send] [@bs.new] [@bs.scope "eth"]
+  // [@bs.send] [@new] [@bs.scope "eth"]
   // external getContract: (t, abi, ethAddress) => contract = "Contract";
 
   // Temporary code until I work out how to make the above binding work...

--- a/jscomp/syntax/tests/parsing/errors/typexpr/bsObjSugar.res
+++ b/jscomp/syntax/tests/parsing/errors/typexpr/bsObjSugar.res
@@ -20,7 +20,7 @@ type state = {
 }
 
 type state = {
-  @bs.meth
+  @meth
   "send": string =>
 }
 

--- a/jscomp/syntax/tests/parsing/errors/typexpr/expected/bsObjSugar.res.txt
+++ b/jscomp/syntax/tests/parsing/errors/typexpr/expected/bsObjSugar.res.txt
@@ -53,7 +53,7 @@
   Syntax error!
   tests/parsing/errors/typexpr/bsObjSugar.res:25:1
 
-  23 │   @bs.meth
+  23 │   @meth
   24 │   "send": string =>
   25 │ }
   26 │ 
@@ -141,7 +141,7 @@ type nonrec state =
   < url: string  ;protocols: [%rescript.typehole ]  ;websocket: Websocket.t  
     > 
 type nonrec state = < url: string  ;protocols: [%rescript.typehole ]   > 
-type nonrec state = < send: string -> [%rescript.typehole ] [@bs.meth ]  > 
+type nonrec state = < send: string -> [%rescript.typehole ] [@meth ]  > 
 type nonrec state = < age: [%rescript.typehole ]  ;name: string   > 
 type nonrec state = < age: [%rescript.typehole ] [@set ] ;name: string   > 
 type nonrec state = < age: [%rescript.typehole ]   ;.. > 

--- a/jscomp/syntax/tests/parsing/errors/typexpr/expected/garbage.res.txt
+++ b/jscomp/syntax/tests/parsing/errors/typexpr/expected/garbage.res.txt
@@ -2,11 +2,11 @@
   Syntax error!
   tests/parsing/errors/typexpr/garbage.res:2:28
 
-  1 │ @bs.module("moduleName")
+  1 │ @module("moduleName")
   2 │ external printName: (~name:?, unit) => unit = "printName"
   3 │ 
 
   I'm not sure what to parse here when looking at "?".
 
 external printName : name:((unit)[@res.namedArgLoc ]) -> unit = "printName"
-[@@bs.module {js|moduleName|js}]
+[@@module {js|moduleName|js}]

--- a/jscomp/syntax/tests/parsing/errors/typexpr/garbage.res
+++ b/jscomp/syntax/tests/parsing/errors/typexpr/garbage.res
@@ -1,2 +1,2 @@
-@bs.module("moduleName")
+@module("moduleName")
 external printName: (~name:?, unit) => unit = "printName"

--- a/jscomp/syntax/tests/parsing/grammar/structure/expected/externalDefinition.res.txt
+++ b/jscomp/syntax/tests/parsing/grammar/structure/expected/externalDefinition.res.txt
@@ -7,5 +7,5 @@ external attachShader :
 [@@bs.send ]
 external svg : unit -> React.element = "svg"
 external svg : unit -> React.element = "svg"
-external createDate : unit -> unit -> date = "Date"[@@bs.new ]
+external createDate : unit -> unit -> date = "Date"[@@new ]
 let foobar = (createDate ()) ()

--- a/jscomp/syntax/tests/parsing/grammar/structure/externalDefinition.res
+++ b/jscomp/syntax/tests/parsing/grammar/structure/externalDefinition.res
@@ -12,7 +12,7 @@ external svg: () => React.element = "svg";
 external svg: () => React.element = "svg"
 
 // should not infinite loop
-@bs.new
+@new
 external createDate: (unit, unit) => date = "Date"
 
 let foobar = createDate()()

--- a/jscomp/test/demo_page.res
+++ b/jscomp/test/demo_page.res
@@ -53,12 +53,12 @@ type vdom
 /* FIXME: investigate 
    cases:
    {[
-     [@@bs.module "package1" "same_name"]
-     [@@bs.module "package2" "same_name"]
+     [@@module "package1" "same_name"]
+     [@@module "package2" "same_name"]
    ]}
    {[
-     [@@bs.module "package" "name1"]
-     [@@bs.module "package" "name2"]
+     [@@module "package" "name1"]
+     [@@module "package" "name2"]
    ]}
 */
 @send @variadic external h1: (vdom, ~attrs: attrs=?, array<component>) => component = "h1"

--- a/jscomp/test/ffi_splice_test.res
+++ b/jscomp/test/ffi_splice_test.res
@@ -38,7 +38,7 @@ type t
 @send external sum: (t, unit) => int = "sum"
 
 /* compile error */
-/* external join : string  -> string = "" [@@bs.module "path"] [@@bs.splice] */
+/* external join : string  -> string = "" [@@module "path"] [@@bs.splice] */
 @module("path") @variadic external join: array<string> => string = "join"
 
 @send @variadic external test: (t, array<string>) => t = "test" /* FIXME */

--- a/jscomp/test/gpr_441.res
+++ b/jscomp/test/gpr_441.res
@@ -1,4 +1,4 @@
 /* external new_rectangle : */
-/* unit -> int  = "" [@@bs.new] [@@bs.module "@Rectangle"] */
+/* unit -> int  = "" [@@new] [@@module "@Rectangle"] */
 
 /* let rect = new_rectangle */

--- a/jscomp/test/hash_sugar_desugar.resi
+++ b/jscomp/test/hash_sugar_desugar.resi
@@ -3,7 +3,7 @@ let h3: {.."hi": (int, int) => 'a} => 'a
 let g5: {..@set "hi": int} => unit
 let h5: {..@set "hi": int} => unit
 /* The inferred type is 
-   val h5 : < hi#= : (int -> unit [@bs.meth]); .. > -> unit
+   val h5 : < hi#= : (int -> unit [@meth]); .. > -> unit
    We should propose the rescript syntax:
    { mutable "hi" : int  }
 */

--- a/jscomp/test/inline_const.resi
+++ b/jscomp/test/inline_const.resi
@@ -23,7 +23,7 @@ let hh: string
 
 @inline(1) let f6: int
 
-/* val f7 : bool [@@bs.inline 1L] */
+/* val f7 : bool [@@inline 1L] */
 
 @inline(100L) let v: int64
 @inline(1L) let u: int64

--- a/jscomp/test/js_val.res
+++ b/jscomp/test/js_val.res
@@ -5,7 +5,7 @@
 @val @module(("x", "U")) external vvv: int = "vv"
 @module(("x", "U")) external vvvv: int = "vvvv"
 
-/* TODO: unify all [bs.module] name, here ideally,
+/* TODO: unify all [module] name, here ideally,
  we should have only one [require("x")] here */
 let h = u
 let hh = vv

--- a/jscomp/test/module_as_class_ffi.res
+++ b/jscomp/test/module_as_class_ffi.res
@@ -4,16 +4,16 @@ type t
 
 let f = () => mk(3)
 
-/* external mk2 : int -> t = "xx/foo_class" [@@bs.new "x"] [@@bs.module] 
+/* external mk2 : int -> t = "xx/foo_class" [@@new "x"] [@@module] 
 
 File "module_as_class_ffi.ml", line 9, characters 0-69:
-conflict attributes found: (bs.new should not carry payload here)
+conflict attributes found: (new should not carry payload here)
 */
 /*
 TODO: more error checking
-1. [@@bs.module] can only be used once
-2. here [bs.new] should not have any payload
-3. consolidate all [bs.module] 
+1. [@@module] can only be used once
+2. here [new] should not have any payload
+3. consolidate all [module] 
 
 
 let ff () =

--- a/jscomp/test/test_react.res
+++ b/jscomp/test/test_react.res
@@ -23,12 +23,12 @@ type vdom
 /* FIXME: investigate 
    cases:
    {[
-     [@@bs.module "package1" "same_name"]
-     [@@bs.module "package2" "same_name"]
+     [@@module "package1" "same_name"]
+     [@@module "package2" "same_name"]
    ]}
    {[
-     [@@bs.module "package" "name1"]
-     [@@bs.module "package" "name2"]
+     [@@module "package" "name1"]
+     [@@module "package" "name2"]
    ]}
 */
 @send @variadic external h1: (vdom, ~attrs: attrs=?, array<component>) => component = "h1"


### PR DESCRIPTION
* `bs.ignore` -> `ignore`
* `bs.inline` -> `inline`
* `bs.int` -> `int`
* `bs.meth` -> `meth`
* `bs.module` -> `module`
* `bs.new` -> `new`

More to follow in additional PRs.