### PR TITLE
No parens around tagged template literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 # 11.1.0-rc.3 (Unreleased)
 
 #### :nail_care: Polish
-- No parens around tagged template literals.
+- No parens around tagged template literals. https://github.com/rescript-lang/rescript-compiler/pull/6639
 
 # 11.1.0-rc.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 # 11.1.0-rc.3 (Unreleased)
 
+#### :nail_care: Polish
+- No parens around tagged template literals.
+
 # 11.1.0-rc.2
 
 #### :rocket: New Feature


### PR DESCRIPTION
I accidentally pushed the actual fix directly to the branch: https://github.com/rescript-lang/rescript-compiler/commit/a82ea96187cf95d51487c99671e7bee65a19377c

This just adds the changelog. 