### PR TITLE
Make the partial match suggestion easier to copy-paste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@
 - Fix making the static import for the dynamic import of external ffi https://github.com/rescript-lang/rescript-compiler/pull/6664
 
 #### :nail-care: Polish
+
 - Omit `undefined` in external function calls for trailing optional arguments when not supplied. https://github.com/rescript-lang/rescript-compiler/pull/6653
+- Make pattern match suggestions to be easier to copy-paste. https://github.com/rescript-lang/rescript-compiler/pull/6656
 
 # 11.1.0-rc.3
 

--- a/jscomp/build_tests/super_errors/expected/warnings4.res.expected
+++ b/jscomp/build_tests/super_errors/expected/warnings4.res.expected
@@ -10,4 +10,4 @@
   14 [2m│[0m 
 
   You forgot to handle a possible case here, for example: 
-  #second(_) | #fourth | #third
+  | #second(_) | #fourth | #third

--- a/jscomp/build_tests/super_errors/expected/warnings5.res.expected
+++ b/jscomp/build_tests/super_errors/expected/warnings5.res.expected
@@ -24,7 +24,7 @@ Either bind these labels explicitly or add ', _' to the pattern.
   15 [2m│[0m switch y {
 
   You forgot to handle a possible case here, for example: 
-  {otherValue: true, _}
+  | {otherValue: true, _}
 
 
   [1;33mWarning number 9[0m
@@ -52,7 +52,7 @@ Either bind these labels explicitly or add ', _' to the pattern.
   19 [2m│[0m let arr = [1]
 
   You forgot to handle a possible case here, for example: 
-  {typ: WithPayload(false), _}
+  | {typ: WithPayload(false), _}
 | {typ: Variant | One | Two | Three | Four | Five | Six | Seven(_), _}
 
 
@@ -68,7 +68,7 @@ Either bind these labels explicitly or add ', _' to the pattern.
   25 [2m│[0m switch arr {
 
   You forgot to handle a possible case here, for example: 
-  [_]
+  | [_]
 
 
   [1;33mWarning number 8[0m
@@ -83,7 +83,7 @@ Either bind these labels explicitly or add ', _' to the pattern.
   29 [2m│[0m switch arr {
 
   You forgot to handle a possible case here, for example: 
-  []
+  | []
 
 
   [1;33mWarning number 8[0m
@@ -98,7 +98,7 @@ Either bind these labels explicitly or add ', _' to the pattern.
   33 [2m│[0m let lst = list{}
 
   You forgot to handle a possible case here, for example: 
-  [1, 0] | [0, _] | []
+  | [1, 0] | [0, _] | []
 
 
   [1;33mWarning number 8[0m
@@ -113,7 +113,7 @@ Either bind these labels explicitly or add ', _' to the pattern.
   39 [2m│[0m switch lst {
 
   You forgot to handle a possible case here, for example: 
-  list{_, ..._}
+  | list{_, ..._}
 
 
   [1;33mWarning number 8[0m
@@ -128,7 +128,7 @@ Either bind these labels explicitly or add ', _' to the pattern.
   43 [2m│[0m switch lst {
 
   You forgot to handle a possible case here, for example: 
-  list{1, 2, _, ..._} | list{1, 0, ..._} | list{1} | list{0, ..._} | list{}
+  | list{1, 2, _, ..._} | list{1, 0, ..._} | list{1} | list{0, ..._} | list{}
 
 
   [1;33mWarning number 8[0m
@@ -143,7 +143,7 @@ Either bind these labels explicitly or add ', _' to the pattern.
   47 [2m│[0m switch "abc" {
 
   You forgot to handle a possible case here, for example: 
-  list{1, _, ..._} | list{0, ..._} | list{}
+  | list{1, _, ..._} | list{0, ..._} | list{}
 
 
   [1;33mWarning number 8[0m
@@ -158,7 +158,7 @@ Either bind these labels explicitly or add ', _' to the pattern.
   51 [2m│[0m switch 0 {
 
   You forgot to handle a possible case here, for example: 
-  "*"
+  | "*"
 
 
   [1;33mWarning number 8[0m
@@ -173,7 +173,7 @@ Either bind these labels explicitly or add ', _' to the pattern.
   55 [2m│[0m let tuple = (1, true)
 
   You forgot to handle a possible case here, for example: 
-  0
+  | 0
 
 
   [1;33mWarning number 8[0m
@@ -187,4 +187,4 @@ Either bind these labels explicitly or add ', _' to the pattern.
   60 [2m│[0m 
 
   You forgot to handle a possible case here, for example: 
-  (_, true)
+  | (_, true)

--- a/jscomp/ml/parmatch.ml
+++ b/jscomp/ml/parmatch.ml
@@ -2099,6 +2099,7 @@ let do_check_partial ?pred exhaust loc casel pss = match pss with
               let errmsg =
                 try
                   let buf = Buffer.create 16 in
+                  Buffer.add_string buf "| ";
                   Buffer.add_string buf (!print_res_pat v);
                   begin match check_partial_all v casel with
                   | None -> ()


### PR DESCRIPTION
In current behavior:

```res
let next = (state, event) => {
  // Compiler understand what type you want here, without additional annotations
  switch (state, event) {
    | (Paused(data), Start | Resume) => Running(data)
    | (Running({ count }), Increase) => Running({ count: count + 1 })
    | (Running({ count }), Decrease) => Running({ count: count - 1 })
    | (Running({ count }), Pause) => Paused({ count: count })
    | (_, Reset) => init()
  }
}
```

```
You forgot to handle a possible case here, for example: 
  (Running({count: _, _}), Start | Resume)
| (Paused(_), Pause | Increase | Decrease)
```
When I want to copy the pattern suggested from this message, copying two lines is not enough. I need to manually insert `|` at front of the pattern.

```diff
You forgot to handle a possible case here, for example: 
- (Running({count: _, _}), Start | Resume)
+| (Running({count: _, _}), Start | Resume)
 | (Paused(_), Pause | Increase | Decrease)
```

This simple change makes moving lines much easier