### PR TITLE
Prioritizing `--help` arg handling

### DIFF
--- a/jscomp/build_tests/cli_help/input.js
+++ b/jscomp/build_tests/cli_help/input.js
@@ -81,35 +81,21 @@ assert.equal(out.stdout, buildHelp);
 assert.equal(out.stderr, "");
 assert.equal(out.status, 0);
 
-// FIXME: Help works incorrectly in watch mode
 out = child_process.spawnSync(`../../../rescript`, ["build", "-w", "--help"], {
   encoding: "utf8",
   cwd: __dirname,
 });
-// FIXME: Shouldn't have "Start compiling" for help
-assert.equal(out.stdout, ">>>> Start compiling\n" + buildHelp);
-// FIXME: Don't run the watcher when showing help
-assert.match(
-  out.stderr,
-  new RegExp(
-    "Uncaught Exception Error: ENOENT: no such file or directory, watch 'bsconfig.json'\n"
-  )
-);
-// FIXME: Should be 0
-assert.equal(out.status, 1);
+assert.equal(out.stdout, buildHelp);
+assert.equal(out.stderr, "");
+assert.equal(out.status, 0);
 
-// FIXME: Has the same problem with `rescript -w`
 out = child_process.spawnSync(`../../../rescript`, ["-w", "--help"], {
   encoding: "utf8",
   cwd: __dirname,
 });
-assert.equal(out.stdout, ">>>> Start compiling\n" + buildHelp);
-assert.match(
-  out.stderr,
-  new RegExp(
-    "Uncaught Exception Error: ENOENT: no such file or directory, watch 'bsconfig.json'\n"
-  )
-);
+assert.equal(out.stdout, cliHelp);
+assert.equal(out.stderr, "");
+assert.equal(out.status, 0);
 
 // Shows cli help with --help arg even if there are invalid arguments after it
 out = child_process.spawnSync(`../../../rescript`, ["--help", "-w"], {

--- a/rescript
+++ b/rescript
@@ -67,66 +67,64 @@ process.on("SIGUSR2", exitProcess);
 process.on("SIGTERM", exitProcess);
 process.on("SIGHUP", exitProcess);
 
-const process_argv = process.argv;
-const maybeSubcommand = process_argv[2];
+const args = process.argv.slice(2);
+const helpArgIndex = args.findIndex(arg => /help|-h|-help|--help/.test(arg));
+const firstPositionalArgIndex = args.findIndex(arg => !arg.startsWith("-"));
 
-if (!maybeSubcommand) {
-  bsb.build([]);
-} else {
-  switch (maybeSubcommand) {
+if (helpArgIndex !== -1 && (firstPositionalArgIndex === -1 || helpArgIndex <= firstPositionalArgIndex)) {
+  console.log(helpMessage);
+
+} else if (/version|-v|-version|--version/.test(args[0])) {
+  console.log(require("./package.json").version);
+
+} else if (firstPositionalArgIndex !== -1) {
+  const subcmd = args[firstPositionalArgIndex];
+  const subcmdArgs = args.slice(firstPositionalArgIndex + 1);
+
+  switch (subcmd) {
     case "info": {
-      bsb.info(process_argv.slice(3));
+      bsb.info(subcmdArgs);
       break;
     }
     case "clean": {
-      bsb.clean(process_argv.slice(3));
+      bsb.clean(subcmdArgs);
       break;
     }
     case "build": {
-      bsb.build(process_argv.slice(3));
+      bsb.build(subcmdArgs);
       break;
     }
-    case "format":
+    case "format": {
       require("./scripts/rescript_format.js").main(
-        process.argv.slice(3),
+        subcmdArgs,
         rescript_exe,
         bsc_exe
       );
       break;
-    case "dump":
+    }
+    case "dump": {
       require("./scripts/rescript_dump.js").main(
-        process.argv.slice(3),
+        subcmdArgs,
         rescript_exe,
         bsc_exe
       );
       break;
-    case "convert":
+    }
+    case "convert": {
       require("./scripts/rescript_convert.js").main(
-        process.argv.slice(3),
+        subcmdArgs,
         rescript_exe,
         bsc_exe
       );
       break;
-    case "-h":
-    case "-help":
-    case "--help":
-    case "help":
-      console.log(helpMessage);
-      break;
-    case "-v":
-    case "-version":
-    case "--version":
-    case "version":
-      console.log(require("./package.json").version);
-      break;
-    default:
-      if (maybeSubcommand.startsWith("-")) {
-        bsb.build(process_argv.slice(2));
-      } else {
-        console.error(
-          `Error: Unknown command "${maybeSubcommand}".\n${helpMessage}`
-        );
-        process.exit(2);
-      }
+    }
+    default: {
+      console.error(
+        `Error: Unknown command "${subcmd}".\n${helpMessage}`
+      );
+      process.exit(2);
+    }
   }
+} else {
+  bsb.build(args);
 }

--- a/scripts/rescript_bsb.js
+++ b/scripts/rescript_bsb.js
@@ -493,6 +493,10 @@ function build(args) {
     });
     return;
   }
+  if (args.some(arg => /-h|-help|--help/.test(arg))) {
+    delegate(["build", "-h"]);
+    return;
+  }
   if (args.includes("-w")) {
     watch(args);
     return;


### PR DESCRIPTION
cc @DZakh 

This also indirectly fixes the indeterministic build timeout on the master branch

> If the process intercepts and handles the SIGTERM signal and doesn't exit, the parent process will wait until the child process has exited.