### PR TITLE
Fix issue in partial application when the last named arg is provided.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix emitting static import instead of dynamic import. https://github.com/rescript-lang/rescript-compiler/pull/6664
 - Fix local type variables breaking react components. https://github.com/rescript-lang/rescript-compiler/pull/6665
 - Fix remove redundant branches in generated switch body. https://github.com/rescript-lang/rescript-compiler/pull/6672
+- Fix issue in partial application when the last named arg is provided. https://github.com/rescript-lang/rescript-compiler/pull/6681
 
 #### :nail-care: Polish
 

--- a/jscomp/test/UncurriedAlways.js
+++ b/jscomp/test/UncurriedAlways.js
@@ -179,6 +179,33 @@ function a$1(__x) {
               }), 2, __x);
 }
 
+function f3(x, y, z) {
+  console.log(x);
+  return (x + y | 0) + z | 0;
+}
+
+function fx(extra, extra$1) {
+  return f3(1, extra, extra$1);
+}
+
+function fy(none, extra) {
+  return f3(none, 1, extra);
+}
+
+function fz(none, none$1) {
+  return f3(none, none$1, 1);
+}
+
+var fxyz = f3(1, 1, 1);
+
+var PartialApplication = {
+  f3: f3,
+  fx: fx,
+  fy: fy,
+  fz: fz,
+  fxyz: fxyz
+};
+
 exports.foo = foo;
 exports.z = z;
 exports.bar = bar;
@@ -198,4 +225,5 @@ exports.OptMixed = OptMixed;
 exports.fn = fn;
 exports.fn1 = fn1;
 exports.a = a$1;
+exports.PartialApplication = PartialApplication;
 /*  Not a pure module */

--- a/jscomp/test/UncurriedAlways.res
+++ b/jscomp/test/UncurriedAlways.res
@@ -75,3 +75,18 @@ fn(s => Js.log(#foo(s)))
 let fn1 = (a, b, ()) => a() + b 
 
 let a = fn1(() => 1, 2, _)
+
+module PartialApplication = {
+  let f3 = (~x, ~y, ~z) => {
+    Js.log(x)
+    x + y + z
+  }
+
+  let fx = f3(~x=1, ...)
+
+  let fy = f3(~y=1, ...)
+
+  let fz = f3(~z=1, ...)
+
+  let fxyz = f3(~x=1, ~y=1, ~z=1, ...)
+}


### PR DESCRIPTION
Fix the check to determine whether all the arguments were passed to a partial application. The check needs to keep into account the real arguments passed.

Fixes https://github.com/rescript-lang/rescript-compiler/issues/6680