### PR TITLE
Update Node.js requirement to the latest LTS (v20)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Copy exes to platform bin dirs
         run: node ./scripts/copyExes.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - `lazy` syntax is no longer supported. If you're using it, use `Lazy` module or `React.lazy_` instead. https://github.com/rescript-lang/rescript-compiler/pull/6342
 - Remove handling of attributes with `bs.` prefix (`@bs.as` -> `@as` etc.). https://github.com/rescript-lang/rescript-compiler/pull/6643
 - Remove obsolete `@bs.open` feature. https://github.com/rescript-lang/rescript-compiler/pull/6629
-- Drop Node.js version <18 support, due to it reaching End-of-Life. https://github.com/rescript-lang/rescript-compiler/pull/6429
+- Drop Node.js version <20 support. https://github.com/rescript-lang/rescript-compiler/pull/6484
 
 #### :house: Internal
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Happy hacking!
 
 > Most of our contributors are working on Apple machines, so all our instructions are currently macOS / Linux centric. Contributions for Windows development welcome!
 
-- [NodeJS v18](https://nodejs.org/)
+- [NodeJS v20+](https://nodejs.org/)
 - C compiler toolchain (usually installed with `xcode` on Mac)
 - `opam` (OCaml Package Manager)
 - VSCode (+ [OCaml Platform Extension](https://marketplace.visualstudio.com/items?itemName=ocamllabs.ocaml-platform))

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "prettier": "2.7.1"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "bin": {
     "bsc": "bsc",


### PR DESCRIPTION
#6429 merged, then why not jump directly to the latest LTS?

It has a longer lifespan and several more stable APIs that are useful for development.

And I think upgrading an old version of node to v18 or v20 isn't much different.