### PR TITLE
Hyphen_jsx_attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 - Improve error when using '@deriving(accessors)' on a variant with record arguments. https://github.com/rescript-lang/rescript-compiler/pull/6712
 
+- Stop escaping JSX prop names with hyphens. https://github.com/rescript-lang/rescript-compiler/pull/6705
+
 # 11.1.0-rc.7
 
 #### :bug: Bug Fix

--- a/jscomp/syntax/src/res_printer.ml
+++ b/jscomp/syntax/src/res_printer.ml
@@ -4410,6 +4410,7 @@ and printJsxProps ~state args cmtTbl : Doc.t * Parsetree.expression option =
   loop [] args
 
 and printJsxProp ~state arg cmtTbl =
+  let printIdentLike ident = printIdentLike ~allowHyphen:true ident in
   match arg with
   | ( ((Asttypes.Labelled lblTxt | Optional lblTxt) as lbl),
       {

--- a/jscomp/syntax/tests/printer/expr/expected/exoticIdent.res.txt
+++ b/jscomp/syntax/tests/printer/expr/expected/exoticIdent.res.txt
@@ -62,7 +62,7 @@ lazy \"let"
 let x = 1
 
 let x =
-  <div \"aria-foo"=\"type">
+  <div aria-foo=\"type">
     \"module"
     \"let"
   </div>

--- a/jscomp/syntax/tests/printer/expr/expected/jsx.res.txt
+++ b/jscomp/syntax/tests/printer/expr/expected/jsx.res.txt
@@ -47,6 +47,11 @@ let x =
     {a}
     <B />
   </Foo.custom-tag>
+let x =
+  <custom-tag data-custom-state=true>
+    {a}
+    <B />
+  </custom-tag>
 
 let x = <div className="container" className2="container2" className3="container3" onClick />
 

--- a/jscomp/syntax/tests/printer/expr/jsx.res
+++ b/jscomp/syntax/tests/printer/expr/jsx.res
@@ -17,6 +17,7 @@ let x = <A> {a} </A>
 let x = <A> {a} {b} </A>
 let x = <custom-tag className="container" > {a} <B/> </custom-tag>
 let x = <Foo.custom-tag className="container" > {a} <B/> </Foo.custom-tag>
+let x = <custom-tag data-custom-state=true > {a} <B/> </custom-tag>
 
 let x =
   <div


### PR DESCRIPTION
Since the parser already supported hyphens in prop names, I updated the printer to support it too, I guess it's more coherent.