### PR TITLE
Deprecated es6 and es6-global in favor of esmodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 - Fix trailing undefined for optional parameters not omitted with `@send` and `@new`. https://github.com/rescript-lang/rescript-compiler/pull/6716
 - Fix JSX4 adding the incorrect type annotation for the prop `ref` in React.forwardRef component https://github.com/rescript-lang/rescript-compiler/pull/6718
 
+#### :nail_care: Polish
+
+- Module spec `es6` and `es6-global` is deprecated in favor of `esmodule`. https://github.com/rescript-lang/rescript-compiler/pull/6709
+
 # 11.1.0-rc.7
 
 #### :bug: Bug Fix

--- a/docs/docson/build-schema.json
+++ b/docs/docson/build-schema.json
@@ -2,8 +2,8 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "module-format": {
-      "enum": ["commonjs", "es6", "es6-global"],
-      "description": "es6-global generate relative `require` paths instead of relying on NodeJS' module resolution. Default: commonjs."
+      "enum": ["esmodule", "commonjs", "es6", "es6-global"],
+      "description": "es6 and es6-global are deprecated. Default: commonjs."
     },
     "suffix-spec": {
       "type": "string",

--- a/jscomp/bsb/bsb_config.ml
+++ b/jscomp/bsb/bsb_config.ml
@@ -42,7 +42,7 @@ let rev_lib_bs = ".." // ".."
 (* access the js directory from "lib/bs",
    it would be '../js'
 
-   TODO: should be renamed, js -> cjs, es6 -> esm in v12
+   TODO: should be renamed, js -> cjs, es6 -> mjs in v12
 *)
 let lib_bs_prefix_of_format (x : Ext_module_system.t) =
   ".."

--- a/jscomp/bsb/bsb_config.ml
+++ b/jscomp/bsb/bsb_config.ml
@@ -41,16 +41,18 @@ let rev_lib_bs = ".." // ".."
 
 (* access the js directory from "lib/bs",
    it would be '../js'
+
+   TODO: should be renamed, js -> cjs, es6 -> esm in v12
 *)
 let lib_bs_prefix_of_format (x : Ext_module_system.t) =
   ".."
-  // match x with NodeJS -> "js" | Es6 -> "es6" | Es6_global -> "es6_global"
+  // match x with Commonjs -> "js" | Esmodule -> "es6" | Es6_global -> "es6_global"
 
 (* lib/js, lib/es6, lib/es6_global *)
 let top_prefix_of_format (x : Ext_module_system.t) =
   match x with
-  | NodeJS -> lib_js
-  | Es6 -> lib_es6
+  | Commonjs -> lib_js
+  | Esmodule -> lib_es6
   | Es6_global -> lib_es6_global
 
 let rev_lib_bs_prefix p = rev_lib_bs // p

--- a/jscomp/bsb/bsb_config.mli
+++ b/jscomp/bsb/bsb_config.mli
@@ -33,8 +33,10 @@ val lib_js : string
 val lib_bs : string
 
 val lib_es6 : string
+[@@ocaml.deprecated "will be removed in v12"]
 
 val lib_es6_global : string
+[@@ocaml.deprecated "will be removed in v12"]
 
 val lib_ocaml : string
 

--- a/jscomp/bsb/bsb_spec_set.ml
+++ b/jscomp/bsb/bsb_spec_set.ml
@@ -25,7 +25,7 @@
 [@@@warning "+9"]
 
 (* TODO: sync up with {!Js_packages_info.module_system}  *)
-type format = Ext_module_system.t = NodeJS | Es6 | Es6_global
+type format = Ext_module_system.t
 
 type spec = { format : format; in_source : bool; suffix : string }
 

--- a/jscomp/build_tests/cycle1/rescript.json
+++ b/jscomp/build_tests/cycle1/rescript.json
@@ -7,7 +7,7 @@
     "subdirs": true
   },
   "package-specs": {
-    "module": "es6",
+    "module": "esmodule",
     "in-source": true
   },
   "suffix": ".bs.js"

--- a/jscomp/build_tests/deprecated-package-specs/input.js
+++ b/jscomp/build_tests/deprecated-package-specs/input.js
@@ -1,0 +1,9 @@
+const child_process = require("child_process");
+const assert = require("assert");
+const rescript_exe = require("../../../scripts/bin_path").rescript_exe;
+
+const out = child_process.spawnSync(rescript_exe, { encoding: "utf8" });
+assert.match(
+  out.stderr,
+  /deprecated: Option "es6-global" is deprecated\. Use "esmodule" instead\./
+);

--- a/jscomp/build_tests/deprecated-package-specs/rescript.json
+++ b/jscomp/build_tests/deprecated-package-specs/rescript.json
@@ -1,0 +1,8 @@
+{
+  "name": "deprecated-package-specs",
+  "version": "0.1.0",
+  "sources": "src",
+  "package-specs": {
+    "module": "es6-global"
+  }
+}

--- a/jscomp/build_tests/deprecated-package-specs/src/Index.res
+++ b/jscomp/build_tests/deprecated-package-specs/src/Index.res
@@ -1,0 +1,1 @@
+let () = Js.log("Hello, ReScript")

--- a/jscomp/build_tests/in_source/rescript.json
+++ b/jscomp/build_tests/in_source/rescript.json
@@ -7,7 +7,7 @@
       "in-source": true
     },
     {
-      "module": "es6",
+      "module": "esmodule",
       "in-source": true
     }
   ]

--- a/jscomp/core/dune
+++ b/jscomp/core/dune
@@ -6,4 +6,4 @@
    (run %{bin:cppo} %{env:CPPO_FLAGS=} %{input-file})))
  (flags
   (:standard -w +a-4-9-27-30-40-41-42-48-70))
- (libraries depends frontend gentype js_parser))
+ (libraries depends ext frontend gentype js_parser))

--- a/jscomp/core/js_dump_program.ml
+++ b/jscomp/core/js_dump_program.ml
@@ -79,7 +79,7 @@ let node_program ~output_dir f (x : J.deps_program) =
         | true -> None
         | false -> 
            Some ( x.id,
-             Js_name_of_module_id.string_of_module_id x ~output_dir NodeJS,
+             Js_name_of_module_id.string_of_module_id x ~output_dir Commonjs,
              is_default x.kind )))
   in
   program f cxt x.program
@@ -129,8 +129,8 @@ let pp_deps_program ~(output_prefix : string)
     let output_dir = Filename.dirname output_prefix in
     ignore
       (match kind with
-      | Es6 | Es6_global -> es6_program ~output_dir kind f program
-      | NodeJS -> node_program ~output_dir f program);
+      | Esmodule | Es6_global -> es6_program ~output_dir kind f program
+      | Commonjs -> node_program ~output_dir f program);
     P.newline f;
     P.string f
       (match program.side_effect with

--- a/jscomp/core/js_name_of_module_id.ml
+++ b/jscomp/core/js_name_of_module_id.ml
@@ -77,7 +77,7 @@ let get_runtime_module_path
         *)
     else  
       match module_system with 
-      | NodeJS | Es6 -> 
+      | Commonjs | Esmodule -> 
         Js_packages_info.runtime_package_path module_system js_file              
       (* Note we did a post-processing when working on Windows *)
       | Es6_global 
@@ -164,7 +164,7 @@ let string_of_module_id
             get_runtime_module_path dep_module_id current_package_info module_system
           else 
             begin match module_system with 
-              | NodeJS | Es6 -> 
+              | Commonjs | Esmodule -> 
                 dep_pkg.pkg_rel_path // js_file
               (* Note we did a post-processing when working on Windows *)
               | Es6_global 

--- a/jscomp/core/js_packages_info.mli
+++ b/jscomp/core/js_packages_info.mli
@@ -22,7 +22,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-type module_system = NodeJS | Es6 | Es6_global
+type module_system = Ext_module_system.t
 
 val runtime_dir_of_module_system : module_system -> string
 

--- a/jscomp/core/lam_compile_main.ml
+++ b/jscomp/core/lam_compile_main.ml
@@ -292,7 +292,7 @@ let lambda_as_module
   : unit = 
   let package_info = Js_packages_state.get_packages_info () in 
   if Js_packages_info.is_empty package_info && !Js_config.js_stdout then begin    
-    Js_dump_program.dump_deps_program ~output_prefix NodeJS (lambda_output) stdout
+    Js_dump_program.dump_deps_program ~output_prefix Commonjs (lambda_output) stdout
   end else
     Js_packages_info.iter package_info (fun {module_system; path; suffix} -> 
         let output_chan chan  = 

--- a/jscomp/core/lam_compile_primitive.ml
+++ b/jscomp/core/lam_compile_primitive.ml
@@ -44,12 +44,12 @@ let get_module_system () =
     let package_info = Js_packages_state.get_packages_info () in
     let module_system =
         if Js_packages_info.is_empty package_info && !Js_config.js_stdout then
-            [Js_packages_info.NodeJS]
+            [Ext_module_system.Commonjs]
         else Js_packages_info.map package_info (fun {module_system} -> module_system)
     in
     match module_system with
     | [module_system] -> module_system
-    | _ -> NodeJS
+    | _ -> Commonjs
 
 let import_of_path path =
   E.call

--- a/jscomp/ext/ext_module_system.ml
+++ b/jscomp/ext/ext_module_system.ml
@@ -1,1 +1,1 @@
-type t = NodeJS | Es6 | Es6_global
+type t =  Commonjs | Esmodule | Es6_global

--- a/jscomp/ext/literals.ml
+++ b/jscomp/ext/literals.ml
@@ -125,11 +125,15 @@ let suffix_gen_js = ".gen.js"
 
 let suffix_gen_tsx = ".gen.tsx"
 
+let esmodule = "esmodule"
+
 let commonjs = "commonjs"
 
 let es6 = "es6"
+[@@ocaml.deprecated "Will be removed in v12"]
 
 let es6_global = "es6-global"
+[@@ocaml.deprecated "Will be removed in v12"]
 
 let unused_attribute = "Unused attribute "
 

--- a/jscomp/gentype/EmitType.ml
+++ b/jscomp/gentype/EmitType.ml
@@ -382,7 +382,7 @@ let emitRequire ~importedValueOrComponent ~early ~emitters ~(config : Config.t)
   let importPathString = ImportPath.emit importPath in
   let output =
     match config.module_ with
-    | ES6 when not importedValueOrComponent ->
+    | ESModule when not importedValueOrComponent ->
       "import * as " ^ moduleNameString ^ " from '" ^ importPathString ^ "';"
     | _ ->
       "const " ^ moduleNameString ^ " = require('" ^ importPathString ^ "');"

--- a/jscomp/gentype/GenTypeConfig.ml
+++ b/jscomp/gentype/GenTypeConfig.ml
@@ -1,6 +1,6 @@
 module ModuleNameMap = Map.Make (ModuleName)
 
-type module_ = CommonJS | ES6
+type module_ = CommonJS | ESModule
 
 (** Compatibility for `compilerOptions.moduleResolution` in TypeScript projects. *)
 type moduleResolution =
@@ -41,7 +41,7 @@ let default =
     everything = false;
     exportInterfaces = false;
     generatedFileExtension = None;
-    module_ = ES6;
+    module_ = ESModule;
     moduleResolution = Node;
     namespace = None;
     platformLib = "";
@@ -53,7 +53,7 @@ let default =
 
 let bsPlatformLib ~config =
   match config.module_ with
-  | ES6 -> config.platformLib ^ "/lib/es6"
+  | ESModule -> config.platformLib ^ "/lib/es6"
   | CommonJS -> config.platformLib ^ "/lib/js"
 
 let getBsCurryPath ~config = Filename.concat (bsPlatformLib ~config) "curry.js"
@@ -154,9 +154,9 @@ let readConfig ~getConfigFile ~namespace =
       (* Give priority to gentypeconfig, followed by package-specs *)
       match (moduleString, packageSpecsModuleString) with
       | Some "commonjs", _ -> CommonJS
-      | Some "es6", _ -> ES6
+      | Some ("esmodule" | "es6"), _ -> ESModule
       | None, Some "commonjs" -> CommonJS
-      | None, Some ("es6" | "es6-global") -> ES6
+      | None, Some ("esmodule" | "es6" | "es6-global") -> ESModule
       | _ -> default.module_
     in
     let moduleResolution =

--- a/jscomp/gentype_tests/typescript-react-example/rescript.json
+++ b/jscomp/gentype_tests/typescript-react-example/rescript.json
@@ -1,7 +1,7 @@
 {
   "gentypeconfig": {
     "language": "typescript",
-    "module": "es6",
+    "module": "esmodule",
     "importPath": "relative",
     "shims": {
       "Js": "Js",
@@ -26,7 +26,7 @@
   ],
   "uncurried": false,
   "package-specs": {
-    "module": "es6",
+    "module": "esmodule",
     "in-source": true
   },
   "suffix": ".res.js"

--- a/jscomp/jsoo/jsoo_playground_main.ml
+++ b/jscomp/jsoo/jsoo_playground_main.ml
@@ -74,7 +74,7 @@ end
 
 module BundleConfig = struct
   type t = {
-    mutable module_system: Js_packages_info.module_system;
+    mutable module_system: Ext_module_system.t;
     mutable filename: string option;
     mutable warn_flags: string;
     mutable open_modules: string list;
@@ -86,7 +86,7 @@ module BundleConfig = struct
   }
 
   let make () = {
-    module_system=Js_packages_info.NodeJS;
+    module_system=Ext_module_system.Commonjs;
     filename=None;
     warn_flags=Bsc_warnings.defaults_w;
     open_modules=[];
@@ -97,8 +97,8 @@ module BundleConfig = struct
   let default_filename (lang: Lang.t) = "playground." ^ (Lang.toString lang)
 
   let string_of_module_system m = (match m with
-    | Js_packages_info.NodeJS -> "nodejs"
-    | Es6 -> "es6"
+    | Ext_module_system.Commonjs -> "nodejs"
+    | Esmodule -> "es6"
     | Es6_global -> "es6_global")
 end
 
@@ -608,10 +608,10 @@ module Export = struct
     let config = BundleConfig.make () in
     let set_module_system value =
       match value with
-      | "es6" ->
-        config.module_system <- Js_packages_info.Es6; true
-      | "nodejs" ->
-        config.module_system <- NodeJS; true
+      | "esmodule" | "es6" ->
+        config.module_system <- Ext_module_system.Esmodule; true
+      | "commonjs" | "nodejs" ->
+        config.module_system <- Commonjs; true
       | _ -> false in
     let set_filename value =
       config.filename <- Some value; true

--- a/packages/playground-bundling/rescript.json
+++ b/packages/playground-bundling/rescript.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "bs-dependencies": ["@rescript/react", "@rescript/core"],
   "package-specs": {
-    "module": "es6",
+    "module": "esmodule",
     "in-source": false
   },
   "sources": {

--- a/packages/playground-bundling/scripts/generate_cmijs.js
+++ b/packages/playground-bundling/scripts/generate_cmijs.js
@@ -6,7 +6,7 @@
  * rescript version as the compiler bundle.
  *
  * This script extracts all cmi / cmj files of the rescript/lib/ocaml and all
- * dependencies listed in the project root's bsconfig.json, creates cmij.js
+ * dependencies listed in the project root's rescript.json, creates cmij.js
  * files for each library and puts them in the compiler playground directory.
  *
  * The cmij files are representing the marshaled dependencies that can be used with the ReScript
@@ -17,7 +17,7 @@ const child_process = require("child_process");
 const fs = require("fs");
 const path = require("path");
 
-const bsconfig = require("../bsconfig.json");
+const resConfig = require("../rescript.json");
 
 const RESCRIPT_COMPILER_ROOT_DIR = path.join(__dirname, "..", "..", "..");
 const PLAYGROUND_DIR = path.join(RESCRIPT_COMPILER_ROOT_DIR, "playground");
@@ -51,7 +51,7 @@ e(`npm link ${RESCRIPT_COMPILER_ROOT_DIR}`);
 e(`npx rescript clean`);
 e(`npx rescript`);
 
-const packages = bsconfig["bs-dependencies"];
+const packages = resConfig["bs-dependencies"];
 
 // We need to build the compiler's builtin modules as a separate cmij.
 // Otherwise we can't use them for compilation within the playground.

--- a/packages/test/rescript.json
+++ b/packages/test/rescript.json
@@ -8,7 +8,7 @@
   ],
   "package-specs": [
     {
-      "module": "es6",
+      "module": "esmodule",
       "in-source": true
     }
   ],


### PR DESCRIPTION
In v11.x, we only print a deprecation warning for `"es6"` and `"es6"` usage and notice to use `"esmodule"`

In v12
- Remove `"es6"` and "es6-global" completely, and redirect related output paths (`lib/js` to `lib/cjs`, `lib/es6` to `lib/mjs` or we can just merge it into single `lib/js`)
- `"esmodule"`, the standard format will be the default output format.
- Additional option to emit an [importmap](https://github.com/WICG/import-maps) so provide better alternative to the legacy `"es6-global"`