### PR TITLE
Improve error when using '@deriving(accessors)` on a variant with a record arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 # 11.1.0-rc.8 (Unreleased)
 
+#### :bug: Bug Fix
+
+- Improve error when using '@deriving(accessors)' on a variant with record arguments. https://github.com/rescript-lang/rescript-compiler/pull/6712
+
 # 11.1.0-rc.7
 
 #### :bug: Bug Fix

--- a/jscomp/build_tests/super_errors/expected/DerivingAccessorsRecordParam.res.expected
+++ b/jscomp/build_tests/super_errors/expected/DerivingAccessorsRecordParam.res.expected
@@ -1,0 +1,9 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/DerivingAccessorsRecordParam.res[0m:[2m2:10-25[0m
+
+  1 [2m│[0m @deriving(accessors)
+  [1;31m2[0m [2m│[0m type t = [1;31mStruct({a: int})[0m
+  3 [2m│[0m 
+
+  @deriving(accessors) from a variant record argument is unsupported. Either define the record type separately from the variant type or use a positional argument.

--- a/jscomp/build_tests/super_errors/fixtures/DerivingAccessorsRecordParam.res
+++ b/jscomp/build_tests/super_errors/fixtures/DerivingAccessorsRecordParam.res
@@ -1,0 +1,2 @@
+@deriving(accessors)
+type t = Struct({a: int})

--- a/jscomp/frontend/ast_derive_projector.ml
+++ b/jscomp/frontend/ast_derive_projector.ml
@@ -55,7 +55,7 @@ let init () =
                     {
                       pcd_name = {loc; txt = con_name};
                       pcd_args;
-                      pcd_loc = _;
+                      pcd_loc;
                       pcd_res;
                     }
                   ->
@@ -63,7 +63,12 @@ let init () =
                     let pcd_args =
                       match pcd_args with
                       | Pcstr_tuple pcd_args -> pcd_args
-                      | Pcstr_record _ -> assert false
+                      | Pcstr_record _ ->
+                        Location.raise_errorf ~loc:pcd_loc
+                          "@deriving(accessors) from a variant record argument \
+                           is unsupported. Either define the record type \
+                           separately from the variant type or use a \
+                           positional argument."
                     in
                     let little_con_name =
                       Ext_string.uncapitalize_ascii con_name
@@ -146,14 +151,19 @@ let init () =
                     {
                       pcd_name = {loc; txt = con_name};
                       pcd_args;
-                      pcd_loc = _;
+                      pcd_loc;
                       pcd_res;
                     }
                   ->
                     let pcd_args =
                       match pcd_args with
                       | Pcstr_tuple pcd_args -> pcd_args
-                      | Pcstr_record _ -> assert false
+                      | Pcstr_record _ ->
+                        Location.raise_errorf ~loc:pcd_loc
+                          "@deriving(accessors) from a variant record argument \
+                           is unsupported. Either define the record type \
+                           separately from the variant type or use a \
+                           positional argument."
                     in
                     let arity = pcd_args |> List.length in
                     let annotate_type =

--- a/jscomp/frontend/ast_derive_projector.ml
+++ b/jscomp/frontend/ast_derive_projector.ml
@@ -4,6 +4,12 @@ let invalid_config (config : Parsetree.expression) =
   Location.raise_errorf ~loc:config.pexp_loc
     "such configuration is not supported"
 
+let raise_unsupported_vaiant_record_arg loc =
+  Location.raise_errorf ~loc
+    "@deriving(accessors) from a variant record argument is unsupported. \
+     Either define the record type separately from the variant type or use a \
+     positional argument."
+
 type tdcls = Parsetree.type_declaration list
 
 let derivingName = "accessors"
@@ -64,11 +70,7 @@ let init () =
                       match pcd_args with
                       | Pcstr_tuple pcd_args -> pcd_args
                       | Pcstr_record _ ->
-                        Location.raise_errorf ~loc:pcd_loc
-                          "@deriving(accessors) from a variant record argument \
-                           is unsupported. Either define the record type \
-                           separately from the variant type or use a \
-                           positional argument."
+                        raise_unsupported_vaiant_record_arg pcd_loc
                     in
                     let little_con_name =
                       Ext_string.uncapitalize_ascii con_name
@@ -159,11 +161,7 @@ let init () =
                       match pcd_args with
                       | Pcstr_tuple pcd_args -> pcd_args
                       | Pcstr_record _ ->
-                        Location.raise_errorf ~loc:pcd_loc
-                          "@deriving(accessors) from a variant record argument \
-                           is unsupported. Either define the record type \
-                           separately from the variant type or use a \
-                           positional argument."
+                        raise_unsupported_vaiant_record_arg pcd_loc
                     in
                     let arity = pcd_args |> List.length in
                     let annotate_type =


### PR DESCRIPTION
Closes #6704 

Previously

```res
@deriving(accessors)
type t = Struct({a: int})
```
would error with:

```
Fatal error: exception File "jscomp/frontend/ast_derive_projector.ml", line 57, characters 42-48: Assertion failed
```

now we get:
```
  We've found a bug for you!
  /.../fixtures/DerivingAccessorsRecordParam.res:2:10-25
                                                                                                               
  1 │ @deriving(accessors)
  2 │ type t = Struct({a: int})
  3 │
                                                                                                               
  @deriving(accessors) from a variant record argument is unsupported. Either define the record type separatelyfrom the variant type or use a positional argument.
```
