### PR TITLE
%todo extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 # 11.1.0-rc.8 (Unreleased)
 
+#### :rocket: New Feature
+
+- Add `%todo` extension for leaving implementation for later. https://github.com/rescript-lang/rescript-compiler/pull/6713
+
 #### :bug: Bug Fix
 
 - Improve error when using '@deriving(accessors)' on a variant with record arguments. https://github.com/rescript-lang/rescript-compiler/pull/6712

--- a/jscomp/build_tests/super_errors/expected/todo_with_no_payload.res.expected
+++ b/jscomp/build_tests/super_errors/expected/todo_with_no_payload.res.expected
@@ -8,4 +8,4 @@
 
   Todo found.
 
-  This code will crash if it's run. Be sure to finish it before running your program.
+  This code is not implemented yet and will crash at runtime. Make sure you implement this before running the code.

--- a/jscomp/build_tests/super_errors/expected/todo_with_no_payload.res.expected
+++ b/jscomp/build_tests/super_errors/expected/todo_with_no_payload.res.expected
@@ -1,0 +1,11 @@
+
+  [1;33mWarning number 110[0m
+  [36m/.../fixtures/todo_with_no_payload.res[0m:[2m1:38-42[0m
+
+  [1;33m1[0m [2m│[0m let implementMeLater = (): string => [1;33m%todo[0m
+  2 [2m│[0m 
+  3 [2m│[0m let x = implementMeLater()
+
+  Todo found.
+
+This code will crash if it's run. Be sure to finish it before running your program.

--- a/jscomp/build_tests/super_errors/expected/todo_with_no_payload.res.expected
+++ b/jscomp/build_tests/super_errors/expected/todo_with_no_payload.res.expected
@@ -8,4 +8,4 @@
 
   Todo found.
 
-This code will crash if it's run. Be sure to finish it before running your program.
+  This code will crash if it's run. Be sure to finish it before running your program.

--- a/jscomp/build_tests/super_errors/expected/todo_with_payload.res.expected
+++ b/jscomp/build_tests/super_errors/expected/todo_with_payload.res.expected
@@ -9,4 +9,4 @@
 
   Todo found: This should return a string eventually.
 
-  This code will crash if it's run. Be sure to finish it before running your program.
+  This code is not implemented yet and will crash at runtime. Make sure you implement this before running the code.

--- a/jscomp/build_tests/super_errors/expected/todo_with_payload.res.expected
+++ b/jscomp/build_tests/super_errors/expected/todo_with_payload.res.expected
@@ -9,4 +9,4 @@
 
   Todo found: This should return a string eventually.
 
-This code will crash if it's run. Be sure to finish it before running your program.
+  This code will crash if it's run. Be sure to finish it before running your program.

--- a/jscomp/build_tests/super_errors/expected/todo_with_payload.res.expected
+++ b/jscomp/build_tests/super_errors/expected/todo_with_payload.res.expected
@@ -1,0 +1,12 @@
+
+  [1;33mWarning number 110[0m
+  [36m/.../fixtures/todo_with_payload.res[0m:[2m1:38-85[0m
+
+  [1;33m1[0m [2m│[0m let implementMeLater = (): string => [1;33m%todo("This should return a string [0m
+    [2m│[0m [1;33meventually.")[0m
+  2 [2m│[0m 
+  3 [2m│[0m let x = implementMeLater()
+
+  Todo found: This should return a string eventually.
+
+This code will crash if it's run. Be sure to finish it before running your program.

--- a/jscomp/build_tests/super_errors/fixtures/todo_with_no_payload.res
+++ b/jscomp/build_tests/super_errors/fixtures/todo_with_no_payload.res
@@ -1,0 +1,5 @@
+let implementMeLater = (): string => %todo
+
+let x = implementMeLater()
+
+Js.log(x->Js.String2.includes("x"))

--- a/jscomp/build_tests/super_errors/fixtures/todo_with_payload.res
+++ b/jscomp/build_tests/super_errors/fixtures/todo_with_payload.res
@@ -1,0 +1,5 @@
+let implementMeLater = (): string => %todo("This should return a string eventually.")
+
+let x = implementMeLater()
+
+Js.log(x->Js.String2.includes("x"))

--- a/jscomp/ext/warnings.ml
+++ b/jscomp/ext/warnings.ml
@@ -515,7 +515,7 @@ let message = function
       match maybe_text with 
       | None -> "Todo found." 
       | Some todo -> "Todo found: " ^ todo
-    ) ^ "\n\n  This code will crash if it's run. Be sure to finish it before running your program."
+    ) ^ "\n\n  This code is not implemented yet and will crash at runtime. Make sure you implement this before running the code."
 
 let sub_locs = function
   | Deprecated (_, def, use) ->

--- a/jscomp/ext/warnings.ml
+++ b/jscomp/ext/warnings.ml
@@ -515,7 +515,7 @@ let message = function
       match maybe_text with 
       | None -> "Todo found." 
       | Some todo -> "Todo found: " ^ todo
-    ) ^ "\n\nThis code will crash if it's run. Be sure to finish it before running your program."
+    ) ^ "\n\n  This code will crash if it's run. Be sure to finish it before running your program."
 
 let sub_locs = function
   | Deprecated (_, def, use) ->

--- a/jscomp/ext/warnings.ml
+++ b/jscomp/ext/warnings.ml
@@ -86,6 +86,7 @@ type t =
   | Bs_integer_literal_overflow (* 107 *)
   | Bs_uninterpreted_delimiters of string (* 108 *)
   | Bs_toplevel_expression_unit of (string * topLevelUnitHelp) option (* 109 *)
+  | Bs_todo of string option (* 110 *)
 
 (* If you remove a warning, leave a hole in the numbering.  NEVER change
    the numbers of existing warnings.
@@ -151,6 +152,7 @@ let number = function
   | Bs_integer_literal_overflow -> 107
   | Bs_uninterpreted_delimiters _ -> 108
   | Bs_toplevel_expression_unit _ -> 109
+  | Bs_todo _ -> 110
 
 let last_warning_number = 110
 
@@ -509,6 +511,11 @@ let message = function
           | Other -> "yourExpression") in
           Printf.sprintf "\n\n  Possible solutions:\n  - Assigning to a value that is then ignored: `let _ = %s`\n  - Piping into the built-in ignore function to ignore the result: `%s->ignore`" helpText helpText
         | _ -> "") 
+    | Bs_todo maybe_text -> (
+      match maybe_text with 
+      | None -> "Todo found." 
+      | Some todo -> "Todo found: " ^ todo
+    ) ^ "\n\nThis code will crash if it's run. Be sure to finish it before running your program."
 
 let sub_locs = function
   | Deprecated (_, def, use) ->

--- a/jscomp/ext/warnings.mli
+++ b/jscomp/ext/warnings.mli
@@ -79,6 +79,7 @@ type t =
   | Bs_integer_literal_overflow (* 107 *)
   | Bs_uninterpreted_delimiters of string (* 108 *)
   | Bs_toplevel_expression_unit of (string * topLevelUnitHelp) option (* 109 *)
+  | Bs_todo of string option (* 110 *)
 
 val parse_options : bool -> string -> unit
 

--- a/jscomp/frontend/ast_exp_extension.ml
+++ b/jscomp/frontend/ast_exp_extension.ml
@@ -33,15 +33,26 @@ let handle_extension e (self : Bs_ast_mapper.mapper)
       | None -> None
     in
     Location.prerr_warning e.Parsetree.pexp_loc (Bs_todo todo_message);
+    let pretext =
+      loc.loc_start.pos_fname ^ ":"
+      ^ string_of_int loc.loc_start.pos_lnum
+      ^ ":"
+      ^ string_of_int loc.loc_start.pos_cnum
+      ^ "-"
+      ^ string_of_int loc.loc_end.pos_cnum
+    in
+
     Exp.apply ~loc
-      (Exp.ident ~loc {txt = Longident.parse "failwith"; loc})
+      (Exp.ident ~loc {txt = Longident.parse "Js.Exn.raiseError"; loc})
       [
         ( Nolabel,
           Exp.constant ~loc
             (Pconst_string
-               ( (match todo_message with
-                 | None -> "todo"
-                 | Some msg -> msg),
+               ( (pretext
+                 ^
+                 match todo_message with
+                 | None -> " - Todo"
+                 | Some msg -> " - Todo: " ^ msg),
                  None )) );
       ]
   | "ffi" -> Ast_exp_handle_external.handle_ffi ~loc ~payload

--- a/jscomp/frontend/ast_exp_extension.ml
+++ b/jscomp/frontend/ast_exp_extension.ml
@@ -26,6 +26,15 @@ open Ast_helper
 let handle_extension e (self : Bs_ast_mapper.mapper)
     (({txt; loc}, payload) : Parsetree.extension) =
   match txt with
+  | "todo" ->
+    Location.prerr_warning e.Parsetree.pexp_loc
+      (Bs_todo
+         (match Ast_payload.is_single_string payload with
+         | Some (s, _) -> Some s
+         | None -> None));
+    Exp.apply ~loc
+      (Exp.ident ~loc {txt = Longident.parse "Obj.magic"; loc})
+      [(Nolabel, Exp.construct ~loc {txt = Longident.Lident "()"; loc} None)]
   | "ffi" -> Ast_exp_handle_external.handle_ffi ~loc ~payload
   | "bs.raw" | "raw" ->
     Ast_exp_handle_external.handle_raw ~kind:Raw_exp loc payload

--- a/jscomp/frontend/ast_exp_extension.ml
+++ b/jscomp/frontend/ast_exp_extension.ml
@@ -27,14 +27,23 @@ let handle_extension e (self : Bs_ast_mapper.mapper)
     (({txt; loc}, payload) : Parsetree.extension) =
   match txt with
   | "todo" ->
-    Location.prerr_warning e.Parsetree.pexp_loc
-      (Bs_todo
-         (match Ast_payload.is_single_string payload with
-         | Some (s, _) -> Some s
-         | None -> None));
+    let todo_message =
+      match Ast_payload.is_single_string payload with
+      | Some (s, _) -> Some s
+      | None -> None
+    in
+    Location.prerr_warning e.Parsetree.pexp_loc (Bs_todo todo_message);
     Exp.apply ~loc
-      (Exp.ident ~loc {txt = Longident.parse "Obj.magic"; loc})
-      [(Nolabel, Exp.construct ~loc {txt = Longident.Lident "()"; loc} None)]
+      (Exp.ident ~loc {txt = Longident.parse "failwith"; loc})
+      [
+        ( Nolabel,
+          Exp.constant ~loc
+            (Pconst_string
+               ( (match todo_message with
+                 | None -> "todo"
+                 | Some msg -> msg),
+                 None )) );
+      ]
   | "ffi" -> Ast_exp_handle_external.handle_ffi ~loc ~payload
   | "bs.raw" | "raw" ->
     Ast_exp_handle_external.handle_raw ~kind:Raw_exp loc payload


### PR DESCRIPTION
This adds a `%todo` extension, for which the compiler will warn (but not fail) when encountered:

```rescript
let implementMeLater = (): string => %todo("This should return a string eventually.")

let x = implementMeLater()

Js.log(x->Js.String2.includes("x"))
```

Gives:
![image](https://github.com/rescript-lang/rescript-compiler/assets/1457626/fe863b18-08a4-4641-a9a3-868649e65ea2)(I've shamelessly taken the warning text from a screenshot of the same functionality in Gleam. We should change that if we want to merge this)

And compiles to the following JS:
```javascript
// Generated by ReScript, PLEASE EDIT WITH CARE
'use strict';

var Js_exn = require("rescript/lib/js/js_exn.js");

function implementMeLater(param) {
  return Js_exn.raiseError("tst.res:1:37-42 - Todo: This should return a string eventually.");
}

var x = Js_exn.raiseError("tst.res:1:37-42 - Todo: This should return a string eventually.");

console.log(x.includes("x"));

exports.implementMeLater = implementMeLater;
exports.x = x;
/* x Not a pure module */
```

`%todo` doesn't need to have a payload string unless you want it to:
![image](https://github.com/rescript-lang/rescript-compiler/assets/1457626/a7e4e211-ae3e-4a8a-a431-ea2047889957)

```javascript
// Generated by ReScript, PLEASE EDIT WITH CARE
'use strict';

var Js_exn = require("rescript/lib/js/js_exn.js");

function implementMeLater(param) {
  return Js_exn.raiseError("tst.res:1:37-42 - Todo");
}

var x = Js_exn.raiseError("tst.res:1:37-42 - Todo");

console.log(x.includes("x"));

exports.implementMeLater = implementMeLater;
exports.x = x;
/* x Not a pure module */
```

Notice that the source ReScript file name + location is also included in the runtime error.

You can also easily run the compiler with this warning producing an error instead (as to make sure no `%todo` makes it into actual prod builds, or similar): `rescript -warn-error +110`

The `%todo` node itself is transformed into `Js.Exn.raiseError(todoMessage)`.