### PR TITLE
Revert escape hyphens in jsx prop names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 # 11.1.0-rc.9 (Unreleased)
 
+#### :bug: Bug Fix
+
+- revert escape JSX prop names with hyphens (#6705). https://github.com/rescript-lang/rescript-compiler/pull/6731.
+
 # 11.1.0-rc.8
 
 #### :rocket: New Feature

--- a/jscomp/syntax/src/res_printer.ml
+++ b/jscomp/syntax/src/res_printer.ml
@@ -4410,7 +4410,6 @@ and printJsxProps ~state args cmtTbl : Doc.t * Parsetree.expression option =
   loop [] args
 
 and printJsxProp ~state arg cmtTbl =
-  let printIdentLike ident = printIdentLike ~allowHyphen:true ident in
   match arg with
   | ( ((Asttypes.Labelled lblTxt | Optional lblTxt) as lbl),
       {

--- a/jscomp/syntax/tests/printer/expr/expected/exoticIdent.res.txt
+++ b/jscomp/syntax/tests/printer/expr/expected/exoticIdent.res.txt
@@ -62,7 +62,7 @@ lazy \"let"
 let x = 1
 
 let x =
-  <div aria-foo=\"type">
+  <div \"aria-foo"=\"type">
     \"module"
     \"let"
   </div>

--- a/jscomp/syntax/tests/printer/expr/expected/jsx.res.txt
+++ b/jscomp/syntax/tests/printer/expr/expected/jsx.res.txt
@@ -47,11 +47,6 @@ let x =
     {a}
     <B />
   </Foo.custom-tag>
-let x =
-  <custom-tag data-custom-state=true>
-    {a}
-    <B />
-  </custom-tag>
 
 let x = <div className="container" className2="container2" className3="container3" onClick />
 

--- a/jscomp/syntax/tests/printer/expr/jsx.res
+++ b/jscomp/syntax/tests/printer/expr/jsx.res
@@ -17,7 +17,6 @@ let x = <A> {a} </A>
 let x = <A> {a} {b} </A>
 let x = <custom-tag className="container" > {a} <B/> </custom-tag>
 let x = <Foo.custom-tag className="container" > {a} <B/> </Foo.custom-tag>
-let x = <custom-tag data-custom-state=true > {a} <B/> </custom-tag>
 
 let x =
   <div


### PR DESCRIPTION
This reverts commit 1ec144b4acd8ca54438a946bb6c666159f7afa7e. (#6705).

It created an issue #6723 that will be fixed by improving how we handle modes in the parser. We'll reintroduce #6705 when this lands.