### PR TITLE
Cleanup: Remove unused `stub`.

### DIFF
--- a/jscomp/ml/lambda.ml
+++ b/jscomp/ml/lambda.ml
@@ -320,7 +320,6 @@ type let_kind = Strict | Alias | StrictOpt | Variable
 type function_attribute = {
   inline : inline_attribute;
   is_a_functor: bool;
-  stub: bool;
   return_unit : bool;
   async : bool;
   directive : string option;
@@ -391,15 +390,11 @@ let lambda_unit = Lconst const_unit
 let default_function_attribute = {
   inline = Default_inline;
   is_a_functor = false;
-  stub = false;
   return_unit = false;
   async = false;
   oneUnitArg = false;
   directive = None;
 }
-
-let default_stub_attribute =
-  { default_function_attribute with stub = true }
 
 (* Build sharing keys *)
 (*

--- a/jscomp/ml/lambda.mli
+++ b/jscomp/ml/lambda.mli
@@ -290,7 +290,6 @@ type let_kind = Strict | Alias | StrictOpt | Variable
 type function_attribute = {
   inline : inline_attribute;
   is_a_functor: bool;
-  stub: bool;
   return_unit : bool;
   async : bool;
   directive : string option;
@@ -387,7 +386,6 @@ val commute_comparison : comparison -> comparison
 val negate_comparison : comparison -> comparison
 
 val default_function_attribute : function_attribute
-val default_stub_attribute : function_attribute
 
 (***********************)
 (* For static failures *)

--- a/jscomp/ml/printlambda.ml
+++ b/jscomp/ml/printlambda.ml
@@ -345,11 +345,9 @@ let name_of_primitive = function
   | Popaque -> "Popaque"
   | Pcreate_extension _ -> "Pcreate_extension"
 
-let function_attribute ppf { inline; is_a_functor; stub; return_unit } =
+let function_attribute ppf { inline; is_a_functor; return_unit } =
   if is_a_functor then
     fprintf ppf "is_a_functor@ ";
-  if stub then
-    fprintf ppf "stub@ ";
   if return_unit then 
     fprintf ppf "void@ ";  
   begin match inline with

--- a/jscomp/ml/translattribute.ml
+++ b/jscomp/ml/translattribute.ml
@@ -65,7 +65,7 @@ let get_inline_attribute l =
 let rec add_inline_attribute (expr : Lambda.lambda) loc attributes =
   match (expr, get_inline_attribute attributes) with
   | expr, Default_inline -> expr
-  | Lfunction ({ attr = { stub = false } as attr } as funct), inline ->
+  | Lfunction ({ attr } as funct), inline ->
       (match attr.inline with
       | Default_inline -> ()
       | Always_inline | Never_inline ->

--- a/jscomp/ml/translcore.ml
+++ b/jscomp/ml/translcore.ml
@@ -471,7 +471,7 @@ let transl_primitive loc p env ty =
           params = [ parm ];
           body = Matching.inline_lazy_force (Lvar parm) Location.none;
           loc;
-          attr = default_stub_attribute;
+          attr = default_function_attribute;
         }
   | Ploc kind -> (
       let lam = lam_of_loc kind loc in
@@ -483,7 +483,7 @@ let transl_primitive loc p env ty =
           Lfunction
             {
               params = [ param ];
-              attr = default_stub_attribute;
+              attr = default_function_attribute;
               loc;
               body = Lprim (Pmakeblock Blk_tuple, [ lam; Lvar param ], loc);
             }
@@ -505,7 +505,7 @@ let transl_primitive loc p env ty =
         Lfunction
           {
             params;
-            attr = default_stub_attribute;
+            attr = default_function_attribute;
             loc;
             body = Lprim (prim, List.map (fun id -> Lvar id) params, loc);
           }
@@ -1078,7 +1078,7 @@ and transl_apply ?(inlined = Default_inline) ?(uncurried_partial_application=Non
                 {
                   params = [ id_arg ];
                   body = lam;
-                  attr = default_stub_attribute;
+                  attr = default_function_attribute;
                   loc;
                 }
         in

--- a/jscomp/ml/translmod.ml
+++ b/jscomp/ml/translmod.ml
@@ -98,7 +98,6 @@ and apply_coercion_result loc strict funct params args cc_res =
                 {
                   Lambda.default_function_attribute with
                   is_a_functor = true;
-                  stub = true;
                 };
               loc;
               body =
@@ -274,7 +273,6 @@ let rec compile_functor mexp coercion root_path loc =
         {
           inline = inline_attribute;
           is_a_functor = true;
-          stub = false;
           return_unit = false;
           async = false;
           oneUnitArg = false;


### PR DESCRIPTION
Looking at the difference between `Fun of {...}` in `j.ml` and `type function_attribute` in `lambda.mli`, to see if it's worth using some shared sub-structure, noticed that this is unused.

If a shared sub-structure is used, then `function_attribute` can copied into `Fun of {...}` and replace the 3 fields:
```
      return_unit : bool;
      async : bool;
      directive : string option;
```
