### PR TITLE
Fix formatter eats comments on the first argument of a function

### DIFF
--- a/jscomp/syntax/src/res_comments_table.ml
+++ b/jscomp/syntax/src/res_comments_table.ml
@@ -1799,6 +1799,8 @@ and walkCoreType typ t comments =
     attach t.trailing typexpr.ptyp_loc afterTyp
   | Ptyp_variant (rowFields, _, _) ->
     walkList (rowFields |> List.map (fun rf -> RowField rf)) t comments
+  | Ptyp_constr ({txt = Lident "function$"}, [({ptyp_desc = Ptyp_arrow _}) as desc; _]) ->
+      walkCoreType desc t comments
   | Ptyp_constr (longident, typexprs) ->
     let beforeLongident, _afterLongident =
       partitionLeadingTrailing comments longident.loc


### PR DESCRIPTION
Fix https://github.com/rescript-lang/rescript-compiler/issues/6661