### PR TITLE
Enable Uncurried Mode by Default for Parser Development CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 #### :house: Internal
 
 - Build with OCaml 5.1.1. https://github.com/rescript-lang/rescript-compiler/pull/6641
+- Enable uncurried mode for parser dev cli https://github.com/rescript-lang/rescript-compiler/pull/6765
 
 #### :nail_care: Polish
 
@@ -70,7 +71,7 @@
 
 #### :bug: Bug Fix
 
-- Fix variance setting for builtin `dict` type. Fixes issues around inference. https://github.com/rescript-lang/rescript-compiler/pull/6707 
+- Fix variance setting for builtin `dict` type. Fixes issues around inference. https://github.com/rescript-lang/rescript-compiler/pull/6707
 
 # 11.1.0-rc.6
 

--- a/jscomp/syntax/cli/res_cli.ml
+++ b/jscomp/syntax/cli/res_cli.ml
@@ -220,6 +220,9 @@ end = struct
         Arg.Unit (fun () -> typechecker := true),
         "Parses the ast as it would be passed to the typechecker and not the \
          printer" );
+      ( "-legacy-curried",
+        Arg.Unit (fun () -> Config.uncurried := Legacy),
+        "Use legacy curried syntax" );
     ]
 
   let parse () = Arg.parse spec (fun f -> file := f) usage
@@ -310,6 +313,7 @@ end
 
 let () =
   if not !Sys.interactive then (
+    Config.uncurried := Uncurried;
     ResClflags.parse ();
     CliArgProcessor.processFile ~isInterface:!ResClflags.interface
       ~width:!ResClflags.width ~recover:!ResClflags.recover


### PR DESCRIPTION
When debugging the AST through the parser's development CLI, there is a discrepancy between calling `dune exec bsc` and `dune exec res_parser`. The former defaults to uncurried mode, while the latter does not.

This commit enables uncurried mode by default for the parser development CLI. If needed, this can be optionally disabled by using the `-legacy-curried` flag.