### PR TITLE
Fix formatter removed parens in uncurried function when used with this-callback

### DIFF
--- a/jscomp/syntax/src/res_printer.ml
+++ b/jscomp/syntax/src/res_printer.ml
@@ -2889,6 +2889,27 @@ and printExpression ~state (e : Parsetree.expression) cmtTbl =
               Doc.softLine;
               Doc.rparen;
             ]
+        | Some
+            ({
+               pexp_desc = Pexp_construct ({txt = Lident "Function$"}, Some expr);
+             } as arg) -> (
+          let doc = printExpressionWithComments ~state expr cmtTbl in
+          match arg.pexp_attributes with
+          | [] -> doc
+          | attrs ->
+            addParens
+              (Doc.concat
+                 [
+                   printAttributes ~state attrs cmtTbl;
+                   Doc.lparen;
+                   Doc.concat
+                     [
+                       Doc.indent (Doc.concat [Doc.softLine; doc]);
+                       Doc.trailingComma;
+                       Doc.softLine;
+                     ];
+                   Doc.rparen;
+                 ]))
         | Some arg ->
           let argDoc =
             let doc = printExpressionWithComments ~state arg cmtTbl in

--- a/jscomp/syntax/src/res_printer.ml
+++ b/jscomp/syntax/src/res_printer.ml
@@ -2646,21 +2646,24 @@ and printExpression ~state (e : Parsetree.expression) cmtTbl =
         ( Nolabel,
           None,
           {ppat_desc = Ppat_var {txt = "__x"}},
-          {pexp_desc = Pexp_apply _} )
+          {pexp_desc = Pexp_apply _} ) ->
+      printExpressionWithComments ~state
+        (ParsetreeViewer.rewriteUnderscoreApply e)
+        cmtTbl
     | Pexp_construct
         ( {txt = Lident "Function$"},
           Some
-            {
-              pexp_desc =
-                Pexp_fun
-                  ( Nolabel,
-                    None,
-                    {ppat_desc = Ppat_var {txt = "__x"}},
-                    {pexp_desc = Pexp_apply _} );
-            } ) ->
+            ({
+               pexp_desc =
+                 Pexp_fun
+                   ( Nolabel,
+                     None,
+                     {ppat_desc = Ppat_var {txt = "__x"}},
+                     {pexp_desc = Pexp_apply _} );
+             } as e_fun) ) ->
       (* (__x) => f(a, __x, c) -----> f(a, _, c)  *)
       printExpressionWithComments ~state
-        (ParsetreeViewer.rewriteUnderscoreApply e)
+        (ParsetreeViewer.rewriteUnderscoreApply e_fun)
         cmtTbl
     | Pexp_construct ({txt = Lident "Function$"}, Some expr) -> (
       let nonGhostAttrs =

--- a/jscomp/syntax/src/res_printer.ml
+++ b/jscomp/syntax/src/res_printer.ml
@@ -2635,36 +2635,16 @@ and printExpression ~state (e : Parsetree.expression) cmtTbl =
         Doc.concat [Doc.text ": "; typDoc]
       | _ -> Doc.nil
     in
-    let nonGhostAttrs =
-      List.filter
-        (fun (x, _) -> not x.Asttypes.loc.Location.loc_ghost)
-        attrs
+    let hasThisAttr =
+      List.exists (fun ({Asttypes.txt}, _) -> txt = "this") attrs
     in
     let attrs = printAttributes ~state attrs cmtTbl in
-    match nonGhostAttrs with
-    | [] 
-    | _  when not (ParsetreeViewer.hasAttributes nonGhostAttrs) ->
-      Doc.group
-        (Doc.concat
-           [
-             attrs;
-             parametersDoc;
-             typConstraintDoc;
-             Doc.text " =>";
-             returnExprDoc;
-           ])
-    | _ ->
-      Doc.group
-        (Doc.concat
-           [
-             attrs;
-             Doc.lparen;
-             parametersDoc;
-             typConstraintDoc;
-             Doc.text " =>";
-             returnExprDoc;
-             Doc.rparen;
-           ])
+    let doc =
+      Doc.concat
+        [parametersDoc; typConstraintDoc; Doc.text " =>"; returnExprDoc]
+    in
+    if hasThisAttr then Doc.group (Doc.concat [attrs; addParens doc])
+    else Doc.group (Doc.concat [attrs; doc])
   in
   let uncurried = Ast_uncurried.exprIsUncurriedFun e in
   let e_fun =

--- a/jscomp/syntax/tests/printer/other/attributes.res
+++ b/jscomp/syntax/tests/printer/other/attributes.res
@@ -24,3 +24,8 @@ let x = 1
 )
 let x = 1
 
+#b(@this (t => unit), @this ((x,t) => unit))
+
+#b(@this (t => unit))
+
+#b((t => unit))

--- a/jscomp/syntax/tests/printer/other/expected/attributes.res.txt
+++ b/jscomp/syntax/tests/printer/other/expected/attributes.res.txt
@@ -22,3 +22,9 @@ let x = 1
 
 @inlinePrivate(@module("./logo.svg") external logo: string = "default")
 let x = 1
+
+#b(@this (t => unit), @this ((x,t) => unit))
+
+#b(@this (t => unit))
+
+#b(t => unit)


### PR DESCRIPTION
Fix https://github.com/rescript-lang/rescript-compiler/issues/6638