### PR TITLE
Add dict literal syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 #### :rocket: New Feature
 
 - Allow coercing polyvariants to variants when we can guarantee that the runtime representation matches. https://github.com/rescript-lang/rescript-compiler/pull/6981
+- Add new dict literal syntax (`dict{"foo": "bar"}`). https://github.com/rescript-lang/rescript-compiler/pull/6774
 
 #### :nail_care: Polish
 

--- a/jscomp/syntax/src/res_comments_table.ml
+++ b/jscomp/syntax/src/res_comments_table.ml
@@ -1345,6 +1345,19 @@ and walk_expression expr t comments =
     walk_list
       [Expression parent_expr; Expression member_expr; Expression target_expr]
       t comments
+  | Pexp_apply
+      ( {
+          pexp_desc =
+            Pexp_ident
+              {
+                txt =
+                  Longident.Ldot
+                    (Longident.Ldot (Lident "Js", "Dict"), "fromArray");
+              };
+        },
+        [(Nolabel, key_values)] )
+    when Res_parsetree_viewer.is_tuple_array key_values ->
+    walk_list [Expression key_values] t comments
   | Pexp_apply (call_expr, arguments) ->
     let before, inside, after = partition_by_loc comments call_expr.pexp_loc in
     let after =

--- a/jscomp/syntax/src/res_core.ml
+++ b/jscomp/syntax/src/res_core.ml
@@ -3927,14 +3927,14 @@ and parse_dict_expr ~start_pos p =
       ~f:parse_dict_expr_row p
   in
   let loc = mk_loc start_pos p.prev_end_pos in
-  let to_key_value_pair record_item =
+  let to_key_value_pair
+      (record_item : Longident.t Location.loc * Parsetree.expression) =
     match record_item with
-    | {Location.txt = Longident.Lident key}, value_expr ->
+    | {Location.txt = Longident.Lident key; loc}, valueExpr ->
       Some
-        (Ast_helper.Exp.tuple ~loc
-           [
-             Ast_helper.Exp.constant ~loc (Pconst_string (key, None)); value_expr;
-           ])
+        (Ast_helper.Exp.tuple
+           ~loc:(mk_loc loc.loc_start valueExpr.pexp_loc.loc_end)
+           [Ast_helper.Exp.constant ~loc (Pconst_string (key, None)); valueExpr])
     | _ -> None
   in
   let key_value_pairs = List.filter_map to_key_value_pair exprs in

--- a/jscomp/syntax/src/res_core.ml
+++ b/jscomp/syntax/src/res_core.ml
@@ -222,6 +222,7 @@ let get_closing_token = function
   | Lbrace -> Rbrace
   | Lbracket -> Rbracket
   | List -> Rbrace
+  | Dict -> Rbrace
   | LessThan -> GreaterThan
   | _ -> assert false
 
@@ -233,7 +234,7 @@ let rec go_to_closing closing_token state =
   | GreaterThan, GreaterThan ->
     Parser.next state;
     ()
-  | ((Token.Lbracket | Lparen | Lbrace | List | LessThan) as t), _ ->
+  | ((Token.Lbracket | Lparen | Lbrace | List | Dict | LessThan) as t), _ ->
     Parser.next state;
     go_to_closing (get_closing_token t) state;
     go_to_closing closing_token state
@@ -1896,6 +1897,9 @@ and parse_atomic_expr p =
     | List ->
       Parser.next p;
       parse_list_expr ~start_pos p
+    | Dict ->
+      Parser.next p;
+      parse_dict_expr ~start_pos p
     | Module ->
       Parser.next p;
       parse_first_class_module_expr ~start_pos p
@@ -3122,6 +3126,20 @@ and parse_record_expr_row p =
     | _ -> None)
   | _ -> None
 
+and parse_dict_expr_row p =
+  match p.Parser.token with
+  | String s -> (
+    let loc = mk_loc p.start_pos p.end_pos in
+    Parser.next p;
+    let field = Location.mkloc (Longident.Lident s) loc in
+    match p.Parser.token with
+    | Colon ->
+      Parser.next p;
+      let fieldExpr = parse_expr p in
+      Some (field, fieldExpr)
+    | _ -> Some (field, Ast_helper.Exp.ident ~loc:field.loc field))
+  | _ -> None
+
 and parse_record_expr_with_string_keys ~start_pos first_row p =
   let rows =
     first_row
@@ -3902,6 +3920,32 @@ and parse_list_expr ~start_pos p =
                (Longident.Ldot (Longident.Lident "Belt", "List"), "concatMany"))
             loc))
       [(Asttypes.Nolabel, Ast_helper.Exp.array ~loc list_exprs)]
+
+and parse_dict_expr ~start_pos p =
+  let exprs =
+    parse_comma_delimited_region ~grammar:Grammar.DictRows ~closing:Rbrace
+      ~f:parse_dict_expr_row p
+  in
+  let loc = mk_loc start_pos p.prev_end_pos in
+  let to_key_value_pair record_item =
+    match record_item with
+    | {Location.txt = Longident.Lident key}, value_expr ->
+      Some
+        (Ast_helper.Exp.tuple ~loc
+           [
+             Ast_helper.Exp.constant ~loc (Pconst_string (key, None)); value_expr;
+           ])
+    | _ -> None
+  in
+  let key_value_pairs = List.filter_map to_key_value_pair exprs in
+  Parser.expect Rbrace p;
+  Ast_helper.Exp.apply ~loc
+    (Ast_helper.Exp.ident ~loc
+       (Location.mkloc
+          (Longident.Ldot
+             (Longident.Ldot (Longident.Lident "Js", "Dict"), "fromArray"))
+          loc))
+    [(Asttypes.Nolabel, Ast_helper.Exp.array ~loc key_value_pairs)]
 
 and parse_array_exp p =
   let start_pos = p.Parser.start_pos in

--- a/jscomp/syntax/src/res_grammar.ml
+++ b/jscomp/syntax/src/res_grammar.ml
@@ -138,7 +138,7 @@ let is_atomic_pattern_start = function
 let is_atomic_expr_start = function
   | Token.True | False | Int _ | String _ | Float _ | Codepoint _ | Backtick
   | Uident _ | Lident _ | Hash | Lparen | List | Lbracket | Lbrace | LessThan
-  | Module | Percent | Forwardslash | ForwardslashDot ->
+  | Module | Percent | Forwardslash | ForwardslashDot | Dict ->
     true
   | _ -> false
 
@@ -153,7 +153,7 @@ let is_expr_start = function
   | For | Hash | If | Int _ | Lbrace | Lbracket | LessThan | Lident _ | List
   | Lparen | Minus | MinusDot | Module | Percent | Plus | PlusDot | String _
   | Switch | True | Try | Uident _ | Underscore (* _ => doThings() *)
-  | While | Forwardslash | ForwardslashDot ->
+  | While | Forwardslash | ForwardslashDot | Dict ->
     true
   | _ -> false
 
@@ -266,7 +266,7 @@ let is_block_expr_start = function
   | False | Float _ | For | Forwardslash | ForwardslashDot | Hash | If | Int _
   | Lbrace | Lbracket | LessThan | Let | Lident _ | List | Lparen | Minus
   | MinusDot | Module | Open | Percent | Plus | PlusDot | String _ | Switch
-  | True | Try | Uident _ | Underscore | While ->
+  | True | Try | Uident _ | Underscore | While | Dict ->
     true
   | _ -> false
 

--- a/jscomp/syntax/src/res_grammar.ml
+++ b/jscomp/syntax/src/res_grammar.ml
@@ -59,6 +59,7 @@ type t =
   | Pattern
   | AttributePayload
   | TagNames
+  | DictRows
 
 let to_string = function
   | OpenDescription -> "an open description"
@@ -120,6 +121,7 @@ let to_string = function
   | ExprFor -> "a for expression"
   | AttributePayload -> "an attribute payload"
   | TagNames -> "tag names"
+  | DictRows -> "rows of a dict"
 
 let is_signature_item_start = function
   | Token.At | Let | Typ | External | Exception | Open | Include | Module | AtAt
@@ -219,6 +221,10 @@ let is_mod_expr_start = function
     true
   | _ -> false
 
+let is_dict_row_start = function
+  | Token.String _ -> true
+  | _ -> false
+
 let is_record_row_start = function
   | Token.DotDotDot -> true
   | Token.Uident _ | Lident _ -> true
@@ -278,6 +284,7 @@ let is_list_element grammar token =
   | FunctorArgs -> is_functor_arg_start token
   | ModExprList -> is_mod_expr_start token
   | TypeParameters -> is_type_parameter_start token
+  | DictRows -> is_dict_row_start token
   | RecordRows -> is_record_row_start token
   | RecordRowsStringKey -> is_record_row_string_key_start token
   | ArgumentList -> is_argument_start token

--- a/jscomp/syntax/src/res_parsetree_viewer.ml
+++ b/jscomp/syntax/src/res_parsetree_viewer.ml
@@ -743,3 +743,13 @@ let is_rewritten_underscore_apply_sugar expr =
   match expr.pexp_desc with
   | Pexp_ident {txt = Longident.Lident "_"} -> true
   | _ -> false
+
+let is_tuple_array (expr : Parsetree.expression) =
+  let is_plain_tuple (expr : Parsetree.expression) =
+    match expr with
+    | {pexp_desc = Pexp_tuple _} -> true
+    | _ -> false
+  in
+  match expr with
+  | {pexp_desc = Pexp_array items} -> List.for_all is_plain_tuple items
+  | _ -> false

--- a/jscomp/syntax/src/res_parsetree_viewer.mli
+++ b/jscomp/syntax/src/res_parsetree_viewer.mli
@@ -164,3 +164,5 @@ val has_if_let_attribute : Parsetree.attributes -> bool
 val is_rewritten_underscore_apply_sugar : Parsetree.expression -> bool
 
 val is_fun_newtype : Parsetree.expression -> bool
+
+val is_tuple_array : Parsetree.expression -> bool

--- a/jscomp/syntax/src/res_printer.ml
+++ b/jscomp/syntax/src/res_printer.ml
@@ -429,16 +429,6 @@ let is_valid_numeric_polyvar_number (x : string) =
          | _ -> false)
   else a >= 48
 
-let is_tuple_array (expr : Parsetree.expression) =
-  let is_plain_tuple (expr : Parsetree.expression) =
-    match expr with
-    | {pexp_desc = Pexp_tuple _} -> true
-    | _ -> false
-  in
-  match expr with
-  | {pexp_desc = Pexp_array items} -> List.for_all is_plain_tuple items
-  | _ -> false
-
 (* Exotic identifiers in poly-vars have a "lighter" syntax: #"ease-in" *)
 let print_poly_var_ident txt =
   (* numeric poly-vars don't need quotes: #644 *)
@@ -4091,7 +4081,7 @@ and print_pexp_apply ~state expr cmt_tbl =
               };
         },
         [(Nolabel, key_values)] )
-    when is_tuple_array key_values ->
+    when Res_parsetree_viewer.is_tuple_array key_values ->
     Doc.concat
       [
         Doc.text "dict{";

--- a/jscomp/syntax/src/res_printer.ml
+++ b/jscomp/syntax/src/res_printer.ml
@@ -1419,7 +1419,7 @@ and print_literal_dict_expr ~state (e : Parsetree.expression) cmt_tbl =
            {pexp_desc = Pexp_constant (Pconst_string (name, _)); pexp_loc}; value;
          ];
     } ->
-      Some (Location.mkloc (Longident.Lident name) pexp_loc, value)
+      Some ((Location.mkloc (Longident.Lident name) pexp_loc, value), e)
     | _ -> None
   in
   let rows =
@@ -1438,7 +1438,11 @@ and print_literal_dict_expr ~state (e : Parsetree.expression) cmt_tbl =
                 Doc.join
                   ~sep:(Doc.concat [Doc.text ","; Doc.line])
                   (List.map
-                     (fun row -> print_bs_object_row ~state row cmt_tbl)
+                     (fun ((row, e) :
+                            (Longident.t Location.loc * Parsetree.expression)
+                            * Parsetree.expression) ->
+                       let doc = print_bs_object_row ~state row cmt_tbl in
+                       print_comments doc cmt_tbl e.pexp_loc)
                      rows);
               ]);
          Doc.trailing_comma;

--- a/jscomp/syntax/src/res_scanner.ml
+++ b/jscomp/syntax/src/res_scanner.ml
@@ -196,11 +196,16 @@ let scan_identifier scanner =
     (String.sub [@doesNotRaise]) scanner.src start_off
       (scanner.offset - start_off)
   in
-  if '{' == scanner.ch && str = "list" then (
+  match (scanner, str) with
+  | {ch = '{'}, "list" ->
     next scanner;
     (* TODO: this isn't great *)
-    Token.lookup_keyword "list{")
-  else Token.lookup_keyword str
+    Token.lookup_keyword "list{"
+  | {ch = '{'}, "dict" ->
+    next scanner;
+    (* TODO: this isn't great *)
+    Token.lookup_keyword "dict{"
+  | _ -> Token.lookup_keyword str
 
 let scan_digits scanner ~base =
   if base <= 10 then

--- a/jscomp/syntax/src/res_token.ml
+++ b/jscomp/syntax/src/res_token.ml
@@ -89,6 +89,7 @@ type t =
   | PercentPercent
   | Comment of Comment.t
   | List
+  | Dict
   | TemplateTail of string * Lexing.position
   | TemplatePart of string * Lexing.position
   | Backtick
@@ -200,6 +201,7 @@ let to_string = function
   | PercentPercent -> "%%"
   | Comment c -> "Comment" ^ Comment.to_string c
   | List -> "list{"
+  | Dict -> "dict{"
   | TemplatePart (text, _) -> text ^ "${"
   | TemplateTail (text, _) -> "TemplateTail(" ^ text ^ ")"
   | Backtick -> "`"
@@ -224,6 +226,7 @@ let keyword_table = function
   | "include" -> Include
   | "let" -> Let
   | "list{" -> List
+  | "dict{" -> Dict
   | "module" -> Module
   | "mutable" -> Mutable
   | "of" -> Of
@@ -242,7 +245,7 @@ let keyword_table = function
 let is_keyword = function
   | Await | And | As | Assert | Constraint | Else | Exception | External | False
   | For | If | In | Include | Land | Let | List | Lor | Module | Mutable | Of
-  | Open | Private | Rec | Switch | True | Try | Typ | When | While ->
+  | Open | Private | Rec | Switch | True | Try | Typ | When | While | Dict ->
     true
   | _ -> false
 

--- a/jscomp/syntax/tests/parsing/grammar/expressions/dict.res
+++ b/jscomp/syntax/tests/parsing/grammar/expressions/dict.res
@@ -1,0 +1,11 @@
+// empty dict
+let x = dict{}
+
+// one value
+let x = dict{"foo": "bar"}
+
+// two values
+let x = dict{"foo": "bar", "bar": "baz"}
+
+let baz = "foo"
+let x = dict{"foo": "bar", "bar": "baz", "baz": baz}

--- a/jscomp/syntax/tests/parsing/grammar/expressions/expected/dict.res.txt
+++ b/jscomp/syntax/tests/parsing/grammar/expressions/expected/dict.res.txt
@@ -1,0 +1,7 @@
+let x = Js.Dict.fromArray [||]
+let x = Js.Dict.fromArray [|("foo", {js|bar|js})|]
+let x = Js.Dict.fromArray [|("foo", {js|bar|js});("bar", {js|baz|js})|]
+let baz = {js|foo|js}
+let x =
+  Js.Dict.fromArray
+    [|("foo", {js|bar|js});("bar", {js|baz|js});("baz", baz)|]

--- a/jscomp/syntax/tests/printer/expr/bsObj.res
+++ b/jscomp/syntax/tests/printer/expr/bsObj.res
@@ -56,3 +56,41 @@ React.jsx(
     {"data-foo": (\"data-foo": string)}
   }
 )
+
+// comments
+let x = {/* foo */ "foo": "bar"}
+let x = {"foo": /* foo */ "bar"}
+let x = {"foo": "bar" /* foo */ }
+
+let x = {
+	// foo
+	"foo": "bar",
+	// bar
+	"bar": "baz",
+	// baz
+	"baz": baz
+}
+
+let x = {
+	"foo": "bar", // foo
+	"bar": "baz", // bar
+	"baz": baz // baz
+}
+
+let x = {
+	"foo": /* foo */ "bar",
+	"bar": /* bar */ "baz",
+	"baz": /* bar */ baz
+}
+
+let x = {
+	/* foo */ "foo": "bar",
+	/* bar */ "bar": "baz",
+	/* bar */ "baz": baz
+}
+
+let x = {
+	"foo": "bar" /* foo */,
+	"bar": "baz" /* bar */,
+	"baz": baz /* bar */
+}

--- a/jscomp/syntax/tests/printer/expr/dict.res
+++ b/jscomp/syntax/tests/printer/expr/dict.res
@@ -1,0 +1,27 @@
+// empty dict
+let x = dict{}
+
+// one value
+let x = dict{"foo": "bar"}
+
+// two values
+let x = dict{"foo": "bar", "bar": "baz"}
+
+let baz = "foo"
+let x = dict{"foo": "bar", "bar": "baz", "baz": baz}
+
+// multiline
+let x = dict{
+	"foo": "bar",
+	"bar": "baz",
+	"baz": baz
+}
+
+let x = Js.Dict.fromArray([("foo", "bar"), ("bar", "baz")])
+let x = Js.Dict.fromArray([("foo", "bar"), ("bar", "baz"), ("baz", baz)])
+
+let x = Js.Dict.fromArray([
+	("foo", "bar"),
+	("bar", "baz"),
+	("baz", baz)
+])

--- a/jscomp/syntax/tests/printer/expr/dict.res
+++ b/jscomp/syntax/tests/printer/expr/dict.res
@@ -25,3 +25,61 @@ let x = Js.Dict.fromArray([
 	("bar", "baz"),
 	("baz", baz)
 ])
+
+// comments
+let x = dict{/* foo */ "foo": "bar"}
+let x = dict{"foo": /* foo */ "bar"}
+let x = dict{"foo": "bar" /* foo */ }
+
+let x = dict{
+	// foo
+	"foo": "bar",
+	// bar
+	"bar": "baz",
+	// baz
+	"baz": baz
+}
+
+let x = dict{
+	"foo": "bar", // foo
+	"bar": "baz", // bar
+	"baz": baz // baz
+}
+
+let x = dict{
+	"foo": /* foo */ "bar",
+	"bar": /* bar */ "baz",
+	"baz": /* bar */ baz
+}
+
+let x = dict{
+	/* foo */ "foo": "bar",
+	/* bar */ "bar": "baz",
+	/* bar */ "baz": baz
+}
+
+let x = dict{
+	"foo": "bar" /* foo */,
+	"bar": "baz" /* bar */,
+	"baz": baz /* bar */
+}
+
+let x = Js.Dict.fromArray([/* foo */ ("foo", "bar"), /* bar */ ("bar", "baz")])
+let x = Js.Dict.fromArray([(/* foo */ "foo", "bar"), (/* bar */"bar", "baz"), (/* baz */ "baz", baz)])
+let x = Js.Dict.fromArray([("foo", /* foo */"bar"), ("bar", /* bar */"baz"), ("baz", /* baz */baz)])
+let x = Js.Dict.fromArray([("foo", "bar" /* foo */), ("bar", "baz" /* bar */), ("baz", baz /* baz */)])
+
+let x = Js.Dict.fromArray([
+	// foo
+	("foo", "bar"),
+	// bar
+	("bar", "baz"),
+	// baz
+	("baz", baz)
+])
+
+let x = Js.Dict.fromArray([
+	("foo", "bar"), // foo
+	("bar", "baz"), // bar
+	("baz", baz) // baz
+])

--- a/jscomp/syntax/tests/printer/expr/expected/bsObj.res.txt
+++ b/jscomp/syntax/tests/printer/expr/expected/bsObj.res.txt
@@ -60,3 +60,41 @@ React.jsx(
     {"data-foo": (\"data-foo": string)}
   },
 )
+
+// comments
+let x = {/* foo */ "foo": "bar"}
+let x = {"foo": /* foo */ "bar"}
+let x = {"foo": "bar" /* foo */}
+
+let x = {
+  // foo
+  "foo": "bar",
+  // bar
+  "bar": "baz",
+  // baz
+  "baz": baz,
+}
+
+let x = {
+  "foo": "bar", // foo
+  "bar": "baz", // bar
+  "baz": baz, // baz
+}
+
+let x = {
+  "foo": /* foo */ "bar",
+  "bar": /* bar */ "baz",
+  "baz": /* bar */ baz,
+}
+
+let x = {
+  /* foo */ "foo": "bar",
+  /* bar */ "bar": "baz",
+  /* bar */ "baz": baz,
+}
+
+let x = {
+  "foo": "bar" /* foo */,
+  "bar": "baz" /* bar */,
+  "baz": baz /* bar */,
+}

--- a/jscomp/syntax/tests/printer/expr/expected/dict.res.txt
+++ b/jscomp/syntax/tests/printer/expr/expected/dict.res.txt
@@ -7,7 +7,6 @@ let x = dict{"foo": "bar"}
 // two values
 let x = dict{"foo": "bar", "bar": "baz"}
 
-// punning
 let baz = "foo"
 let x = dict{"foo": "bar", "bar": "baz", "baz": baz}
 

--- a/jscomp/syntax/tests/printer/expr/expected/dict.res.txt
+++ b/jscomp/syntax/tests/printer/expr/expected/dict.res.txt
@@ -1,0 +1,28 @@
+// empty dict
+let x = dict{}
+
+// one value
+let x = dict{"foo": "bar"}
+
+// two values
+let x = dict{"foo": "bar", "bar": "baz"}
+
+// punning
+let baz = "foo"
+let x = dict{"foo": "bar", "bar": "baz", "baz": baz}
+
+// multiline
+let x = dict{
+  "foo": "bar",
+  "bar": "baz",
+  "baz": baz,
+}
+
+let x = dict{"foo": "bar", "bar": "baz"}
+let x = dict{"foo": "bar", "bar": "baz", "baz": baz}
+
+let x = dict{
+  "foo": "bar",
+  "bar": "baz",
+  "baz": baz,
+}

--- a/jscomp/syntax/tests/printer/expr/expected/dict.res.txt
+++ b/jscomp/syntax/tests/printer/expr/expected/dict.res.txt
@@ -25,3 +25,61 @@ let x = dict{
   "bar": "baz",
   "baz": baz,
 }
+
+// comments
+let x = dict{/* foo */ "foo": "bar"}
+let x = dict{"foo": /* foo */ "bar"}
+let x = dict{"foo": "bar" /* foo */}
+
+let x = dict{
+  // foo
+  "foo": "bar",
+  // bar
+  "bar": "baz",
+  // baz
+  "baz": baz,
+}
+
+let x = dict{
+  "foo": "bar", // foo
+  "bar": "baz", // bar
+  "baz": baz, // baz
+}
+
+let x = dict{
+  "foo": /* foo */ "bar",
+  "bar": /* bar */ "baz",
+  "baz": /* bar */ baz,
+}
+
+let x = dict{
+  /* foo */ "foo": "bar",
+  /* bar */ "bar": "baz",
+  /* bar */ "baz": baz,
+}
+
+let x = dict{
+  "foo": "bar" /* foo */,
+  "bar": "baz" /* bar */,
+  "baz": baz /* bar */,
+}
+
+let x = dict{/* foo */ "foo": "bar", /* bar */ "bar": "baz"}
+let x = dict{/* foo */ "foo": "bar", /* bar */ "bar": "baz", /* baz */ "baz": baz}
+let x = dict{"foo": /* foo */ "bar", "bar": /* bar */ "baz", "baz": /* baz */ baz}
+let x = dict{"foo": "bar" /* foo */, "bar": "baz" /* bar */, "baz": baz /* baz */}
+
+let x = dict{
+  // foo
+  "foo": "bar",
+  // bar
+  "bar": "baz",
+  // baz
+  "baz": baz,
+}
+
+let x = dict{
+  "foo": "bar", // foo
+  "bar": "baz", // bar
+  "baz": baz, // baz
+}


### PR DESCRIPTION
This PR adds basic support for the `dict{}` literal syntax (https://github.com/rescript-lang/rescript-compiler/issues/6545).

## Parsing

Semantics within the braces are similar to the record with string keys (as dict keys can be any string).

It then turns `dict{"foo": "bar"}` into `Js.Dict.fromArray([("foo", "bar")])`. 

## Printing

Any `Js.Dict.fromArray` call that contains a literal array of tuples (with no spread) is now printed as `dict{...}`. 

I think this change is safe for the upcoming stdlib change (that'll move `Js.Dict` into `Dict`) as the change will be invisible once using this syntax. If that's something we don't want, we can add an attribute when parsing a `dict{}` expression so that we only print those back and leave `Js.Dict.fromArray` calls.