### PR TITLE
Do not try to check for unused @uncurry

### DIFF
--- a/jscomp/frontend/bs_ast_invariant.ml
+++ b/jscomp/frontend/bs_ast_invariant.ml
@@ -29,7 +29,7 @@
 let is_bs_attribute txt =
   match txt with
   (* TODO #6636: | "as "| "int" *)
-  | "bs" | "config" | "ignore" | "optional" | "string" | "uncurry" | "unwrap" ->
+  | "bs" | "config" | "ignore" | "optional" | "string" | "unwrap" ->
     true
   | _ -> false
 


### PR DESCRIPTION
This is giving me warnings when building @rescript/react, e.g.:

```
@module("react")
external useSyncExternalStoreWithServerSnapshot: (
  ~subscribe: @uncurry ((unit => unit) => (. unit) => unit),
  ~getSnapshot: @uncurry unit => 'state,
  ~getServerSnapshot: @uncurry unit => 'state,
) => 'state = "useSyncExternalStore"
```

As `@uncurry` will go away eventually anyway, just remove it from the list of attributes to check.