### PR TITLE
Fix location of let bindings with attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 #### :house: Internal
 
 - Convert OCaml codebase to snake case style. https://github.com/rescript-lang/rescript-compiler/pull/6702
+- Fix location of let bindings with attributes. https://github.com/rescript-lang/rescript-compiler/pull/6791
 
 #### :boom: Breaking Change
 

--- a/jscomp/syntax/src/res_core.ml
+++ b/jscomp/syntax/src/res_core.ml
@@ -2574,8 +2574,7 @@ and parse_attributes_and_binding (p : Parser.t) =
   | _ -> []
 
 (* definition	::=	let [rec] let-binding  { and let-binding }   *)
-and parse_let_bindings ~attrs p =
-  let start_pos = p.Parser.start_pos in
+and parse_let_bindings ~attrs ~start_pos p =
   Parser.optional p Let |> ignore;
   let rec_flag =
     if Parser.optional p Token.Rec then Asttypes.Recursive
@@ -3249,7 +3248,7 @@ and parse_expr_block_item p =
     let loc = mk_loc start_pos p.prev_end_pos in
     Ast_helper.Exp.open_ ~loc od.popen_override od.popen_lid block_expr
   | Let ->
-    let rec_flag, let_bindings = parse_let_bindings ~attrs p in
+    let rec_flag, let_bindings = parse_let_bindings ~attrs ~start_pos p in
     parse_newline_or_semicolon_expr_block p;
     let next =
       if Grammar.is_block_expr_start p.Parser.token then parse_expr_block p
@@ -5693,7 +5692,7 @@ and parse_structure_item_region p =
     let loc = mk_loc start_pos p.prev_end_pos in
     Some (Ast_helper.Str.open_ ~loc open_description)
   | Let ->
-    let rec_flag, let_bindings = parse_let_bindings ~attrs p in
+    let rec_flag, let_bindings = parse_let_bindings ~attrs ~start_pos p in
     parse_newline_or_semicolon_structure p;
     let loc = mk_loc start_pos p.prev_end_pos in
     Some (Ast_helper.Str.value ~loc rec_flag let_bindings)


### PR DESCRIPTION
The location of let bindings did not include annotations attached to the binding (for the first binding in a sequence).

This would show up in actions for dead code elimination in the editor tooling, which would remove everything but the annotation: https://github.com/rescript-lang/rescript-vscode/issues/991