### PR TITLE
Fix issue of incorrect switch cases with identical bodies when mixing…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 #### :bug: Bug Fix
 
 - Allow to use exotic ParscalCased identifiers for types. https://github.com/rescript-lang/rescript-compiler/pull/6777
+- Fix issue of incorrect switch cases with identical bodies when mixing object and array. https://github.com/rescript-lang/rescript-compiler/pull/6792
 
 #### :house: Internal
 

--- a/jscomp/test/UntaggedVariants.js
+++ b/jscomp/test/UntaggedVariants.js
@@ -587,6 +587,42 @@ let OnlyOne = {
   onlyOne: "OnlyOne"
 };
 
+function should_not_merge(x) {
+  if (Array.isArray(x)) {
+    return "do not merge";
+  }
+  if (x instanceof Date) {
+    return "do not merge";
+  }
+  switch (typeof x) {
+    case "boolean" :
+        return "boolean";
+    case "object" :
+        return "do not merge";
+    
+  }
+}
+
+function can_merge(x) {
+  if (Array.isArray(x)) {
+    return "do not merge";
+  }
+  if (x instanceof Date) {
+    return "do not merge";
+  }
+  switch (typeof x) {
+    case "boolean" :
+    case "object" :
+        return "merge";
+    
+  }
+}
+
+let MergeCases = {
+  should_not_merge: should_not_merge,
+  can_merge: can_merge
+};
+
 let i = 42;
 
 let i2 = 42.5;
@@ -634,4 +670,5 @@ exports.Arr = Arr;
 exports.AllInstanceofTypes = AllInstanceofTypes;
 exports.Aliased = Aliased;
 exports.OnlyOne = OnlyOne;
+exports.MergeCases = MergeCases;
 /* l2 Not a pure module */

--- a/jscomp/test/UntaggedVariants.res
+++ b/jscomp/test/UntaggedVariants.res
@@ -432,3 +432,30 @@ module OnlyOne = {
   @unboxed type onlyOne = OnlyOne
   let onlyOne = OnlyOne
 }
+
+module MergeCases = {
+  type obj = {name: string}
+
+  @unboxed
+  type t =
+    | Boolean(bool)
+    | Object(obj)
+    | Array(array<int>)
+    | Date(Js.Date.t)
+
+  let should_not_merge = x =>
+    switch x {
+    | Object(_) => "do not merge"
+    | Array(_) => "do not merge"
+    | Date(_) => "do not merge"
+    | Boolean(_) => "boolean"
+    }
+
+  let can_merge = x =>
+    switch x {
+    | Object(_) => "merge"
+    | Array(_) => "do not merge"
+    | Date(_) => "do not merge"
+    | Boolean(_) => "merge"
+    }
+}


### PR DESCRIPTION
… object and array.

Fixes https://github.com/rescript-lang/rescript-compiler/issues/6789

The issue happens when 2 cases, here `Object` and `Array`, have identical body (here `Console.log(v)`). The switch-generation code, which was not designed with untagged unions in mind, merges the two cases into one (and makes one of the two empty).

However, for `Object` and `Array`, what's generated is not a straight switch, but a mix of `if-then-else` and `switch`. This means that the `Object` and `Array` cases are apart in the generated code, and merging them (making one empty) is wrong.