### PR TITLE
PPX v4: mark props type in externals as `@live`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Fix issue of incorrect switch cases with identical bodies when mixing object and array. https://github.com/rescript-lang/rescript-compiler/pull/6792
 - Fix formatter eats comments on the first argument of an uncurried function. https://github.com/rescript-lang/rescript-compiler/pull/6763 
 - Fix formatter removes parens in pipe operator with anonymous uncurried function. https://github.com/rescript-lang/rescript-compiler/pull/6766
+- PPX v4: mark props type in externals as `@live` to avoid dead code warnings for prop fields in the editor tooling. https://github.com/rescript-lang/rescript-compiler/pull/6796
 
 #### :house: Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,6 @@
 #### :bug: Bug Fix
 
 - Fix unhandled cases for exotic idents (allow to use exotic PascalCased identifiers for types). https://github.com/rescript-lang/rescript-compiler/pull/6777
-- Fix issue of incorrect switch cases with identical bodies when mixing object and array. https://github.com/rescript-lang/rescript-compiler/pull/6792
-- Fix formatter eats comments on the first argument of an uncurried function. https://github.com/rescript-lang/rescript-compiler/pull/6763 
-- Fix formatter removes parens in pipe operator with anonymous uncurried function. https://github.com/rescript-lang/rescript-compiler/pull/6766
 - PPX v4: mark props type in externals as `@live` to avoid dead code warnings for prop fields in the editor tooling. https://github.com/rescript-lang/rescript-compiler/pull/6796
 
 #### :house: Internal

--- a/jscomp/syntax/tests/ppx/react/expected/externalWithCustomName.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/externalWithCustomName.res.txt
@@ -13,6 +13,7 @@ let t = React.createElement(Foo.component, Foo.componentProps(~a=1, ~b={"1"}, ()
 @@jsxConfig({version: 4, mode: "classic"})
 
 module Foo = {
+  @live
   type props<'a, 'b> = {a: 'a, b: 'b}
 
   @module("Foo")
@@ -24,6 +25,7 @@ let t = React.createElement(Foo.component, {a: 1, b: "1"})
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module Foo = {
+  @live
   type props<'a, 'b> = {a: 'a, b: 'b}
 
   @module("Foo")

--- a/jscomp/syntax/tests/ppx/react/expected/externalWithRef.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/externalWithRef.res.txt
@@ -18,6 +18,7 @@ module V3 = {
 @@jsxConfig({version: 4, mode: "classic"})
 
 module V4C = {
+  @live
   type props<'x, 'ref> = {
     x: 'x,
     ref?: 'ref,
@@ -28,9 +29,21 @@ module V4C = {
     "component"
 }
 
+module type V4CType = {
+  @live
+  type props<'x, 'y> = {
+    x: 'x,
+    y: 'y,
+  }
+
+  @module("someModule")
+  external make: React.componentLike<props<string, string>, React.element> = "component"
+}
+
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module V4C = {
+  @live
   type props<'x, 'ref> = {
     x: 'x,
     ref?: 'ref,

--- a/jscomp/syntax/tests/ppx/react/expected/externalWithTypeVariables.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/externalWithTypeVariables.res.txt
@@ -16,6 +16,7 @@ module V3 = {
 @@jsxConfig({version: 4, mode: "classic"})
 
 module V4C = {
+  @live
   type props<'x, 'children> = {
     x: 'x,
     children: 'children,
@@ -28,6 +29,7 @@ module V4C = {
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module V4C = {
+  @live
   type props<'x, 'children> = {
     x: 'x,
     children: 'children,

--- a/jscomp/syntax/tests/ppx/react/expected/firstClassModules.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/firstClassModules.res.txt
@@ -88,6 +88,7 @@ module External = {
     type key
     type t
   }
+  @live
   type props<'model, 'selected, 'onChange, 'items> = {
     model: 'model,
     selected: 'selected,

--- a/jscomp/syntax/tests/ppx/react/expected/mangleKeyword.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/mangleKeyword.res.txt
@@ -47,6 +47,7 @@ module C4C0 = {
   }
 }
 module C4C1 = {
+  @live
   type props<'T_open, 'T_type> = {@as("open") _open: 'T_open, @as("type") _type: 'T_type}
 
   external make: @as("open") React.componentLike<props<string, string>, React.element> = "default"
@@ -68,6 +69,7 @@ module C4A0 = {
   }
 }
 module C4A1 = {
+  @live
   type props<'T_open, 'T_type> = {@as("open") _open: 'T_open, @as("type") _type: 'T_type}
 
   external make: @as("open") React.componentLike<props<string, string>, React.element> = "default"

--- a/jscomp/syntax/tests/ppx/react/expected/noPropsWithKey.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/noPropsWithKey.res.txt
@@ -12,6 +12,7 @@ module V4CA = {
 }
 
 module V4CB = {
+  @live
   type props = {}
 
   @module("c")
@@ -51,6 +52,7 @@ module V4CA = {
 }
 
 module V4CB = {
+  @live
   type props = {}
 
   @module("c")

--- a/jscomp/syntax/tests/ppx/react/expected/v4.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/v4.res.txt
@@ -35,12 +35,14 @@ module type TUncurried = {
 }
 
 module E = {
+  @live
   type props<'x> = {x: 'x}
 
   external make: React.componentLike<props<string>, React.element> = "default"
 }
 
 module EUncurried = {
+  @live
   type props<'x> = {x: 'x}
 
   external make: React.componentLike<props<string>, React.element> = "default"

--- a/jscomp/syntax/tests/ppx/react/externalWithRef.res
+++ b/jscomp/syntax/tests/ppx/react/externalWithRef.res
@@ -18,6 +18,14 @@ module V4C = {
     ) => React.element = "component"
 }
 
+module type V4CType = {
+  @module("someModule") @react.component
+    external make: (
+      ~x: string,
+      ~y: string,
+    ) => React.element = "component"
+}
+
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module V4C = {


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-vscode/issues/994

Dead code elimination in the editor tooling complains about props never being read in the `props` type record defined by the V4 ppx. This is because externals don't provide the implementation of the component, and it's in the implementation that props could be read. This PR marks the `props` type definition as `@live` for external components, so the dead code analysis does not complain.