### PR TITLE
Reactivate unused attribute check for `@int`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Fix unhandled cases for exotic idents (allow to use exotic PascalCased identifiers for types). https://github.com/rescript-lang/rescript-compiler/pull/6777
 - PPX v4: mark props type in externals as `@live` to avoid dead code warnings for prop fields in the editor tooling. https://github.com/rescript-lang/rescript-compiler/pull/6796
 - Fix unused attribute check for `@as`. https://github.com/rescript-lang/rescript-compiler/pull/6795
+- Reactivate unused attribute check for `@int`. https://github.com/rescript-lang/rescript-compiler/pull/6802
 
 #### :house: Internal
 

--- a/jscomp/frontend/bs_ast_invariant.ml
+++ b/jscomp/frontend/bs_ast_invariant.ml
@@ -28,9 +28,8 @@
 *)
 let is_bs_attribute txt =
   match txt with
-  (* TODO #6636: "int" *)
-  | "as" | "bs" | "config" | "ignore" | "optional" | "string" | "uncurry"
-  | "unwrap" ->
+  | "as" | "bs" | "config" | "ignore" | "int" | "optional" | "string"
+  | "uncurry" | "unwrap" ->
     true
   | _ -> false
 


### PR DESCRIPTION
Not sure why I had kept this one deactivated before.
Compiler libs and tests build fine with this, and I also tested successfully with some of my projects.