### PR TITLE
Run OCaml format check as part of CI tests

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,8 +4,8 @@ jscomp/build_tests/*/**
 !jscomp/build_tests/*/input.js
 !jscomp/build_tests/*/*.json
 lib/
-vendor/
 ninja/
+rewatch/target/
 _build/
 _opam
 CHANGELOG.md

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ format:
 	dune build @fmt --auto-promote
 
 checkformat:
-	dune build @fmt
+	node scripts/check_format.sh
 
 clean-gentype:
 	make -C jscomp/gentype_tests/typescript-react-example clean

--- a/scripts/check_format.sh
+++ b/scripts/check_format.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+warningYellow='\033[0;33m'
+successGreen='\033[0;32m'
+reset='\033[0m'
+
+case "$(uname -s)" in
+  Darwin|Linux)
+    echo "Checking code formatting..."
+    if opam exec -- dune build @fmt; then
+      printf "${successGreen}✅ OCaml code formatting ok.${reset}\n"
+    else
+      printf "${warningYellow}⚠️ OCaml code formatting issues found.${reset}\n"
+      exit 1
+    fi
+    ;;
+  *)
+    # Does not work on Windows
+    echo "OCaml code formatting check skipped for this platform."
+esac

--- a/scripts/ciTest.js
+++ b/scripts/ciTest.js
@@ -90,6 +90,11 @@ async function runTests() {
       cwd: path.join(__dirname, ".."),
       stdio: [0, 1, 2],
     });
+
+    cp.execSync("bash scripts/check_format.sh", {
+      cwd: path.join(__dirname, ".."),
+      stdio: [0, 1, 2],
+    });
   }
 }
 

--- a/scripts/test_syntax.sh
+++ b/scripts/test_syntax.sh
@@ -115,16 +115,3 @@ fi
 
 rm -r temp/
 popd
-
-# Check format (does not work on Windows)
-case "$(uname -s)" in
-  Darwin|Linux)
-    echo "Checking code formatting..."
-    if opam exec -- dune build @fmt; then
-      printf "${successGreen}✅ Code formatting ok.${reset}\n"
-    else
-      printf "${warningYellow}⚠️ Code formatting failed.${reset}\n"
-      exit 1
-    fi
-    ;;
-esac


### PR DESCRIPTION
Always run the ocamlformat check in CI, not just when something has changed in jscomp/syntax.

Fixes #6801