### PR TITLE
Format jscomp/common

### DIFF
--- a/jscomp/common/.ocamlformat
+++ b/jscomp/common/.ocamlformat
@@ -1,1 +1,0 @@
-disable

--- a/jscomp/common/bs_loc.ml
+++ b/jscomp/common/bs_loc.ml
@@ -23,9 +23,9 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 type t = Location.t = {
-  loc_start : Lexing.position;
-  loc_end : Lexing.position;
-  loc_ghost : bool;
+  loc_start: Lexing.position;
+  loc_end: Lexing.position;
+  loc_ghost: bool;
 }
 
 let is_ghost x = x.loc_ghost
@@ -35,7 +35,7 @@ let merge (l : t) (r : t) =
   else if is_ghost r then l
   else
     match (l, r) with
-    | { loc_start; _ }, { loc_end; _ } (* TODO: improve*) ->
-        { loc_start; loc_end; loc_ghost = false }
+    | {loc_start; _}, {loc_end; _} (* TODO: improve*) ->
+      {loc_start; loc_end; loc_ghost = false}
 
 (* let none = Location.none *)

--- a/jscomp/common/bs_loc.mli
+++ b/jscomp/common/bs_loc.mli
@@ -23,9 +23,9 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
 type t = Location.t = {
-  loc_start : Lexing.position;
-  loc_end : Lexing.position;
-  loc_ghost : bool;
+  loc_start: Lexing.position;
+  loc_end: Lexing.position;
+  loc_ghost: bool;
 }
 
 (* val is_ghost : t -> bool *)

--- a/jscomp/common/ext_log.ml
+++ b/jscomp/common/ext_log.ml
@@ -30,7 +30,7 @@ let dwarn ?(__POS__ : (string * int * int * int) option) f =
     match __POS__ with
     | None -> Format.fprintf Format.err_formatter ("WARN: " ^^ f ^^ "@.")
     | Some (file, line, _, _) ->
-        Format.fprintf Format.err_formatter
-          ("WARN: %s,%d " ^^ f ^^ "@.")
-          file line
+      Format.fprintf Format.err_formatter
+        ("WARN: %s,%d " ^^ f ^^ "@.")
+        file line
   else Format.ifprintf Format.err_formatter ("WARN: " ^^ f ^^ "@.")

--- a/jscomp/common/js_config.ml
+++ b/jscomp/common/js_config.ml
@@ -58,30 +58,30 @@ let no_export = ref false
 let as_ppx = ref false
 
 let int_of_jsx_version = function
-| Jsx_v3 -> 3
-| Jsx_v4 -> 4
+  | Jsx_v3 -> 3
+  | Jsx_v4 -> 4
 
 let string_of_jsx_module = function
-| React -> "react"
-| Generic {module_name} -> module_name
+  | React -> "react"
+  | Generic {module_name} -> module_name
 
 let string_of_jsx_mode = function
-| Classic -> "classic"
-| Automatic -> "automatic"
+  | Classic -> "classic"
+  | Automatic -> "automatic"
 
 let jsx_version_of_int = function
-| 3 -> Some Jsx_v3
-| 4 -> Some Jsx_v4
-| _ -> None
+  | 3 -> Some Jsx_v3
+  | 4 -> Some Jsx_v4
+  | _ -> None
 
 let jsx_module_of_string = function
-| "react" -> React
-| module_name -> Generic {module_name}
+  | "react" -> React
+  | module_name -> Generic {module_name}
 
 let jsx_mode_of_string = function
-| "classic" -> Classic
-| "automatic" -> Automatic
-| _ -> Classic
+  | "classic" -> Classic
+  | "automatic" -> Automatic
+  | _ -> Classic
 
 (* option to config `@rescript/std`*)
 let customize_runtime : string option ref = ref None

--- a/jscomp/common/js_config.mli
+++ b/jscomp/common/js_config.mli
@@ -79,9 +79,9 @@ val force_cmj : bool ref
 
 val jsx_version : jsx_version option ref
 
-val jsx_module: jsx_module ref
+val jsx_module : jsx_module ref
 
-val jsx_mode: jsx_mode ref
+val jsx_mode : jsx_mode ref
 
 val js_stdout : bool ref
 

--- a/jscomp/common/pattern_printer.ml
+++ b/jscomp/common/pattern_printer.ml
@@ -7,36 +7,35 @@ let mkpat desc = Ast_helper.Pat.mk desc
 let untype typed =
   let rec loop pat =
     match pat.pat_desc with
-    | Tpat_or (p1, { pat_desc = Tpat_or (p2, p3, r_i) }, r_o) ->
+    | Tpat_or (p1, {pat_desc = Tpat_or (p2, p3, r_i)}, r_o) ->
       (* Turn A | (B | C) into (A | B) | C for pretty printing without parens *)
-        let new_inner = { pat with pat_desc = Tpat_or (p1, p2, r_i) } in
-        let new_outer = { pat with pat_desc = Tpat_or (new_inner, p3, r_o) } in
-        loop new_outer
+      let new_inner = {pat with pat_desc = Tpat_or (p1, p2, r_i)} in
+      let new_outer = {pat with pat_desc = Tpat_or (new_inner, p3, r_o)} in
+      loop new_outer
     | Tpat_or (pa, pb, _) -> mkpat (Ppat_or (loop pa, loop pb))
     | Tpat_any | Tpat_var _ -> mkpat Ppat_any
     | Tpat_constant c -> mkpat (Ppat_constant (Untypeast.constant c))
     | Tpat_alias (p, _, _) -> loop p
     | Tpat_tuple lst -> mkpat (Ppat_tuple (List.map loop lst))
     | Tpat_construct (cstr_lid, cstr, lst) ->
-        let lid = { cstr_lid with txt = Longident.Lident cstr.cstr_name } in
-        let arg =
-          match List.map loop lst with
-          | [] -> None
-          | [ p ] -> Some p
-          | lst -> Some (mkpat (Ppat_tuple lst))
-        in
-        mkpat (Ppat_construct (lid, arg))
+      let lid = {cstr_lid with txt = Longident.Lident cstr.cstr_name} in
+      let arg =
+        match List.map loop lst with
+        | [] -> None
+        | [p] -> Some p
+        | lst -> Some (mkpat (Ppat_tuple lst))
+      in
+      mkpat (Ppat_construct (lid, arg))
     | Tpat_variant (label, p_opt, _row_desc) ->
-        let arg = Option.map loop p_opt in
-        mkpat (Ppat_variant (label, arg))
+      let arg = Option.map loop p_opt in
+      mkpat (Ppat_variant (label, arg))
     | Tpat_record (subpatterns, closed_flag) ->
-        let fields =
-          List.map
-            (fun (_, lbl, p) ->
-              (mknoloc (Longident.Lident lbl.lbl_name), loop p))
-            subpatterns
-        in
-        mkpat (Ppat_record (fields, closed_flag))
+      let fields =
+        List.map
+          (fun (_, lbl, p) -> (mknoloc (Longident.Lident lbl.lbl_name), loop p))
+          subpatterns
+      in
+      mkpat (Ppat_record (fields, closed_flag))
     | Tpat_array lst -> mkpat (Ppat_array (List.map loop lst))
     | Tpat_lazy p -> mkpat (Ppat_lazy (loop p))
   in


### PR DESCRIPTION
There are other directories, too, where `ocamlformat` is still disabled.
Let's start with this one, as it is pretty small.