### PR TITLE
gentype: support Jsx.element in addition to React.element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Fix unused attribute check for `@as`. https://github.com/rescript-lang/rescript-compiler/pull/6795
 - Reactivate unused attribute check for `@int`. https://github.com/rescript-lang/rescript-compiler/pull/6802
 - Fix issue where optional labels were not taken into account when disambiguating record value construction. https://github.com/rescript-lang/rescript-compiler/pull/6798
+- Fix issue in gentype when type `Jsx.element` surfaces to the user. https://github.com/rescript-lang/rescript-compiler/pull/6808
 
 #### :house: Internal
 

--- a/jscomp/gentype/TranslateTypeExprFromTypes.ml
+++ b/jscomp/gentype/TranslateTypeExprFromTypes.ml
@@ -216,7 +216,8 @@ let translate_constr ~config ~params_translation ~(path : Path.t) ~type_env =
     {dependencies = []; type_ = EmitType.type_react_event_mouse_t}
   | ( ( ["React"; "element"]
       | ["ReactV3"; "React"; "element"]
-      | ["ReasonReact"; "reactElement"] ),
+      | ["ReasonReact"; "reactElement"]
+      | [("Pervasives" | "PervasivesU"); "Jsx"; "element"] ),
       [] ) ->
     {dependencies = []; type_ = EmitType.type_react_element}
   | (["FB"; "option"] | ["option"]), [param_translation] ->


### PR DESCRIPTION
The type Jsx.element can show user-side in ppx V4 (at least), and affects gentype too. It special-cases `React.element`, and needs to then special-case `Jsx.element` too.

Fixes https://github.com/rescript-lang/rescript-compiler/issues/6807