### PR TITLE
Fix issue where capitalised type variables were only allowed in certa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Fix issue where optional labels were not taken into account when disambiguating record value construction. https://github.com/rescript-lang/rescript-compiler/pull/6798
 - Fix issue in gentype when type `Jsx.element` surfaces to the user. https://github.com/rescript-lang/rescript-compiler/pull/6808
 - Fix inclusion check (impl vs interface) for untagged variants, and fix the outcome printer to show tags. https://github.com/rescript-lang/rescript-compiler/pull/6669
+- Fix issue where capitalised type variables were only allowed in certain positions. https://github.com/rescript-lang/rescript-compiler/pull/6820
 
 #### :house: Internal
 

--- a/jscomp/syntax/src/res_core.ml
+++ b/jscomp/syntax/src/res_core.ml
@@ -4048,7 +4048,9 @@ and parse_type_var_list p =
     match p.Parser.token with
     | SingleQuote ->
       Parser.next p;
-      let lident, loc = parse_lident p in
+      let lident, loc =
+        parse_ident ~msg:ErrorMessages.type_param ~start_pos:p.start_pos p
+      in
       let var = Location.mkloc lident loc in
       loop p (var :: vars)
     | _ -> List.rev vars
@@ -4220,7 +4222,9 @@ and parse_type_alias p typ =
   | As ->
     Parser.next p;
     Parser.expect SingleQuote p;
-    let ident, _loc = parse_lident p in
+    let ident, _loc =
+      parse_ident ~msg:ErrorMessages.type_param ~start_pos:p.start_pos p
+    in
     (* TODO: how do we parse attributes here? *)
     Ast_helper.Typ.alias
       ~loc:(mk_loc typ.Parsetree.ptyp_loc.loc_start p.prev_end_pos)
@@ -5029,7 +5033,7 @@ and parse_type_constraint p =
     Parser.next p;
     Parser.expect SingleQuote p;
     match p.Parser.token with
-    | Lident ident ->
+    | Lident ident | Uident ident ->
       let ident_loc = mk_loc start_pos p.end_pos in
       Parser.next p;
       Parser.expect Equal p;

--- a/jscomp/syntax/tests/parsing/grammar/typexpr/expected/typeconstr.res.txt
+++ b/jscomp/syntax/tests/parsing/grammar/typexpr/expected/typeconstr.res.txt
@@ -56,3 +56,9 @@ let (t : < age: int [@attr ]  ;.. >  list) = x
 let (t : < age: int  ;name: string   ;.. >  list) = x
 let (t : < age: int [@attr ] ;name: string [@attr ]  ;.. >  list) = x
 let (t : string list) = x
+type nonrec ('T, 'E) id_6 =
+  | Ok of 'T 
+  | Err of {
+  payload: 'E } 
+let foo (x : int as 'X) = x
+module type A  = (Foo with type  t =  'X constraint 'X = int)

--- a/jscomp/syntax/tests/parsing/grammar/typexpr/typeconstr.res
+++ b/jscomp/syntax/tests/parsing/grammar/typexpr/typeconstr.res
@@ -59,3 +59,12 @@ let t: list<{.. @attr "age": int, @attr "name": string,}> = x // Note: this comp
 
 // >= isn't an infix op
 let t: list<string>= x
+
+// capitalised type variable in record
+type id_6<'T, 'E> = | Ok('T) | Err({payload: 'E})
+
+// capitalised type variable in as pattern
+let foo = (x: int as 'X) => x
+
+// capitalised type variable in type constraint
+module type A = Foo with type t = 'X constraint 'X = int


### PR DESCRIPTION
…in positions.

Fixes https://github.com/rescript-lang/rescript-compiler/issues/6759