### PR TITLE
internal: avoid JS identifier

### DIFF
--- a/packages/playground-bundling/scripts/generate_cmijs.js
+++ b/packages/playground-bundling/scripts/generate_cmijs.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+"use strict";
+
 /*
  * Requires the version matching `rescript` binary to be `npm link`ed in this
  * project. Or in other words: You need to build cmij files with the same
@@ -78,22 +80,22 @@ function buildCompilerCmij() {
 }
 
 function buildThirdPartyCmijs() {
-  packages.forEach(function installLib(package) {
+  packages.forEach(function installLib(pkg) {
     const libOcamlFolder = path.join(
       PROJECT_ROOT_DIR,
       "node_modules",
-      package,
+      pkg,
       "lib",
       "ocaml"
     );
     const libEs6Folder = path.join(
       PROJECT_ROOT_DIR,
       "node_modules",
-      package,
+      pkg,
       "lib",
       "es6"
     );
-    const outputFolder = path.join(PACKAGES_DIR, package);
+    const outputFolder = path.join(PACKAGES_DIR, pkg);
 
     const cmijFile = path.join(outputFolder, `cmij.js`);
 


### PR DESCRIPTION
`package` is a reserved identifier in JavaScript. should throw SyntaxError in strict mode.

- #6838 Biome can audit this kind of problems
- I'm migrating the codebase to ESM, which is in strict mode by default.