### PR TITLE
Specify `packageManager` for Corepack users

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,5 +70,6 @@
   "bugs": {
     "url": "https://github.com/rescript-lang/rescript-compiler/issues"
   },
-  "homepage": "http://rescript-lang.org"
+  "homepage": "http://rescript-lang.org",
+  "packageManager": "npm@10.8.1+sha512.0e9d42e92bd2318408ed81eaff2da5f78baf23ee7d12a6eed44a6e2901d0f29d7ab715d1b918ade601f72e769a824d9a5c322383f22bbbda5dd396e79de2a077"
 }


### PR DESCRIPTION
[Corepack](https://nodejs.org/api/corepack.html) is Node.js' canonical tool for managing PM binaries and shims

When a Node.js user with Corepack enabled runs the `npm` command, the `"packageManager"` field is automatically added like this.

It's better to specify the version we want first before getting unnecessary diffs. This has no effect for users who don't use Corepack.