### PR TITLE
Boost CI speed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,18 +213,18 @@ jobs:
           chmod +x rewatch/rewatch
           chmod +x _build/install/default/bin/*
 
-      - name: Restore OPAM env
-        id: cache-opam-env
+      - name: Restore OPAM tool
+        id: cache-opam-tool
         uses: actions/cache/restore@v4
         with:
           path: |
             ${{ runner.tool_cache }}/opam
             ~/.opam
-          key: opam-env-v1-${{ runner.os }}-${{ hashFiles('dune-project') }}
+          key: opam-tool-v1-${{ matrix.os }}-${{ hashFiles('dune-project') }}
 
       - name: Use OCaml ${{matrix.ocaml_compiler}}
         uses: ocaml/setup-ocaml@v2
-        if: steps.cache-opam-env.outputs.cache-hit != 'true' && matrix.os != 'windows-latest'
+        if: steps.cache-opam-tool.outputs.cache-hit != 'true' && matrix.os != 'windows-latest'
         with:
           ocaml-compiler: ${{matrix.ocaml_compiler}}
           opam-pin: false
@@ -232,7 +232,7 @@ jobs:
 
       - name: Use OCaml ${{matrix.ocaml_compiler}} (Win)
         uses: ocaml/setup-ocaml@v2
-        if: steps.cache-opam-env.outputs.cache-hit != 'true' && matrix.os == 'windows-latest'
+        if: steps.cache-opam-tool.outputs.cache-hit != 'true' && matrix.os == 'windows-latest'
         with:
           ocaml-compiler: ocaml-variants.5.2.0+options,ocaml-option-mingw
           opam-pin: false
@@ -243,50 +243,55 @@ jobs:
             default: https://github.com/ocaml/opam-repository.git
 
       - name: Install OPAM dependencies
-        if: steps.cache-opam-env.outputs.cache-hit != 'true'
+        if: steps.cache-opam-tool.outputs.cache-hit != 'true'
         run: opam install . --deps-only
 
-      - name: Cache OPAM env
-        if: steps.cache-opam-env.outputs.cache-hit != 'true'
+      - name: Save OPAM tool
+        if: steps.cache-opam-tool.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: |
             ${{ runner.tool_cache }}/opam
             ~/.opam
-          key: opam-env-v1-${{ runner.os }}-${{ hashFiles('dune-project') }}
+          key: opam-tool-v1-${{ matrix.os }}-${{ hashFiles('dune-project') }}
 
-      - name: Get OPAM path
-        if: steps.cache-opam-env.outputs.cache-hit != 'true'
+      - name: Get OPAM env
+        if: steps.cache-opam-tool.outputs.cache-hit != 'true'
         run: |
-          which opam
           which opam > .opam-path
+          opam env > .opam-env
 
-      - name: Cache OPAM path
-        id: cache-opam-path
-        if: steps.cache-opam-env.outputs.cache-hit != 'true'
+      - name: Save OPAM env
+        id: cache-opam-env
+        if: steps.cache-opam-tool.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: .opam-path
-          key: opam-path-${{ runner.os }}
+          path: |
+            .opam-path
+            .opam-env
+          key: opam-path-${{ matrix.os }}
 
-      - name: Restore OPAM path
-        if: steps.cache-opam-env.outputs.cache-hit == 'true'
+      - name: Restore OPAM env
+        if: steps.cache-opam-tool.outputs.cache-hit == 'true'
         uses: actions/cache/restore@v4
         with:
-          path: .opam-path
-          key: opam-path-${{ runner.os }}
+          path: |
+            .opam-path
+            .opam-env
+          key: opam-path-${{ matrix.os }}
 
-      - name: Use cached OPAM env
-        if: steps.cache-opam-env.outputs.cache-hit == 'true'
+      - name: Use cached OPAM env - $PATH
+        if: steps.cache-opam-tool.outputs.cache-hit == 'true'
         run: |
           OPAM_PATH="$(cat .opam-path)"
-          chmod +x $OPAM_PATH
-          dirname $OPAM_PATH >> $GITHUB_PATH
+          chmod +x "$OPAM_PATH"
+          dirname "$OPAM_PATH" >> "$GITHUB_PATH"
 
-      - name: Use cached OPAM env
-        if: steps.cache-opam-env.outputs.cache-hit == 'true'
+      - name: Use cached OPAM env - Environment variables
+        if: steps.cache-opam-tool.outputs.cache-hit == 'true'
         run: |
-          opam env | sed "s/'//g; s/; export .*//g" >> $GITHUB_ENV
+          OPAM_ENV="$(cat .opam-env)"
+          sed "s/'//g; s/; export .*//g" "$OPAM_ENV" >> "$GITHUB_ENV"
 
       - name: "Build compiler"
         if: runner.os != 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,20 +54,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Restore APT state cache
-        if: runner.os == 'Linux'
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            /var/lib/apt/lists
-            /var/cache/apt
-          key: apt-dependencies-v1
-
       - name: Install musl gcc
         if: runner.os == 'Linux'
-        run: |
-          sudo apt-get install -y --no-install-recommends \
-            musl-tools
+        run: sudo apt-get install -y --no-install-recommends musl-tools
 
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@v0.0.4
@@ -224,27 +213,13 @@ jobs:
           chmod +x rewatch/rewatch
           chmod +x _build/install/default/bin/*
 
-      - name: Cache APT state
-        if: runner.os == 'Linux'
-        uses: actions/cache@v4
-        with:
-          path: |
-            /var/lib/apt/lists
-            /var/cache/apt
-          key: apt-dependencies-v1
-
       - name: Install dependencies
         if: runner.os == 'Linux'
-        run: |
+        uses: awalsh128/cache-apt-pkgs-action@v1.4.2
+        with:
           # See https://github.com/ocaml/setup-ocaml/blob/92dde8cf/packages/setup-ocaml/src/unix.ts#L13
-          sudo apt-get install -y --no-install-recommends \
-            bubblewrap \
-            darcs \
-            g++-multilib \
-            gcc-multilib \
-            mercurial \
-            musl-tools \
-            rsync
+          packages: bubblewrap darcs g++-multilib gcc-multilib mercurial musl-tools rsync
+          version: v1
 
       - name: Restore OPAM tool
         id: cache-opam-tool
@@ -395,10 +370,6 @@ jobs:
         run: node scripts/ciTest.js -mocha -theme -format
 
       # Build the playground compiler on the fastest runner (ubuntu-latest)
-      - name: Install JSOO
-        if: matrix.os == 'ubuntu-latest'
-        run: opam install js_of_ocaml.5.8.1
-
       - name: Build playground compiler
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,7 @@ jobs:
           path: |
             .opam-path
             .opam-env
-          key: opam-env-v1-${{ matrix.os }}
+          key: opam-env-v2-${{ matrix.os }}
 
       - name: Restore OPAM env
         if: steps.cache-opam-tool.outputs.cache-hit == 'true'
@@ -303,7 +303,7 @@ jobs:
           path: |
             .opam-path
             .opam-env
-          key: opam-env-v1-${{ matrix.os }}
+          key: opam-env-v2-${{ matrix.os }}
 
       - name: Use cached OPAM env - $PATH
         if: steps.cache-opam-tool.outputs.cache-hit == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,10 +238,11 @@ jobs:
           path: |
             ${{ runner.tool_cache }}/opam
             ~/.opam
+            ~/cygwin
             _opam
             .opam-path
             .opam-env
-          key: opam-env-v3-${{ matrix.os }}-${{ hashFiles('dune-project') }}
+          key: opam-env-v5-${{ matrix.os }}-${{ hashFiles('dune-project') }}
 
       - name: Use OCaml ${{matrix.ocaml_compiler}}
         uses: ocaml/setup-ocaml@v2
@@ -266,13 +267,8 @@ jobs:
       - name: Get OPAM environment
         if: steps.cache-opam-env.outputs.cache-hit != 'true'
         run: |
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            which opam.exe > .opam-path
-          else
-            which opam > .opam-path
-          fi
+          command -v opam | tee .opam-path
           opam env > .opam-env
-        shell: bash
 
       - name: Install OPAM dependencies
         if: steps.cache-opam-env.outputs.cache-hit != 'true'
@@ -285,17 +281,35 @@ jobs:
           path: |
             ${{ runner.tool_cache }}/opam
             ~/.opam
+            ~/cygwin
             _opam
             .opam-path
             .opam-env
-          key: opam-env-v3-${{ matrix.os }}-${{ hashFiles('dune-project') }}
+          key: opam-env-v5-${{ matrix.os }}-${{ hashFiles('dune-project') }}
 
       - name: Use cached OPAM environment
         if: steps.cache-opam-env.outputs.cache-hit == 'true'
         run: |
-          OPAM_PATH="$(cat .opam-path)"
-          chmod +x "$OPAM_PATH"
-          dirname "$OPAM_PATH" >> "$GITHUB_PATH"
+          if [[ "$RUNNER_OS" != "Windows" ]]; then
+            OPAM_PATH="$(cat .opam-path)"
+            chmod +x "$OPAM_PATH"
+            dirname "$OPAM_PATH" >> "$GITHUB_PATH"
+
+          else
+            CYGWIN="winsymlinks:native"
+            CYGWIN_ROOT="D:\\cygwin"
+            CYGWIN_ROOT_BIN="D:\\cygwin\\bin"
+            CYGWIN_ROOT_WRAPPERBIN="D:\\cygwin\\wrapperbin"
+
+            echo "CYGWIN=$CYGWIN" >> "$GITHUB_ENV"
+            echo "CYGWIN_ROOT=$CYGWIN_ROOT" >> "$GITHUB_ENV"
+            echo "CYGWIN_ROOT_BIN=$CYGWIN_ROOT_BIN" >> "$GITHUB_ENV"
+            echo "CYGWIN_ROOT_WRAPPERBIN=$CYGWIN_ROOT_WRAPPERBIN" >> "$GITHUB_ENV"
+
+            echo "$CYGWIN_ROOT_BIN" >> "$GITHUB_PATH"
+            echo "$CYGWIN_ROOT_WRAPPERBIN" >> "$GITHUB_PATH"
+          fi
+
           sed "s/'//g; s/; export .*//g" .opam-env >> "$GITHUB_ENV"
         shell: bash
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,31 +54,42 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Restore build cache
+        id: build-cache
+        uses: actions/cache@v4
+        with:
+          path: rewatch/target
+          key: rewatch-build-${{ matrix.rust-target }}-${{ hashFiles('rewatch/src/**', 'rewatch/Cargo.lock') }}
+
       - name: Install musl gcc
-        if: runner.os == 'Linux'
+        if: steps.build-cache.outputs.cache-hit != 'true' && runner.os == 'Linux'
         run: sudo apt-get install -y --no-install-recommends musl-tools
 
       - name: Set up sccache
+        if: steps.build-cache.outputs.cache-hit != 'true'
         uses: mozilla-actions/sccache-action@v0.0.4
         with:
           version: "v0.8.0"
 
       - name: Install rust toolchain
+        if: steps.build-cache.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           targets: ${{matrix.rust-target}}
 
       - name: Build rewatch
+        if: steps.build-cache.outputs.cache-hit != 'true'
         run: cargo build --manifest-path rewatch/Cargo.toml --target ${{matrix.rust-target}} --release
 
       - name: Get artifact dir name
+        id: artifact-dir
         run: node .github/workflows/get_artifact_dir_name.js
 
       - name: "Upload artifact: rewatch binary"
         uses: actions/upload-artifact@v4
         with:
-          name: rewatch-${{env.artifact_dir_name}}
+          name: rewatch-${{ steps.artifact-dir.outputs.dirname }}
           path: rewatch/target/${{matrix.rust-target}}/release/rewatch${{ runner.os == 'Windows' && '.exe' || '' }}
 
   # Build statically linked Linux binaries in an Alpine-based Docker container
@@ -373,6 +384,7 @@ jobs:
       - name: Build playground compiler
         if: matrix.os == 'ubuntu-latest'
         run: |
+          opam install js_of_ocaml.5.8.1
           opam exec -- node packages/playground-bundling/scripts/generate_cmijs.js
           opam exec -- dune build --profile browser
           cp ./_build/default/jscomp/jsoo/jsoo_playground_main.bc.js playground/compiler.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,8 @@ jobs:
 
       - name: Use OCaml ${{matrix.ocaml_compiler}}
         uses: ocaml/setup-ocaml@v2
-        if: steps.cache-opam-env.outputs.cache-hit != 'true' && matrix.os != 'windows-latest'
+        # if: steps.cache-opam-env.outputs.cache-hit != 'true' && matrix.os != 'windows-latest'
+        if: matrix.os != 'windows-latest'
         with:
           ocaml-compiler: ${{matrix.ocaml_compiler}}
           opam-pin: false
@@ -230,7 +231,8 @@ jobs:
 
       - name: Use OCaml ${{matrix.ocaml_compiler}} (Win)
         uses: ocaml/setup-ocaml@v2
-        if: steps.cache-opam-env.outputs.cache-hit != 'true' && matrix.os == 'windows-latest'
+        # if: steps.cache-opam-env.outputs.cache-hit != 'true' && matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-latest'
         with:
           ocaml-compiler: ocaml-variants.5.2.0+options,ocaml-option-mingw
           opam-pin: false
@@ -241,7 +243,7 @@ jobs:
             default: https://github.com/ocaml/opam-repository.git
 
       - name: "Install OPAM dependencies"
-        if: steps.cache-opam-env.outputs.cache-hit != 'true'
+        # if: steps.cache-opam-env.outputs.cache-hit != 'true'
         run: opam install . --deps-only
 
       - name: Cache OPAM env
@@ -252,8 +254,9 @@ jobs:
           key: opam-env-${{ runner.os }}-${{ hashFiles('dune-project') }}
 
       - name: Get OPAM path
-        if: steps.cache-opam-env.outputs.cache-hit != 'true'
+        # if: steps.cache-opam-env.outputs.cache-hit != 'true'
         run: |
+          which opam
           which opam > .opam-path
 
       - name: Cache OPAM path
@@ -274,6 +277,9 @@ jobs:
       - name: Use cached OPAM env
         if: steps.cache-opam-env.outputs.cache-hit == 'true'
         run: |
+          cat .opam-path
+          dirname $(cat .opam-path)
+          ls $(dirname $(cat .opam-path))
           dirname $(cat .opam-path) >> $GITHUB_PATH
 
       - name: Use cached OPAM env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,8 @@ jobs:
           path: |
             ${{ runner.tool_cache }}/opam
             ~/.opam
-          key: opam-tool-v1-${{ matrix.os }}-${{ hashFiles('dune-project') }}
+            _opam
+          key: opam-tool-v2-${{ matrix.os }}-${{ hashFiles('dune-project') }}
 
       - name: Use OCaml ${{matrix.ocaml_compiler}}
         uses: ocaml/setup-ocaml@v2
@@ -253,7 +254,8 @@ jobs:
           path: |
             ${{ runner.tool_cache }}/opam
             ~/.opam
-          key: opam-tool-v1-${{ matrix.os }}-${{ hashFiles('dune-project') }}
+            _opam
+          key: opam-tool-v2-${{ matrix.os }}-${{ hashFiles('dune-project') }}
 
       - name: Get OPAM env
         if: steps.cache-opam-tool.outputs.cache-hit != 'true'
@@ -269,7 +271,7 @@ jobs:
           path: |
             .opam-path
             .opam-env
-          key: opam-path-${{ matrix.os }}
+          key: opam-env-v1-${{ matrix.os }}
 
       - name: Restore OPAM env
         if: steps.cache-opam-tool.outputs.cache-hit == 'true'
@@ -278,7 +280,7 @@ jobs:
           path: |
             .opam-path
             .opam-env
-          key: opam-path-${{ matrix.os }}
+          key: opam-env-v1-${{ matrix.os }}
 
       - name: Use cached OPAM env - $PATH
         if: steps.cache-opam-tool.outputs.cache-hit == 'true'
@@ -290,8 +292,7 @@ jobs:
       - name: Use cached OPAM env - Environment variables
         if: steps.cache-opam-tool.outputs.cache-hit == 'true'
         run: |
-          OPAM_ENV="$(cat .opam-env)"
-          sed "s/'//g; s/; export .*//g" "$OPAM_ENV" >> "$GITHUB_ENV"
+          sed "s/'//g; s/; export .*//g" .opam-env >> "$GITHUB_ENV"
 
       - name: "Build compiler"
         if: runner.os != 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
       - name: Use cached OPAM env
         if: steps.cache-opam-env.outputs.cache-hit == 'true'
         run: |
-          cat .opam-path >> $GITHUB_PATH
+          dirname $(cat .opam-path) >> $GITHUB_PATH
 
       - name: Use cached OPAM env
         if: steps.cache-opam-env.outputs.cache-hit == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,13 +83,12 @@ jobs:
         run: cargo build --manifest-path rewatch/Cargo.toml --target ${{matrix.rust-target}} --release
 
       - name: Get artifact dir name
-        id: artifact-dir
         run: node .github/workflows/get_artifact_dir_name.js
 
       - name: "Upload artifact: rewatch binary"
         uses: actions/upload-artifact@v4
         with:
-          name: rewatch-${{ steps.artifact-dir.outputs.dirname }}
+          name: rewatch-${{env.artifact_dir_name}}
           path: rewatch/target/${{matrix.rust-target}}/release/rewatch${{ runner.os == 'Windows' && '.exe' || '' }}
 
   # Build statically linked Linux binaries in an Alpine-based Docker container
@@ -384,7 +383,6 @@ jobs:
       - name: Build playground compiler
         if: matrix.os == 'ubuntu-latest'
         run: |
-          opam install js_of_ocaml.5.8.1
           opam exec -- node packages/playground-bundling/scripts/generate_cmijs.js
           opam exec -- dune build --profile browser
           cp ./_build/default/jscomp/jsoo/jsoo_playground_main.bc.js playground/compiler.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Python for ninja build
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
       - name: Build compiler binaries
         uses: docker://ghcr.io/rescript-lang/rescript-ci-build:alpine-3.20-ocaml-5.2.0-01
         with:
@@ -116,7 +121,7 @@ jobs:
       - name: Build ninja binary
         uses: docker://ghcr.io/rescript-lang/rescript-ci-build:alpine-3.20-ocaml-5.2.0-01
         with:
-          args: sh -c "cd ninja && LDFLAGS=-static python3 configure.py --bootstrap"
+          args: sh -c "cd ninja && LDFLAGS=-static python configure.py --bootstrap"
 
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v4
@@ -223,13 +228,18 @@ jobs:
           chmod +x rewatch/rewatch
           chmod +x _build/install/default/bin/*
 
-      - name: Install dependencies
+      - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
         uses: awalsh128/cache-apt-pkgs-action@v1.4.2
         with:
-          # See https://github.com/ocaml/setup-ocaml/blob/92dde8cf/packages/setup-ocaml/src/unix.ts#L13
+          # See https://github.com/ocaml/setup-ocaml/blob/b2105f9/packages/setup-ocaml/src/unix.ts#L9
           packages: bubblewrap darcs g++-multilib gcc-multilib mercurial musl-tools rsync
           version: v1
+
+      - name: Setup Python for ninja build
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
 
       - name: Restore OPAM environment
         id: cache-opam-env
@@ -238,11 +248,12 @@ jobs:
           path: |
             ${{ runner.tool_cache }}/opam
             ~/.opam
-            ~/cygwin
             _opam
             .opam-path
             .opam-env
-          key: opam-env-v5-${{ matrix.os }}-${{ hashFiles('dune-project') }}
+            D:\cygwin
+            D:\.opam
+          key: opam-env-v8-${{ matrix.os }}-${{ hashFiles('dune-project') }}
 
       - name: Use OCaml ${{matrix.ocaml_compiler}}
         uses: ocaml/setup-ocaml@v2
@@ -252,7 +263,7 @@ jobs:
           opam-pin: false
           opam-depext: false
 
-      - name: Use OCaml ${{matrix.ocaml_compiler}} (Win)
+      - name: Use OCaml ${{matrix.ocaml_compiler}} (Windows)
         uses: ocaml/setup-ocaml@v2
         if: steps.cache-opam-env.outputs.cache-hit != 'true' && matrix.os == 'windows-latest'
         with:
@@ -281,36 +292,54 @@ jobs:
           path: |
             ${{ runner.tool_cache }}/opam
             ~/.opam
-            ~/cygwin
             _opam
             .opam-path
             .opam-env
-          key: opam-env-v5-${{ matrix.os }}-${{ hashFiles('dune-project') }}
+            D:\cygwin
+            D:\.opam
+          key: opam-env-v8-${{ matrix.os }}-${{ hashFiles('dune-project') }}
 
       - name: Use cached OPAM environment
         if: steps.cache-opam-env.outputs.cache-hit == 'true'
         run: |
+          # https://github.com/ocaml/setup-ocaml/blob/b2105f9/packages/setup-ocaml/src/installer.ts#L33
+          echo "OPAMVERBOSE=$RUNNER_DEBUG"   >> "$GITHUB_ENV"
+          echo "OPAMCOLOR=always"            >> "$GITHUB_ENV"
+          echo "OPAMCONFIRMLEVEL=unsafe-yes" >> "$GITHUB_ENV"
+          echo "OPAMERRLOGLEN=0"             >> "$GITHUB_ENV"
+          echo "OPAMPRECISETRACKING=1"       >> "$GITHUB_ENV"
+          echo "OPAMYES=1"                   >> "$GITHUB_ENV"
+
+          if [[ "$RUNNER_OS" != "Windows" ]]; then
+            echo "OPAMROOT=$HOME/.opam"      >> "$GITHUB_ENV"
+          else
+            echo "OPAMROOT=D:\\.opam"         >> "$GITHUB_ENV"
+          fi
+
           if [[ "$RUNNER_OS" != "Windows" ]]; then
             OPAM_PATH="$(cat .opam-path)"
             chmod +x "$OPAM_PATH"
             dirname "$OPAM_PATH" >> "$GITHUB_PATH"
 
           else
+            fsutil behavior query SymlinkEvaluation
+            fsutil behavior set symlinkEvaluation R2L:1 R2R:1
+            fsutil behavior query SymlinkEvaluation
+
             CYGWIN="winsymlinks:native"
             CYGWIN_ROOT="D:\\cygwin"
-            CYGWIN_ROOT_BIN="D:\\cygwin\\bin"
+            CYGWIN_ROOT_BIN="D:\\cygwin/bin"
             CYGWIN_ROOT_WRAPPERBIN="D:\\cygwin\\wrapperbin"
 
+            echo "HOME=$USERPROFILE" >> "$GITHUB_ENV"
+            echo "MSYS=winsymlinks:native" >> "$GITHUB_ENV"
             echo "CYGWIN=$CYGWIN" >> "$GITHUB_ENV"
             echo "CYGWIN_ROOT=$CYGWIN_ROOT" >> "$GITHUB_ENV"
             echo "CYGWIN_ROOT_BIN=$CYGWIN_ROOT_BIN" >> "$GITHUB_ENV"
             echo "CYGWIN_ROOT_WRAPPERBIN=$CYGWIN_ROOT_WRAPPERBIN" >> "$GITHUB_ENV"
-
             echo "$CYGWIN_ROOT_BIN" >> "$GITHUB_PATH"
             echo "$CYGWIN_ROOT_WRAPPERBIN" >> "$GITHUB_PATH"
           fi
-
-          sed "s/'//g; s/; export .*//g" .opam-env >> "$GITHUB_ENV"
         shell: bash
 
       - name: Build compiler
@@ -325,7 +354,7 @@ jobs:
       - name: Install npm packages
         run: npm ci --ignore-scripts
 
-      - name: "Windows: Use MSVC for ninja build"
+      - name: Setup MSVC for ninja build (Windows)
         if: runner.os == 'Windows'
         uses: TheMrMilchmann/setup-msvc-dev@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Restore APT state cache
+        if: runner.os == 'Linux'
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            /var/lib/apt/lists
+            /var/cache/apt
+          key: apt-dependencies-v1
+
       - name: Install musl gcc
         if: runner.os == 'Linux'
-        run: sudo apt-get install -y musl-tools
+        run: |
+          sudo apt-get install -y --no-install-recommends \
+            musl-tools
 
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@v0.0.4
@@ -212,6 +223,28 @@ jobs:
           chmod +x ninja/ninja
           chmod +x rewatch/rewatch
           chmod +x _build/install/default/bin/*
+
+      - name: Cache APT state
+        if: runner.os == 'Linux'
+        uses: actions/cache@v4
+        with:
+          path: |
+            /var/lib/apt/lists
+            /var/cache/apt
+          key: apt-dependencies-v1
+
+      - name: Install dependencies
+        if: runner.os == 'Linux'
+        run: |
+          # See https://github.com/ocaml/setup-ocaml/blob/92dde8cf/packages/setup-ocaml/src/unix.ts#L13
+          sudo apt-get install -y --no-install-recommends \
+            bubblewrap \
+            darcs \
+            g++-multilib \
+            gcc-multilib \
+            mercurial \
+            musl-tools \
+            rsync
 
       - name: Restore OPAM tool
         id: cache-opam-tool

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,11 @@ jobs:
       - name: Get OPAM env
         if: steps.cache-opam-tool.outputs.cache-hit != 'true'
         run: |
-          which opam > .opam-path
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            which opam.exe > .opam-path
+          else
+            which opam > .opam-path
+          fi
           opam env > .opam-env
         shell: bash
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,8 +217,10 @@ jobs:
         id: cache-opam-env
         uses: actions/cache/restore@v4
         with:
-          path: ~/.opam
-          key: opam-env-${{ runner.os }}-${{ hashFiles('dune-project') }}
+          path: |
+            ${{ runner.tool_cache }}/opam
+            ~/.opam
+          key: opam-env-v1-${{ runner.os }}-${{ hashFiles('dune-project') }}
 
       - name: Use OCaml ${{matrix.ocaml_compiler}}
         uses: ocaml/setup-ocaml@v2
@@ -248,8 +250,10 @@ jobs:
         if: steps.cache-opam-env.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: ~/.opam
-          key: opam-env-${{ runner.os }}-${{ hashFiles('dune-project') }}
+          path: |
+            ${{ runner.tool_cache }}/opam
+            ~/.opam
+          key: opam-env-v1-${{ runner.os }}-${{ hashFiles('dune-project') }}
 
       - name: Get OPAM path
         if: steps.cache-opam-env.outputs.cache-hit != 'true'
@@ -275,10 +279,9 @@ jobs:
       - name: Use cached OPAM env
         if: steps.cache-opam-env.outputs.cache-hit == 'true'
         run: |
-          ls -al "$(dirname "$(cat .opam-path)")"
-          ls -al "$(cat .opam-path)"
-          chmod +x "$(cat .opam-path)"
-          echo "$(dirname "$(cat .opam-path)")" >> $GITHUB_PATH
+          OPAM_PATH="$(cat .opam-path)"
+          chmod +x $OPAM_PATH
+          dirname $OPAM_PATH >> $GITHUB_PATH
 
       - name: Use cached OPAM env
         if: steps.cache-opam-env.outputs.cache-hit == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,27 +103,23 @@ jobs:
         os: [ubuntu-latest, buildjet-2vcpu-ubuntu-2204-arm]
 
     runs-on: ${{matrix.os}}
+    container: ghcr.io/rescript-lang/rescript-ci-build:alpine-3.20-ocaml-5.2.0-01
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python for ninja build
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-
       - name: Build compiler binaries
-        uses: docker://ghcr.io/rescript-lang/rescript-ci-build:alpine-3.20-ocaml-5.2.0-01
-        with:
-          args: opam exec -- dune build --display quiet --profile static
+        run: |
+          opam exec -- dune build --display quiet --profile static
 
       - name: Build ninja binary
-        uses: docker://ghcr.io/rescript-lang/rescript-ci-build:alpine-3.20-ocaml-5.2.0-01
-        with:
-          args: sh -c "cd ninja && LDFLAGS=-static python configure.py --bootstrap"
+        run: |
+          cd ninja
+          LDFLAGS=-static python configure.py --bootstrap
+          cd ..
 
-      - name: "Upload artifacts"
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: static-binaries-linux-${{runner.arch}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,19 +231,21 @@ jobs:
           packages: bubblewrap darcs g++-multilib gcc-multilib mercurial musl-tools rsync
           version: v1
 
-      - name: Restore OPAM tool
-        id: cache-opam-tool
+      - name: Restore OPAM environment
+        id: cache-opam-env
         uses: actions/cache/restore@v4
         with:
           path: |
             ${{ runner.tool_cache }}/opam
             ~/.opam
             _opam
-          key: opam-tool-v2-${{ matrix.os }}-${{ hashFiles('dune-project') }}
+            .opam-path
+            .opam-env
+          key: opam-env-v3-${{ matrix.os }}-${{ hashFiles('dune-project') }}
 
       - name: Use OCaml ${{matrix.ocaml_compiler}}
         uses: ocaml/setup-ocaml@v2
-        if: steps.cache-opam-tool.outputs.cache-hit != 'true' && matrix.os != 'windows-latest'
+        if: steps.cache-opam-env.outputs.cache-hit != 'true' && matrix.os != 'windows-latest'
         with:
           ocaml-compiler: ${{matrix.ocaml_compiler}}
           opam-pin: false
@@ -251,7 +253,7 @@ jobs:
 
       - name: Use OCaml ${{matrix.ocaml_compiler}} (Win)
         uses: ocaml/setup-ocaml@v2
-        if: steps.cache-opam-tool.outputs.cache-hit != 'true' && matrix.os == 'windows-latest'
+        if: steps.cache-opam-env.outputs.cache-hit != 'true' && matrix.os == 'windows-latest'
         with:
           ocaml-compiler: ocaml-variants.5.2.0+options,ocaml-option-mingw
           opam-pin: false
@@ -261,22 +263,8 @@ jobs:
             sunset: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
             default: https://github.com/ocaml/opam-repository.git
 
-      - name: Install OPAM dependencies
-        if: steps.cache-opam-tool.outputs.cache-hit != 'true'
-        run: opam install . --deps-only
-
-      - name: Save OPAM tool
-        if: steps.cache-opam-tool.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ${{ runner.tool_cache }}/opam
-            ~/.opam
-            _opam
-          key: opam-tool-v2-${{ matrix.os }}-${{ hashFiles('dune-project') }}
-
-      - name: Get OPAM env
-        if: steps.cache-opam-tool.outputs.cache-hit != 'true'
+      - name: Get OPAM environment
+        if: steps.cache-opam-env.outputs.cache-hit != 'true'
         run: |
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             which opam.exe > .opam-path
@@ -286,40 +274,32 @@ jobs:
           opam env > .opam-env
         shell: bash
 
-      - name: Save OPAM env
-        id: cache-opam-env
-        if: steps.cache-opam-tool.outputs.cache-hit != 'true'
+      - name: Install OPAM dependencies
+        if: steps.cache-opam-env.outputs.cache-hit != 'true'
+        run: opam install . --deps-only
+
+      - name: Cache OPAM environment
+        if: steps.cache-opam-env.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: |
+            ${{ runner.tool_cache }}/opam
+            ~/.opam
+            _opam
             .opam-path
             .opam-env
-          key: opam-env-v2-${{ matrix.os }}
+          key: opam-env-v3-${{ matrix.os }}-${{ hashFiles('dune-project') }}
 
-      - name: Restore OPAM env
-        if: steps.cache-opam-tool.outputs.cache-hit == 'true'
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            .opam-path
-            .opam-env
-          key: opam-env-v2-${{ matrix.os }}
-
-      - name: Use cached OPAM env - $PATH
-        if: steps.cache-opam-tool.outputs.cache-hit == 'true'
+      - name: Use cached OPAM environment
+        if: steps.cache-opam-env.outputs.cache-hit == 'true'
         run: |
           OPAM_PATH="$(cat .opam-path)"
           chmod +x "$OPAM_PATH"
           dirname "$OPAM_PATH" >> "$GITHUB_PATH"
-        shell: bash
-
-      - name: Use cached OPAM env - Environment variables
-        if: steps.cache-opam-tool.outputs.cache-hit == 'true'
-        run: |
           sed "s/'//g; s/; export .*//g" .opam-env >> "$GITHUB_ENV"
         shell: bash
 
-      - name: "Build compiler"
+      - name: Build compiler
         if: runner.os != 'Linux'
         run: opam exec -- dune build --display quiet --profile release
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,9 +213,16 @@ jobs:
           chmod +x rewatch/rewatch
           chmod +x _build/install/default/bin/*
 
+      - name: Restore OPAM env
+        id: cache-opam-env
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.opam
+          key: opam-env-${{ runner.os }}-${{ hashFiles('dune-project') }}
+
       - name: Use OCaml ${{matrix.ocaml_compiler}}
         uses: ocaml/setup-ocaml@v2
-        if: matrix.os != 'windows-latest'
+        if: steps.cache-opam-env.outputs.cache-hit != 'true' && matrix.os != 'windows-latest'
         with:
           ocaml-compiler: ${{matrix.ocaml_compiler}}
           opam-pin: false
@@ -223,7 +230,7 @@ jobs:
 
       - name: Use OCaml ${{matrix.ocaml_compiler}} (Win)
         uses: ocaml/setup-ocaml@v2
-        if: matrix.os == 'windows-latest'
+        if: steps.cache-opam-env.outputs.cache-hit != 'true' && matrix.os == 'windows-latest'
         with:
           ocaml-compiler: ocaml-variants.5.2.0+options,ocaml-option-mingw
           opam-pin: false
@@ -234,7 +241,45 @@ jobs:
             default: https://github.com/ocaml/opam-repository.git
 
       - name: "Install OPAM dependencies"
+        if: steps.cache-opam-env.outputs.cache-hit != 'true'
         run: opam install . --deps-only
+
+      - name: Cache OPAM env
+        if: steps.cache-opam-env.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.opam
+          key: opam-env-${{ runner.os }}-${{ hashFiles('dune-project') }}
+
+      - name: Get OPAM path
+        if: steps.cache-opam-env.outputs.cache-hit != 'true'
+        run: |
+          which opam > .opam-path
+
+      - name: Cache OPAM path
+        id: cache-opam-path
+        if: steps.cache-opam-env.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .opam-path
+          key: opam-path-${{ runner.os }}
+
+      - name: Restore OPAM path
+        if: steps.cache-opam-env.outputs.cache-hit == 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: .opam-path
+          key: opam-path-${{ runner.os }}
+
+      - name: Use cached OPAM env
+        if: steps.cache-opam-env.outputs.cache-hit == 'true'
+        run: |
+          cat .opam-path >> $GITHUB_PATH
+
+      - name: Use cached OPAM env
+        if: steps.cache-opam-env.outputs.cache-hit == 'true'
+        run: |
+          opam env | sed "s/'//g; s/; export .*//g" >> $GITHUB_ENV
 
       - name: "Build compiler"
         if: runner.os != 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,7 @@ jobs:
 
             CYGWIN="winsymlinks:native"
             CYGWIN_ROOT="D:\\cygwin"
-            CYGWIN_ROOT_BIN="D:\\cygwin/bin"
+            CYGWIN_ROOT_BIN="D:\\cygwin\\bin"
             CYGWIN_ROOT_WRAPPERBIN="D:\\cygwin\\wrapperbin"
 
             echo "HOME=$USERPROFILE" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,8 +222,7 @@ jobs:
 
       - name: Use OCaml ${{matrix.ocaml_compiler}}
         uses: ocaml/setup-ocaml@v2
-        # if: steps.cache-opam-env.outputs.cache-hit != 'true' && matrix.os != 'windows-latest'
-        if: matrix.os != 'windows-latest'
+        if: steps.cache-opam-env.outputs.cache-hit != 'true' && matrix.os != 'windows-latest'
         with:
           ocaml-compiler: ${{matrix.ocaml_compiler}}
           opam-pin: false
@@ -231,8 +230,7 @@ jobs:
 
       - name: Use OCaml ${{matrix.ocaml_compiler}} (Win)
         uses: ocaml/setup-ocaml@v2
-        # if: steps.cache-opam-env.outputs.cache-hit != 'true' && matrix.os == 'windows-latest'
-        if: matrix.os == 'windows-latest'
+        if: steps.cache-opam-env.outputs.cache-hit != 'true' && matrix.os == 'windows-latest'
         with:
           ocaml-compiler: ocaml-variants.5.2.0+options,ocaml-option-mingw
           opam-pin: false
@@ -242,8 +240,8 @@ jobs:
             sunset: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
             default: https://github.com/ocaml/opam-repository.git
 
-      - name: "Install OPAM dependencies"
-        # if: steps.cache-opam-env.outputs.cache-hit != 'true'
+      - name: Install OPAM dependencies
+        if: steps.cache-opam-env.outputs.cache-hit != 'true'
         run: opam install . --deps-only
 
       - name: Cache OPAM env
@@ -254,7 +252,7 @@ jobs:
           key: opam-env-${{ runner.os }}-${{ hashFiles('dune-project') }}
 
       - name: Get OPAM path
-        # if: steps.cache-opam-env.outputs.cache-hit != 'true'
+        if: steps.cache-opam-env.outputs.cache-hit != 'true'
         run: |
           which opam
           which opam > .opam-path
@@ -277,10 +275,8 @@ jobs:
       - name: Use cached OPAM env
         if: steps.cache-opam-env.outputs.cache-hit == 'true'
         run: |
-          cat .opam-path
-          dirname $(cat .opam-path)
-          ls $(dirname $(cat .opam-path))
-          dirname $(cat .opam-path) >> $GITHUB_PATH
+          chmod +x "$(cat .opam-path)"
+          dirname "$(cat .opam-path)" >> $GITHUB_PATH
 
       - name: Use cached OPAM env
         if: steps.cache-opam-env.outputs.cache-hit == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,23 +103,27 @@ jobs:
         os: [ubuntu-latest, buildjet-2vcpu-ubuntu-2204-arm]
 
     runs-on: ${{matrix.os}}
-    container: ghcr.io/rescript-lang/rescript-ci-build:alpine-3.20-ocaml-5.2.0-01
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Python for ninja build
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
       - name: Build compiler binaries
-        run: |
-          opam exec -- dune build --display quiet --profile static
+        uses: docker://ghcr.io/rescript-lang/rescript-ci-build:alpine-3.20-ocaml-5.2.0-01
+        with:
+          args: opam exec -- dune build --display quiet --profile static
 
       - name: Build ninja binary
-        run: |
-          cd ninja
-          LDFLAGS=-static python configure.py --bootstrap
-          cd ..
+        uses: docker://ghcr.io/rescript-lang/rescript-ci-build:alpine-3.20-ocaml-5.2.0-01
+        with:
+          args: sh -c "cd ninja && LDFLAGS=-static python configure.py --bootstrap"
 
-      - name: Upload artifacts
+      - name: "Upload artifacts"
         uses: actions/upload-artifact@v4
         with:
           name: static-binaries-linux-${{runner.arch}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,7 @@ jobs:
         run: |
           which opam > .opam-path
           opam env > .opam-env
+        shell: bash
 
       - name: Save OPAM env
         id: cache-opam-env
@@ -306,11 +307,13 @@ jobs:
           OPAM_PATH="$(cat .opam-path)"
           chmod +x "$OPAM_PATH"
           dirname "$OPAM_PATH" >> "$GITHUB_PATH"
+        shell: bash
 
       - name: Use cached OPAM env - Environment variables
         if: steps.cache-opam-tool.outputs.cache-hit == 'true'
         run: |
           sed "s/'//g; s/; export .*//g" .opam-env >> "$GITHUB_ENV"
+        shell: bash
 
       - name: "Build compiler"
         if: runner.os != 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,8 +275,10 @@ jobs:
       - name: Use cached OPAM env
         if: steps.cache-opam-env.outputs.cache-hit == 'true'
         run: |
+          ls -al "$(dirname "$(cat .opam-path)")"
+          ls -al "$(cat .opam-path)"
           chmod +x "$(cat .opam-path)"
-          dirname "$(cat .opam-path)" >> $GITHUB_PATH
+          echo "$(dirname "$(cat .opam-path)")" >> $GITHUB_PATH
 
       - name: Use cached OPAM env
         if: steps.cache-opam-env.outputs.cache-hit == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,7 @@ jobs:
 
             CYGWIN="winsymlinks:native"
             CYGWIN_ROOT="D:\\cygwin"
-            CYGWIN_ROOT_BIN="D:\\cygwin\\bin"
+            CYGWIN_ROOT_BIN="D:\\cygwin/bin"
             CYGWIN_ROOT_WRAPPERBIN="D:\\cygwin\\wrapperbin"
 
             echo "HOME=$USERPROFILE" >> "$GITHUB_ENV"
@@ -332,7 +332,7 @@ jobs:
             echo "CYGWIN_ROOT=$CYGWIN_ROOT" >> "$GITHUB_ENV"
             echo "CYGWIN_ROOT_BIN=$CYGWIN_ROOT_BIN" >> "$GITHUB_ENV"
             echo "CYGWIN_ROOT_WRAPPERBIN=$CYGWIN_ROOT_WRAPPERBIN" >> "$GITHUB_ENV"
-            echo "$CYGWIN_ROOT_BIN" >> "$GITHUB_PATH"
+            # echo "$CYGWIN_ROOT_BIN" >> "$GITHUB_PATH"
             echo "$CYGWIN_ROOT_WRAPPERBIN" >> "$GITHUB_PATH"
           fi
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,11 +108,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python for ninja build
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-
       - name: Build compiler binaries
         uses: docker://ghcr.io/rescript-lang/rescript-ci-build:alpine-3.20-ocaml-5.2.0-01
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,7 @@ jobs:
 
             CYGWIN="winsymlinks:native"
             CYGWIN_ROOT="D:\\cygwin"
-            CYGWIN_ROOT_BIN="D:\\cygwin/bin"
+            CYGWIN_ROOT_BIN="D:\\cygwin\\bin"
             CYGWIN_ROOT_WRAPPERBIN="D:\\cygwin\\wrapperbin"
 
             echo "HOME=$USERPROFILE" >> "$GITHUB_ENV"
@@ -332,7 +332,7 @@ jobs:
             echo "CYGWIN_ROOT=$CYGWIN_ROOT" >> "$GITHUB_ENV"
             echo "CYGWIN_ROOT_BIN=$CYGWIN_ROOT_BIN" >> "$GITHUB_ENV"
             echo "CYGWIN_ROOT_WRAPPERBIN=$CYGWIN_ROOT_WRAPPERBIN" >> "$GITHUB_ENV"
-            # echo "$CYGWIN_ROOT_BIN" >> "$GITHUB_PATH"
+
             echo "$CYGWIN_ROOT_WRAPPERBIN" >> "$GITHUB_PATH"
           fi
         shell: bash

--- a/.github/workflows/get_artifact_dir_name.js
+++ b/.github/workflows/get_artifact_dir_name.js
@@ -5,6 +5,6 @@ const { dirName: artifactDirName } = require("../../cli/bin_path.js");
 
 // Pass artifactDirName to subsequent GitHub actions
 fs.appendFileSync(
-  process.env.GITHUB_OUTPUT,
-  `dirname=${artifactDirName}${os.EOL}`,
+  process.env.GITHUB_ENV,
+  `artifact_dir_name=${artifactDirName}${os.EOL}`,
 );

--- a/.github/workflows/get_artifact_dir_name.js
+++ b/.github/workflows/get_artifact_dir_name.js
@@ -5,6 +5,6 @@ const { dirName: artifactDirName } = require("../../cli/bin_path.js");
 
 // Pass artifactDirName to subsequent GitHub actions
 fs.appendFileSync(
-  process.env.GITHUB_ENV,
-  `artifact_dir_name=${artifactDirName}${os.EOL}`,
+  process.env.GITHUB_OUTPUT,
+  `dirname=${artifactDirName}${os.EOL}`,
 );

--- a/dune-project
+++ b/dune-project
@@ -24,6 +24,8 @@
    (= 0.26.2))
   (cppo
    (= 1.6.9))
+  (js_of_ocaml
+   (= 5.8.1))
   (js_of_ocaml-compiler
    (= 5.8.1))
   (ounit2

--- a/dune-project
+++ b/dune-project
@@ -26,8 +26,6 @@
    (= 1.6.9))
   (js_of_ocaml
    (= 5.8.1))
-  (js_of_ocaml-compiler
-   (= 5.8.1))
   (ounit2
    (= 2.2.7))
   (reanalyze

--- a/ninja/misc/ci.py
+++ b/ninja/misc/ci.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import os
 

--- a/ninja/misc/output_test.py
+++ b/ninja/misc/output_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 """Runs ./ninja and checks if the output is correct.
 

--- a/rescript.opam
+++ b/rescript.opam
@@ -11,7 +11,6 @@ depends: [
   "ocamlformat" {= "0.26.2"}
   "cppo" {= "1.6.9"}
   "js_of_ocaml" {= "5.8.1"}
-  "js_of_ocaml-compiler" {= "5.8.1"}
   "ounit2" {= "2.2.7"}
   "reanalyze" {= "2.25.1"}
   "dune"

--- a/rescript.opam
+++ b/rescript.opam
@@ -10,6 +10,7 @@ depends: [
   "ocaml" {>= "4.10"}
   "ocamlformat" {= "0.26.2"}
   "cppo" {= "1.6.9"}
+  "js_of_ocaml" {= "5.8.1"}
   "js_of_ocaml-compiler" {= "5.8.1"}
   "ounit2" {= "2.2.7"}
   "reanalyze" {= "2.25.1"}

--- a/scripts/buildNinjaBinary.js
+++ b/scripts/buildNinjaBinary.js
@@ -5,7 +5,7 @@ const path = require("path");
 
 const platform = process.platform;
 const ninjaDir = path.join(__dirname, "..", "ninja");
-const buildCommand = "python3 configure.py --bootstrap --verbose";
+const buildCommand = "python configure.py --bootstrap --verbose";
 
 if (platform === "win32") {
   // On Windows, the build uses the MSVC compiler which needs to be on the path.


### PR DESCRIPTION
## Strategies

Mostly using `actions/cache`

### `build-rewatch`

Skip build if there are no changes in rewatch sources and its dependencies.

### `build`

#### Cache APT dependencies

Pre-install Linux dependencies more efficiently using [cache-apt-pkgs-action](https://github.com/awalsh128/cache-apt-pkgs-action)

#### Cache OPAM installation

Skip OPAM installation as much as possible.

Once it installed, there are three paths can be cached:
- `${{ runner.tool_cache }}/opam/...`: Shared storage for binaries installed by `setup-*` actions. It will contain `opam` executable.
- `~/.opam`: The home directory of OPAM, every modification by OPAM will placed there.
- `_opam`: Local switch

After caching these three, we can restore OPAM installation by adding `PATH` and exporting `opam env`.

#### Install JSOO ahead of the job

It can be cached with other deps

## Results

`build-rewatch` on `ubuntu-latest`:
- before: 50s~90s
- after (cached): ~15s

`build` on `ubuntu-latest`:
- before: ~360s
- after (cached): ~120s