### PR TITLE
Fix Deno compatibility issues on Windows

### DIFF
--- a/rescript
+++ b/rescript
@@ -61,10 +61,15 @@ process.on("uncaughtException", onUncaughtException);
 // Ctrl+C
 process.on("SIGINT", exitProcess);
 // kill pid
-process.on("SIGUSR1", exitProcess);
-process.on("SIGUSR2", exitProcess);
-process.on("SIGTERM", exitProcess);
-process.on("SIGHUP", exitProcess);
+try {
+  process.on("SIGUSR1", exitProcess);
+  process.on("SIGUSR2", exitProcess);
+  process.on("SIGTERM", exitProcess);
+  process.on("SIGHUP", exitProcess);
+} catch (_e) {
+  // Deno might throw an error here, see https://github.com/denoland/deno/issues/9995
+  // TypeError: Windows only supports ctrl-c (SIGINT) and ctrl-break (SIGBREAK).
+}
 
 const args = process.argv.slice(2);
 const argPatterns = {


### PR DESCRIPTION
Rescript fails to start at the moment, if launched with specifically Deno on specifically Windows:

```
PS C:\Users\user> deno run -A npm:rescript
error: Uncaught TypeError: Windows only supports ctrl-c (SIGINT) and ctrl-break (SIGBREAK).
    at bindSignal (ext:runtime/40_signals.js:14:10)
    at Object.addSignalListener (ext:runtime/40_signals.js:54:19)
    at Process.on (node:process:349:12)
    at Object.<anonymous> (file:///C:/Users/user/rust/rescript-compiler/node_modules/.deno/rescript@11.1.2/node_modules/rescript/rescript:64:9)
    at Object.<anonymous> (file:///C:/Users/user/rust/rescript-compiler/node_modules/.deno/rescript@11.1.2/node_modules/rescript/rescript:133:4)
```

The reason is: https://github.com/denoland/deno/issues/9995

I've tested it locally (with some [trickery](https://github.com/denoland/deno/issues/15624#issuecomment-1511621310) required to run commonjs from local fs), so after adding try..catch rescript runs correctly.