### PR TITLE
Audit what files are compiled in curried mode.

### DIFF
--- a/jscomp/bsc/rescript_compiler_main.ml
+++ b/jscomp/bsc/rescript_compiler_main.ml
@@ -34,6 +34,8 @@ let setup_runtime_path path =
      Bs_version.package_name := std);
   Js_config.customize_runtime := Some path
 
+let curry_specified = ref false
+
 
 let process_file sourcefile ?(kind ) ppf = 
   (* This is a better default then "", it will be changed later 
@@ -46,6 +48,11 @@ let process_file sourcefile ?(kind ) ppf =
     match kind with 
     | None -> Ext_file_extensions.classify_input (Ext_filename.get_extension_maybe sourcefile)  
     | Some kind -> kind in 
+  (if !curry_specified = false && !Clflags.dump_source = false && !Js_config.syntax_only = false && List.mem kind [Res; Resi] then
+    let _ = Printf.eprintf "XXX curry not specified %s\n%!" sourcefile in
+    let _ = assert false in
+    ()
+  );
   let res = match kind with 
   | Res -> 
     let sourcefile = set_abs_input_name  sourcefile in     
@@ -406,8 +413,10 @@ let buckle_script_flags : (string * Bsc_args.spec * string) array =
 
     "-nopervasives", set Clflags.nopervasives, 
     "*internal*";
-    "-uncurried", unit_call (fun () -> Config.uncurried := Uncurried),
-    "*internal* Set jsx module";
+    "-uncurried", unit_call (fun () -> curry_specified := true; Config.uncurried := Uncurried),
+    "*internal*";
+    "-curried", unit_call (fun () -> curry_specified := true; Config.uncurried := Legacy),
+    "*internal*";
     "-v", unit_call print_version_string,
     "Print compiler version and location of standard library and exit";  
 

--- a/jscomp/build_tests/super_errors/input.js
+++ b/jscomp/build_tests/super_errors/input.js
@@ -11,7 +11,7 @@ const fixtures = fs
   .filter(fileName => path.extname(fileName) === ".res");
 
 // const runtime = path.join(__dirname, '..', '..', 'runtime')
-const prefix = `${bsc} -w +A`;
+const prefix = `${bsc} -w +A -curried`;
 
 const updateTests = process.argv[2] === "update";
 

--- a/jscomp/others/js_promise.res
+++ b/jscomp/others/js_promise.res
@@ -44,7 +44,7 @@ type error
 */
 
 @new
-external make: ((@uncurry ~resolve: (. 'a) => unit, ~reject: (. exn) => unit) => unit) => promise<
+external make: ((~resolve: (. 'a) => unit, ~reject: (. exn) => unit) => unit) => promise<
   'a,
 > = "Promise"
 
@@ -83,12 +83,12 @@ external all6: (
 
 @val @scope("Promise") external race: array<promise<'a>> => promise<'a> = "race"
 
-@send external then_: (promise<'a>, @uncurry ('a => promise<'b>)) => promise<'b> = "then"
+@send external then_: (promise<'a>, ('a => promise<'b>)) => promise<'b> = "then"
 let then_ = (arg1, obj) => then_(obj, arg1)
 
 
 @send
-external catch: (promise<'a>, @uncurry (error => promise<'a>)) => promise<'a> = "catch"
+external catch: (promise<'a>, (error => promise<'a>)) => promise<'a> = "catch"
 let catch = (arg1, obj) => catch(obj, arg1)
 /* ` p|> catch handler`
     Note in JS the returned promise type is actually runtime dependent,

--- a/jscomp/others/js_promise2.res
+++ b/jscomp/others/js_promise2.res
@@ -16,7 +16,7 @@ let catch: (promise<'a>, error => promise<'a>) => promise<'a> = %raw(`
     `)
 
 @new
-external make: ((@uncurry ~resolve: (. 'a) => unit, ~reject: (. exn) => unit) => unit) => promise<
+external make: ((~resolve: (. 'a) => unit, ~reject: (. exn) => unit) => unit) => promise<
   'a,
 > = "Promise"
 

--- a/jscomp/others/release.ninja
+++ b/jscomp/others/release.ninja
@@ -1,5 +1,5 @@
 
-bsc_primitive_flags =  -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A
+bsc_primitive_flags =  -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A -curried
 bsc_flags = $bsc_primitive_flags -open Belt_internals
 
 rule cc

--- a/jscomp/runtime/release.ninja
+++ b/jscomp/runtime/release.ninja
@@ -1,5 +1,5 @@
 
-bsc_no_open_flags =  -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime  -nopervasives  -unsafe -w +50 -warn-error A
+bsc_no_open_flags =  -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime  -nopervasives  -unsafe -w +50 -warn-error A -curried
 bsc_flags = $bsc_no_open_flags -open Bs_stdlib_mini
 
 rule cc
@@ -10,7 +10,7 @@ rule cc_cmi
     description = $in -> $out
 
 o runtime/bs_stdlib_mini.cmi : cc runtime/bs_stdlib_mini.resi
-    bsc_flags = -nostdlib -nopervasives
+    bsc_flags = -nostdlib -nopervasives -curried
 o runtime/js.cmj runtime/js.cmi : cc runtime/js.res
     bsc_flags = $bsc_no_open_flags
 o runtime/caml.cmj : cc_cmi runtime/caml.res | runtime/caml.cmi runtime/caml_int64_extern.cmj

--- a/jscomp/stdlib-406/release.ninja
+++ b/jscomp/stdlib-406/release.ninja
@@ -1,5 +1,5 @@
 
-bsc_flags = -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -w -9-3-106 -warn-error A -I others
+bsc_flags = -no-keep-locs -no-alias-deps -bs-no-version-header -bs-no-check-div-by-zero -nostdlib  -bs-cross-module-opt -make-runtime -w -9-3-106 -warn-error A -I others -curried
 
 rule cc
     command = $bsc -bs-cmi -bs-cmj $bsc_flags   -I stdlib-406  $in
@@ -9,9 +9,13 @@ rule cc_cmi
     description = $in -> $out
 
 o stdlib-406/pervasives.cmj : cc_cmi stdlib-406/pervasives.res | stdlib-406/pervasives.cmi $bsc others
-    bsc_flags = $bsc_flags -nopervasives
+    bsc_flags = $bsc_flags -nopervasives -curried
 o stdlib-406/pervasives.cmi : cc stdlib-406/pervasives.resi | $bsc others
-    bsc_flags = $bsc_flags -nopervasives
+    bsc_flags = $bsc_flags -nopervasives -curried
+o stdlib-406/pervasivesU.cmj : cc_cmi stdlib-406/pervasivesU.res | stdlib-406/pervasivesU.cmi $bsc others
+    bsc_flags = $bsc_flags -nopervasives -curried
+o stdlib-406/pervasivesU.cmi : cc stdlib-406/pervasivesU.resi | $bsc others
+    bsc_flags = $bsc_flags -nopervasives -curried
 o stdlib-406/arg.cmj : cc_cmi stdlib-406/arg.res | stdlib-406/arg.cmi stdlib-406/array.cmj stdlib-406/buffer.cmj stdlib-406/list.cmj stdlib-406/string.cmj stdlib-406/sys.cmj $bsc others
 o stdlib-406/arg.cmi : cc stdlib-406/arg.resi | stdlib-406/pervasives.cmj $bsc others
 o stdlib-406/array.cmj : cc_cmi stdlib-406/array.res | stdlib-406/array.cmi $bsc others
@@ -64,8 +68,6 @@ o stdlib-406/obj.cmj : cc_cmi stdlib-406/obj.res | stdlib-406/obj.cmi $bsc other
 o stdlib-406/obj.cmi : cc stdlib-406/obj.resi | stdlib-406/pervasives.cmj $bsc others
 o stdlib-406/parsing.cmj : cc_cmi stdlib-406/parsing.res | stdlib-406/array.cmj stdlib-406/lexing.cmj stdlib-406/obj.cmj stdlib-406/parsing.cmi $bsc others
 o stdlib-406/parsing.cmi : cc stdlib-406/parsing.resi | stdlib-406/lexing.cmi stdlib-406/obj.cmi stdlib-406/pervasives.cmj $bsc others
-o stdlib-406/pervasivesU.cmj : cc_cmi stdlib-406/pervasivesU.res | stdlib-406/pervasivesU.cmi $bsc others
-o stdlib-406/pervasivesU.cmi : cc stdlib-406/pervasivesU.resi | stdlib-406/pervasives.cmj $bsc others
 o stdlib-406/queue.cmj : cc_cmi stdlib-406/queue.res | stdlib-406/queue.cmi $bsc others
 o stdlib-406/queue.cmi : cc stdlib-406/queue.resi | stdlib-406/pervasives.cmj $bsc others
 o stdlib-406/random.cmj : cc_cmi stdlib-406/random.res | stdlib-406/array.cmj stdlib-406/char.cmj stdlib-406/digest.cmj stdlib-406/int32.cmj stdlib-406/int64.cmj stdlib-406/random.cmi stdlib-406/string.cmj $bsc others
@@ -89,4 +91,4 @@ o stdlib-406/sys.cmj : cc_cmi stdlib-406/sys.res | stdlib-406/sys.cmi $bsc other
 o stdlib-406/sys.cmi : cc stdlib-406/sys.resi | stdlib-406/pervasives.cmj $bsc others
 o stdlib-406/uchar.cmj : cc_cmi stdlib-406/uchar.res | stdlib-406/char.cmj stdlib-406/uchar.cmi $bsc others
 o stdlib-406/uchar.cmi : cc stdlib-406/uchar.resi | stdlib-406/pervasives.cmj $bsc others
-o $stdlib : phony stdlib-406/pervasives.cmi stdlib-406/pervasives.cmj stdlib-406/arg.cmi stdlib-406/arg.cmj stdlib-406/array.cmi stdlib-406/array.cmj stdlib-406/arrayLabels.cmi stdlib-406/arrayLabels.cmj stdlib-406/buffer.cmi stdlib-406/buffer.cmj stdlib-406/bytes.cmi stdlib-406/bytes.cmj stdlib-406/bytesLabels.cmi stdlib-406/bytesLabels.cmj stdlib-406/callback.cmi stdlib-406/callback.cmj stdlib-406/camlinternalLazy.cmi stdlib-406/camlinternalLazy.cmj stdlib-406/camlinternalMod.cmi stdlib-406/camlinternalMod.cmj stdlib-406/char.cmi stdlib-406/char.cmj stdlib-406/complex.cmi stdlib-406/complex.cmj stdlib-406/digest.cmi stdlib-406/digest.cmj stdlib-406/filename.cmi stdlib-406/filename.cmj stdlib-406/genlex.cmi stdlib-406/genlex.cmj stdlib-406/hashtbl.cmi stdlib-406/hashtbl.cmj stdlib-406/hashtblLabels.cmi stdlib-406/hashtblLabels.cmj stdlib-406/int32.cmi stdlib-406/int32.cmj stdlib-406/int64.cmi stdlib-406/int64.cmj stdlib-406/lazy.cmi stdlib-406/lazy.cmj stdlib-406/lexing.cmi stdlib-406/lexing.cmj stdlib-406/list.cmi stdlib-406/list.cmj stdlib-406/listLabels.cmi stdlib-406/listLabels.cmj stdlib-406/map.cmi stdlib-406/map.cmj stdlib-406/mapLabels.cmi stdlib-406/mapLabels.cmj stdlib-406/moreLabels.cmi stdlib-406/moreLabels.cmj stdlib-406/obj.cmi stdlib-406/obj.cmj stdlib-406/parsing.cmi stdlib-406/parsing.cmj stdlib-406/pervasivesU.cmi stdlib-406/pervasivesU.cmj stdlib-406/queue.cmi stdlib-406/queue.cmj stdlib-406/random.cmi stdlib-406/random.cmj stdlib-406/set.cmi stdlib-406/set.cmj stdlib-406/setLabels.cmi stdlib-406/setLabels.cmj stdlib-406/sort.cmi stdlib-406/sort.cmj stdlib-406/stack.cmi stdlib-406/stack.cmj stdlib-406/stdLabels.cmi stdlib-406/stdLabels.cmj stdlib-406/stream.cmi stdlib-406/stream.cmj stdlib-406/string.cmi stdlib-406/string.cmj stdlib-406/stringLabels.cmi stdlib-406/stringLabels.cmj stdlib-406/sys.cmi stdlib-406/sys.cmj stdlib-406/uchar.cmi stdlib-406/uchar.cmj
+o $stdlib : phony stdlib-406/pervasivesU.cmi stdlib-406/pervasivesU.cmj stdlib-406/arg.cmi stdlib-406/arg.cmj stdlib-406/array.cmi stdlib-406/array.cmj stdlib-406/arrayLabels.cmi stdlib-406/arrayLabels.cmj stdlib-406/buffer.cmi stdlib-406/buffer.cmj stdlib-406/bytes.cmi stdlib-406/bytes.cmj stdlib-406/bytesLabels.cmi stdlib-406/bytesLabels.cmj stdlib-406/callback.cmi stdlib-406/callback.cmj stdlib-406/camlinternalLazy.cmi stdlib-406/camlinternalLazy.cmj stdlib-406/camlinternalMod.cmi stdlib-406/camlinternalMod.cmj stdlib-406/char.cmi stdlib-406/char.cmj stdlib-406/complex.cmi stdlib-406/complex.cmj stdlib-406/digest.cmi stdlib-406/digest.cmj stdlib-406/filename.cmi stdlib-406/filename.cmj stdlib-406/genlex.cmi stdlib-406/genlex.cmj stdlib-406/hashtbl.cmi stdlib-406/hashtbl.cmj stdlib-406/hashtblLabels.cmi stdlib-406/hashtblLabels.cmj stdlib-406/int32.cmi stdlib-406/int32.cmj stdlib-406/int64.cmi stdlib-406/int64.cmj stdlib-406/lazy.cmi stdlib-406/lazy.cmj stdlib-406/lexing.cmi stdlib-406/lexing.cmj stdlib-406/list.cmi stdlib-406/list.cmj stdlib-406/listLabels.cmi stdlib-406/listLabels.cmj stdlib-406/map.cmi stdlib-406/map.cmj stdlib-406/mapLabels.cmi stdlib-406/mapLabels.cmj stdlib-406/moreLabels.cmi stdlib-406/moreLabels.cmj stdlib-406/obj.cmi stdlib-406/obj.cmj stdlib-406/parsing.cmi stdlib-406/parsing.cmj stdlib-406/queue.cmi stdlib-406/queue.cmj stdlib-406/random.cmi stdlib-406/random.cmj stdlib-406/set.cmi stdlib-406/set.cmj stdlib-406/setLabels.cmi stdlib-406/setLabels.cmj stdlib-406/sort.cmi stdlib-406/sort.cmj stdlib-406/stack.cmi stdlib-406/stack.cmj stdlib-406/stdLabels.cmi stdlib-406/stdLabels.cmj stdlib-406/stream.cmi stdlib-406/stream.cmj stdlib-406/string.cmi stdlib-406/string.cmj stdlib-406/stringLabels.cmi stdlib-406/stringLabels.cmj stdlib-406/sys.cmi stdlib-406/sys.cmj stdlib-406/uchar.cmi stdlib-406/uchar.cmj

--- a/jscomp/test/Import.js
+++ b/jscomp/test/Import.js
@@ -10,13 +10,11 @@ async function eachIntAsync(list, f) {
 }
 
 function eachIntLazy(list, f) {
-  let obj = import("../../lib/js/belt_List.js").then(function (m) {
+  return import("../../lib/js/belt_List.js").then(function (m) {
     return m.forEach;
-  });
-  let arg1 = function (each) {
+  }).then(function (each) {
     return Promise.resolve(Curry._2(each, list, f));
-  };
-  return obj.then(arg1);
+  });
 }
 
 eachIntLazy({

--- a/jscomp/test/SafePromises.js
+++ b/jscomp/test/SafePromises.js
@@ -12,10 +12,9 @@ async function nestedPromise(xxx) {
     console.log("Promise2.catch_", x);
     return Promise.resolve(0);
   }));
-  let arg1 = function (x) {
+  xx.then(function (x) {
     return Promise.resolve((console.log("Promise.then_", x), undefined));
-  };
-  xx.then(arg1);
+  });
 }
 
 async function create(x) {

--- a/jscomp/test/build.ninja
+++ b/jscomp/test/build.ninja
@@ -1,5 +1,5 @@
 
-bsc_flags = -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I runtime -I $stdlib -I others
+bsc_flags = -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I runtime -I $stdlib -I others -curried
 
 rule cc
     command = $bsc -bs-cmi -bs-cmj $bsc_flags   -I test  $in

--- a/jscomp/test/mt.js
+++ b/jscomp/test/mt.js
@@ -4,7 +4,6 @@
 let List = require("../../lib/js/list.js");
 let Path = require("path");
 let $$Array = require("../../lib/js/array.js");
-let Curry = require("../../lib/js/curry.js");
 let Assert = require("assert");
 let Process = require("process");
 
@@ -36,7 +35,7 @@ let from_suites = (function from_suites(name, suite) {
             return List.iter((function (param) {
                           var partial_arg = param[1];
                           it(param[0], (function () {
-                                  return Curry._1(partial_arg, undefined);
+                                  return partial_arg(undefined);
                                 }));
                         }), suite);
           }));
@@ -96,15 +95,6 @@ function handleCode(spec) {
   }
 }
 
-function force_curry(x) {
-  List.hd({
-    hd: 3,
-    tl: /* [] */0
-  });
-  $$Array.copy([5]);
-  return Curry._1(x, undefined);
-}
-
 let from_pair_suites = (function from_pair_suites(name, suites) {
   var match = $$Array.to_list(Process.argv);
   if (match) {
@@ -113,7 +103,7 @@ let from_pair_suites = (function from_pair_suites(name, suites) {
               return List.iter((function (param) {
                             var code = param[1];
                             it(param[0], (function () {
-                                    return handleCode(Curry._1(code, undefined));
+                                    return handleCode(code(undefined));
                                   }));
                           }), suites);
             }));
@@ -125,7 +115,7 @@ let from_pair_suites = (function from_pair_suites(name, suites) {
           ]);
       return List.iter((function (param) {
                     var name = param[0];
-                    var fn = Curry._1(param[1], undefined);
+                    var fn = param[1](undefined);
                     switch (fn.TAG) {
                       case "Eq" :
                           console.log([
@@ -306,5 +296,4 @@ exports.old_from_promise_suites_donotuse = old_from_promise_suites_donotuse;
 exports.eq_suites = eq_suites;
 exports.bool_suites = bool_suites;
 exports.throw_suites = throw_suites;
-exports.force_curry = force_curry;
 /* val_unit Not a pure module */

--- a/jscomp/test/mt.js
+++ b/jscomp/test/mt.js
@@ -235,11 +235,10 @@ function old_from_promise_suites_donotuse(name, suites) {
         List.iter((function (param) {
           let code = param[1];
           it(param[0], (function (param) {
-            let arg1 = function (x) {
+            return code.then(function (x) {
               handleCode(x);
               return val_unit;
-            };
-            return code.then(arg1);
+            });
           }));
         }), suites);
       }));

--- a/jscomp/test/mt.res
+++ b/jscomp/test/mt.res
@@ -53,7 +53,7 @@ function from_suites(name, suite) {
             return List.iter((function (param) {
                           var partial_arg = param[1];
                           it(param[0], (function () {
-                                  return Curry._1(partial_arg, undefined);
+                                  return partial_arg(undefined);
                                 }));
                         }), suite);
           }));
@@ -118,11 +118,6 @@ let handleCode = spec =>
   | FailWith(msg) => assert_fail(msg)
   }
 
-let force_curry = x => {
-  let _ = List.hd(list{3})
-  let _ = Array.copy([5])
-  x()
-}
 let from_pair_suites = %raw(`
 function from_pair_suites(name, suites) {
   var match = $$Array.to_list(Process.argv);
@@ -132,7 +127,7 @@ function from_pair_suites(name, suites) {
               return List.iter((function (param) {
                             var code = param[1];
                             it(param[0], (function () {
-                                    return handleCode(Curry._1(code, undefined));
+                                    return handleCode(code(undefined));
                                   }));
                           }), suites);
             }));
@@ -144,7 +139,7 @@ function from_pair_suites(name, suites) {
           ]);
       return List.iter((function (param) {
                     var name = param[0];
-                    var fn = Curry._1(param[1], undefined);
+                    var fn = param[1](undefined);
                     switch (fn.TAG) {
                       case "Eq" :
                           console.log([

--- a/jscomp/test/mt.resi
+++ b/jscomp/test/mt.resi
@@ -25,5 +25,3 @@ let eq_suites: (~test_id: ref<int>, ~suites: ref<pair_suites>, string, 'b, 'b) =
 let bool_suites: (~test_id: ref<int>, ~suites: ref<pair_suites>, string, bool) => unit
 
 let throw_suites: (~test_id: ref<int>, ~suites: ref<pair_suites>, string, unit => unit) => unit
-
-let force_curry: (unit => unit) => unit

--- a/jscomp/test/ocaml_re_test.js
+++ b/jscomp/test/ocaml_re_test.js
@@ -3541,6 +3541,75 @@ function parse(multiline, dollar_endonly, dotall, ungreedy, s) {
       continue;
     };
   };
+  let piece = function (param) {
+    let r = atom();
+    if (accept(/* '*' */42)) {
+      return greedy_mod(repn(r, 0, undefined));
+    }
+    if (accept(/* '+' */43)) {
+      return greedy_mod(repn(r, 1, undefined));
+    }
+    if (accept(/* '?' */63)) {
+      return greedy_mod(repn(r, 0, 1));
+    }
+    if (!accept(/* '{' */123)) {
+      return r;
+    }
+    let i$1 = integer();
+    if (i$1 !== undefined) {
+      let j = accept(/* ',' */44) ? integer() : i$1;
+      if (!accept(/* '}' */125)) {
+        throw new Error(Parse_error, {
+              cause: {
+                RE_EXN_ID: Parse_error
+              }
+            });
+      }
+      if (j !== undefined && j < i$1) {
+        throw new Error(Parse_error, {
+              cause: {
+                RE_EXN_ID: Parse_error
+              }
+            });
+      }
+      return greedy_mod(repn(r, i$1, j));
+    }
+    i.contents = i.contents - 1 | 0;
+    return r;
+  };
+  let integer = function (param) {
+    if (i.contents === l) {
+      return;
+    }
+    let d = get();
+    if (d > 57 || d < 48) {
+      i.contents = i.contents - 1 | 0;
+      return;
+    } else {
+      let _i = d - /* '0' */48 | 0;
+      while(true) {
+        let i$1 = _i;
+        if (i.contents === l) {
+          return i$1;
+        }
+        let d$1 = get();
+        if (d$1 > 57 || d$1 < 48) {
+          i.contents = i.contents - 1 | 0;
+          return i$1;
+        }
+        let i$p = Math.imul(10, i$1) + (d$1 - /* '0' */48 | 0) | 0;
+        if (i$p < i$1) {
+          throw new Error(Parse_error, {
+                cause: {
+                  RE_EXN_ID: Parse_error
+                }
+              });
+        }
+        _i = i$p;
+        continue;
+      };
+    }
+  };
   let atom = function (param) {
     if (accept(/* '.' */46)) {
       if (dotall) {
@@ -3811,75 +3880,6 @@ function parse(multiline, dollar_endonly, dotall, ungreedy, s) {
         _0: single(c$1)
       };
     }
-  };
-  let integer = function (param) {
-    if (i.contents === l) {
-      return;
-    }
-    let d = get();
-    if (d > 57 || d < 48) {
-      i.contents = i.contents - 1 | 0;
-      return;
-    } else {
-      let _i = d - /* '0' */48 | 0;
-      while(true) {
-        let i$1 = _i;
-        if (i.contents === l) {
-          return i$1;
-        }
-        let d$1 = get();
-        if (d$1 > 57 || d$1 < 48) {
-          i.contents = i.contents - 1 | 0;
-          return i$1;
-        }
-        let i$p = Math.imul(10, i$1) + (d$1 - /* '0' */48 | 0) | 0;
-        if (i$p < i$1) {
-          throw new Error(Parse_error, {
-                cause: {
-                  RE_EXN_ID: Parse_error
-                }
-              });
-        }
-        _i = i$p;
-        continue;
-      };
-    }
-  };
-  let piece = function (param) {
-    let r = atom();
-    if (accept(/* '*' */42)) {
-      return greedy_mod(repn(r, 0, undefined));
-    }
-    if (accept(/* '+' */43)) {
-      return greedy_mod(repn(r, 1, undefined));
-    }
-    if (accept(/* '?' */63)) {
-      return greedy_mod(repn(r, 0, 1));
-    }
-    if (!accept(/* '{' */123)) {
-      return r;
-    }
-    let i$1 = integer();
-    if (i$1 !== undefined) {
-      let j = accept(/* ',' */44) ? integer() : i$1;
-      if (!accept(/* '}' */125)) {
-        throw new Error(Parse_error, {
-              cause: {
-                RE_EXN_ID: Parse_error
-              }
-            });
-      }
-      if (j !== undefined && j < i$1) {
-        throw new Error(Parse_error, {
-              cause: {
-                RE_EXN_ID: Parse_error
-              }
-            });
-      }
-      return greedy_mod(repn(r, i$1, j));
-    }
-    i.contents = i.contents - 1 | 0;
-    return r;
   };
   let char = function (param) {
     if (i.contents === l) {

--- a/lib/es6/js_promise.js
+++ b/lib/es6/js_promise.js
@@ -1,13 +1,12 @@
 
 
-import * as Curry from "./curry.js";
 
 function then_(arg1, obj) {
-  return obj.then(Curry.__1(arg1));
+  return obj.then(arg1);
 }
 
 function $$catch(arg1, obj) {
-  return obj.catch(Curry.__1(arg1));
+  return obj.catch(arg1);
 }
 
 export {

--- a/lib/js/js_promise.js
+++ b/lib/js/js_promise.js
@@ -1,13 +1,12 @@
 'use strict';
 
-let Curry = require("./curry.js");
 
 function then_(arg1, obj) {
-  return obj.then(Curry.__1(arg1));
+  return obj.then(arg1);
 }
 
 function $$catch(arg1, obj) {
-  return obj.catch(Curry.__1(arg1));
+  return obj.catch(arg1);
 }
 
 exports.then_ = then_;

--- a/scripts/ninja.js
+++ b/scripts/ninja.js
@@ -782,7 +782,7 @@ async function runtimeNinja(devmode = true) {
   var externalDeps = devmode ? [compilerTarget] : [];
   var ninjaOutput = devmode ? "build.ninja" : "release.ninja";
   var templateRuntimeRules = `
-bsc_no_open_flags =  ${commonBsFlags} -bs-cross-module-opt -make-runtime  -nopervasives  -unsafe -w +50 -warn-error A
+bsc_no_open_flags =  ${commonBsFlags} -bs-cross-module-opt -make-runtime  -nopervasives  -unsafe -w +50 -warn-error A -curried
 bsc_flags = $bsc_no_open_flags -open Bs_stdlib_mini
 ${ruleCC(ninjaCwd)}
 ${ninjaQuickBuildList([
@@ -791,7 +791,7 @@ ${ninjaQuickBuildList([
     "bs_stdlib_mini.resi",
     "cc",
     ninjaCwd,
-    [["bsc_flags", "-nostdlib -nopervasives"]],
+    [["bsc_flags", "-nostdlib -nopervasives -curried"]],
     [],
     externalDeps,
   ],
@@ -863,7 +863,7 @@ async function othersNinja(devmode = true) {
   var ninjaCwd = "others";
 
   var templateOthersRules = `
-bsc_primitive_flags =  ${commonBsFlags} -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A
+bsc_primitive_flags =  ${commonBsFlags} -bs-cross-module-opt -make-runtime   -nopervasives  -unsafe  -w +50 -warn-error A -curried
 bsc_flags = $bsc_primitive_flags -open Belt_internals
 ${ruleCC(ninjaCwd)}
 ${ninjaQuickBuildList([
@@ -965,12 +965,14 @@ async function stdlibNinja(devmode = true) {
   /**
    * @type [string,string][]
    */
-  var bsc_builtin_overrides = [[bsc_flags, `$${bsc_flags} -nopervasives`]];
+  var bsc_builtin_overrides = [
+    [bsc_flags, `$${bsc_flags} -nopervasives -curried`],
+  ];
   // It is interesting `-w -a` would generate not great code sometimes
   // deprecations diabled due to string_of_float
   var warnings = "-w -9-3-106 -warn-error A";
   var templateStdlibRules = `
-${bsc_flags} = ${commonBsFlags} -bs-cross-module-opt -make-runtime ${warnings} -I others
+${bsc_flags} = ${commonBsFlags} -bs-cross-module-opt -make-runtime ${warnings} -I others -curried
 ${ruleCC(ninjaCwd)}
 ${ninjaQuickBuildList([
   // we make it still depends on external
@@ -994,12 +996,31 @@ ${ninjaQuickBuildList([
     [],
     externalDeps,
   ],
+  [
+    "pervasivesU.cmj",
+    "pervasivesU.res",
+    "cc_cmi",
+    ninjaCwd,
+    bsc_builtin_overrides,
+    "pervasivesU.cmi",
+    externalDeps,
+  ],
+  [
+    "pervasivesU.cmi",
+    "pervasivesU.resi",
+    "cc",
+    ninjaCwd,
+    bsc_builtin_overrides,
+    [],
+    externalDeps,
+  ],
 ])}
 `;
   var stdlibDirFiles = fs.readdirSync(stdlibDir, "ascii");
   var sources = stdlibDirFiles.filter(x => {
     return (
       !x.startsWith("pervasives.") &&
+      !x.startsWith("pervasivesU.") &&
       (x.endsWith(".res") || x.endsWith(".resi"))
     );
   });
@@ -1007,8 +1028,8 @@ ${ninjaQuickBuildList([
   await ocamlDepForBscAsync(sources, stdlibDir, depsMap);
   var targets = collectTarget(sources);
   var allTargets = scanFileTargets(targets, [
-    "pervasives.cmi",
-    "pervasives.cmj",
+    "pervasivesU.cmi",
+    "pervasivesU.cmj",
   ]);
   targets.forEach((ext, mod) => {
     switch (ext) {
@@ -1083,10 +1104,11 @@ async function testNinja() {
   var ninjaOutput = "build.ninja";
   var ninjaCwd = `test`;
   var templateTestRules = `
-bsc_flags = -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I runtime -I $stdlib -I others
+bsc_flags = -bs-cross-module-opt -make-runtime-test -bs-package-output commonjs:jscomp/test  -w -3-6-26-27-29-30-32..40-44-45-52-60-9-106+104 -warn-error A  -I runtime -I $stdlib -I others -curried
 ${ruleCC(ninjaCwd)}
 `;
   var testDirFiles = fs.readdirSync(testDir, "ascii");
+  //testDirFiles = [];
   var sources = testDirFiles.filter(x => {
     return x.endsWith(".resi") || x.endsWith(".res");
   });


### PR DESCRIPTION
Add a `-curried` option, and give an error whenever neither `-curried` not `-uncurried` are used. Then change the build and test files to always specify curried/uncurried.