### PR TITLE
export lib paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "cli"
   ],
   "exports": {
+    "./lib/es6/*": "./lib/es6/*",
+    "./lib/js/*": "./lib/js/*",
     "./package.json": "./package.json"
   },
   "imports": {


### PR DESCRIPTION
I switched module exporting to explicit from #6782 without lib paths.

It will possibly break at runtime `ReferenceError`