### PR TITLE
Avoid generating calls to `Curry` when adjusting arity of uncurried f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - Make tests ready for uncurried mode. https://github.com/rescript-lang/rescript-compiler/pull/6862
 - Make gentype tests uncurried. https://github.com/rescript-lang/rescript-compiler/pull/6866
 - Ignore `@uncurry` attribute in uncurried mode, to avoid generating calls to `Curry` at runtime. https://github.com/rescript-lang/rescript-compiler/pull/6869
+- Avoid generating calls to Curry when adjusting arity of uncurried functions. https://github.com/rescript-lang/rescript-compiler/pull/6870
 
 #### :nail_care: Polish
 

--- a/jscomp/core/lam_eta_conversion.ml
+++ b/jscomp/core/lam_eta_conversion.ml
@@ -163,9 +163,13 @@ let unsafe_adjust_to_arity loc ~(to_ : int) ?(from : int option) (fn : Lam.t) :
             let extra_args =
               Ext_list.init (to_ - from) (fun _ -> Ident.create Literals.param)
             in
+            let rec mk_apply body vars = match vars with
+              | [] -> body
+              | var :: vars ->
+                mk_apply (Lam.apply body [var] ap_info) vars in
             Lam.function_ ~attr:Lambda.default_function_attribute ~arity:to_
               ~params:(Ext_list.append params extra_args)
-              ~body:(Lam.apply body (Ext_list.map extra_args Lam.var) ap_info)
+              ~body:(mk_apply body (Ext_list.map extra_args Lam.var))
         | _ -> (
             let arity = to_ in
             let extra_args =

--- a/jscomp/test/mutable_uncurry_test.js
+++ b/jscomp/test/mutable_uncurry_test.js
@@ -69,7 +69,7 @@ function t3(param) {
 function ut4(param, param$1, param$2, param$3) {
   let x0 = param.contents;
   let x1 = param$1.contents;
-  return Curry._2((function (param) {
+  return (function (param) {
     let x2 = param.contents;
     return function (param) {
       let x3 = param.contents;
@@ -80,7 +80,7 @@ function ut4(param, param$1, param$2, param$3) {
         x3
       ];
     };
-  }), param$2, param$3);
+  })(param$2)(param$3);
 }
 
 function t4(param) {
@@ -105,7 +105,7 @@ function t4(param) {
 function ut5(param, param$1, param$2, param$3, param$4) {
   let x0 = param.contents;
   let x1 = param$1.contents;
-  return Curry._3((function (param) {
+  return (function (param) {
     let x2 = param.contents;
     return function (param) {
       let x3 = param.contents;
@@ -120,7 +120,7 @@ function ut5(param, param$1, param$2, param$3, param$4) {
         ];
       };
     };
-  }), param$2, param$3, param$4);
+  })(param$2)(param$3)(param$4);
 }
 
 function t5(param) {


### PR DESCRIPTION
…unctions.

A function such as this one:
```res
let t4 = ({contents: x0}, {contents: x1}, {contents: x2}, {contents: x3}) => (x0, x1, x2, x3)
```

is 4 nested functions each one extracting the `contents` field. In uncurried mode, the arity is adjusted to be 4, by putting a wrapper on top. The wrapper was added by applying all the new args at once, which requires `Curry` runtime.