### PR TITLE
Avoid generation of `Curry` with reverse application `|>`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Fix Deno compatibility issues on Windows. https://github.com/rescript-lang/rescript-compiler/pull/6850
 - Fix issue with infinite loops with type errors on recursive types. https://github.com/rescript-lang/rescript-compiler/pull/6867
 - Fix issue where using partial application `...` can generate code that uses `Curry` at runtime. https://github.com/rescript-lang/rescript-compiler/pull/6872
+- Avoid generation of `Curry` with reverse application `|>`. https://github.com/rescript-lang/rescript-compiler/pull/6876
 
 #### :house: Internal
 

--- a/jscomp/syntax/src/res_core.ml
+++ b/jscomp/syntax/src/res_core.ml
@@ -2261,7 +2261,7 @@ and parse_binary_expr ?(context = OrdinaryExpr) ?a p prec =
           when p.uncurried_config = Uncurried ->
           {b with pexp_desc = Pexp_apply (fun_expr, args @ [(Nolabel, a)])}
         | BarGreater, _ when p.uncurried_config = Uncurried ->
-          Ast_helper.Exp.apply ~loc b [(Nolabel, a)]
+          Ast_helper.Exp.apply ~loc ~attrs:[uncurried_app_attr] b [(Nolabel, a)]
         | _ ->
           Ast_helper.Exp.apply ~loc
             (make_infix_operator p token start_pos end_pos)

--- a/jscomp/test/UncurriedAlways.js
+++ b/jscomp/test/UncurriedAlways.js
@@ -202,6 +202,14 @@ let PartialApplication = {
   fxyz: fxyz
 };
 
+function hello1(y, f) {
+  return f(y);
+}
+
+function hello2(y, f) {
+  return f(y);
+}
+
 exports.foo = foo;
 exports.z = z;
 exports.bar = bar;
@@ -222,4 +230,6 @@ exports.fn = fn;
 exports.fn1 = fn1;
 exports.a = a$1;
 exports.PartialApplication = PartialApplication;
+exports.hello1 = hello1;
+exports.hello2 = hello2;
 /*  Not a pure module */

--- a/jscomp/test/UncurriedAlways.res
+++ b/jscomp/test/UncurriedAlways.res
@@ -90,3 +90,9 @@ module PartialApplication = {
 
   let fxyz = f3(~x=1, ~y=1, ~z=1, ...)
 }
+
+let hello1 = (y, f) => f(y)
+
+let hello2 = (y, f) => y |> f
+
+


### PR DESCRIPTION
Reverse application`|>` is already formatted away, but this takes care of the issue before formatting.

This is the last instance of `Curry` used at runtime in the compiler code/lib/tests, when built in uncurried mode.