### PR TITLE
Remove `%opaque` primitive.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - Build the compiler libraries/tests in uncurried mode. https://github.com/rescript-lang/rescript-compiler/pull/6864
 - Ignore `-uncurried` command-line flag. https://github.com/rescript-lang/rescript-compiler/pull/6885
 - Cleanup: remove tracking of uncurried state in parser/printer. https://github.com/rescript-lang/rescript-compiler/pull/6888
+- Remove `%opaque` primitive. https://github.com/rescript-lang/rescript-compiler/pull/6892
 
 #### :nail_care: Polish
 

--- a/jscomp/core/lam_convert.ml
+++ b/jscomp/core/lam_convert.ml
@@ -357,7 +357,6 @@ let lam_prim ~primitive:(p : Lambda.primitive) ~args loc : Lam.t =
       match a with
       | Pbigint | Pint32 -> prim ~primitive:(Pintcomp b) ~args loc
       | Pint64 -> prim ~primitive:(Pint64comp b) ~args loc)
-  | Popaque -> Ext_list.singleton_exn args
 
 (* Does not exist since we compile array in js backend unlike native backend *)
 
@@ -569,7 +568,7 @@ let convert (exports : Set_ident.t) (lam : Lambda.lambda) :
           Lam.global_module ~dynamic_import id)
     | Lprim
         ( Puncurried_apply,
-          [ Lapply { ap_func = Lprim (Popaque, [ ap_func ], _); ap_args } ],
+          [ Lapply { ap_func; ap_args } ],
           loc ) ->
         let ap_func = convert_aux ap_func in
         let ap_args = Ext_list.map ap_args convert_aux in

--- a/jscomp/ml/lambda.ml
+++ b/jscomp/ml/lambda.ml
@@ -266,8 +266,6 @@ type primitive =
   | Pasrbint of boxed_integer
   | Pbintcomp of boxed_integer * comparison
   | Pctconst of compile_time_constant
-  (* Inhibition of optimisation *)
-  | Popaque
   | Puncurried_apply
   | Pcreate_extension of string
 and comparison =

--- a/jscomp/ml/lambda.mli
+++ b/jscomp/ml/lambda.mli
@@ -233,8 +233,6 @@ type primitive =
   | Pasrbint of boxed_integer
   | Pbintcomp of boxed_integer * comparison
   | Pctconst of compile_time_constant
-  (* Inhibition of optimisation *)
-  | Popaque
   | Puncurried_apply
   | Pcreate_extension of string
 and comparison =

--- a/jscomp/ml/printlambda.ml
+++ b/jscomp/ml/printlambda.ml
@@ -251,7 +251,6 @@ let primitive ppf = function
   | Pbintcomp(bi, Cgt) -> print_boxed_integer ">" ppf bi
   | Pbintcomp(bi, Cle) -> print_boxed_integer "<=" ppf bi
   | Pbintcomp(bi, Cge) -> print_boxed_integer ">=" ppf bi
-  | Popaque -> fprintf ppf "opaque"
   | Pcreate_extension s -> fprintf ppf "extension[%s]" s   
 let name_of_primitive = function
   | Puncurried_apply -> "Puncurried_apply"
@@ -342,7 +341,6 @@ let name_of_primitive = function
   | Plsrbint _ -> "Plsrbint"
   | Pasrbint _ -> "Pasrbint"
   | Pbintcomp _ -> "Pbintcomp"
-  | Popaque -> "Popaque"
   | Pcreate_extension _ -> "Pcreate_extension"
 
 let function_attribute ppf { inline; is_a_functor; return_unit } =

--- a/jscomp/ml/translcore.ml
+++ b/jscomp/ml/translcore.ml
@@ -422,7 +422,6 @@ let primitives_table =
       ("%int64_to_int32", Pcvtbint (Pint64, Pint32));
       ("%int64_of_bigint", Pcvtbint (Pbigint, Pint64));
       ("%int64_to_bigint", Pcvtbint (Pint64, Pbigint));
-      ("%opaque", Popaque);
       ("%uncurried_apply", Puncurried_apply);
     ]
 
@@ -1101,8 +1100,7 @@ and transl_apply ?(inlined = Default_inline) ?(uncurried_partial_application=Non
     let extra_ids = Array.init extra_arity (fun _ -> Ident.create "extra") |> Array.to_list in
     let extra_args = Ext_list.map extra_ids (fun id -> Lvar id) in
     let ap_args = args @ extra_args in
-    let lam_opaque = Lprim (Popaque, [lam], loc) in
-    let l0 = Lapply { ap_func = lam_opaque; ap_args; ap_inlined = inlined; ap_loc = loc } in
+    let l0 = Lapply { ap_func = lam; ap_args; ap_inlined = inlined; ap_loc = loc } in
     let l1 = Lprim (Puncurried_apply, [l0], loc) in
     Lfunction
       {

--- a/jscomp/ml/typecore.ml
+++ b/jscomp/ml/typecore.ml
@@ -2178,7 +2178,7 @@ and type_expect_ ?type_clash_context ?in_function ?(recarg=Rejected) env sexp ty
         | _ -> false in
 
       if fully_applied && not is_primitive then
-        rue (apply_internal "opaqueFullApply" (mk_apply (apply_internal "opaque" funct) args))
+        rue (apply_internal "opaqueFullApply" (mk_apply funct args))
       else
         rue (mk_apply funct args)
   | Pexp_match(sarg, caselist) ->

--- a/jscomp/others/js.res
+++ b/jscomp/others/js.res
@@ -82,7 +82,6 @@ module Internal = {
 
   /* Use opaque instead of [._n] to prevent some optimizations happening */
   external run: ((. unit) => 'a) => 'a = "#run"
-  external opaque: 'a => 'a = "%opaque"
 }
 
 /**

--- a/jscomp/runtime/js.res
+++ b/jscomp/runtime/js.res
@@ -82,7 +82,6 @@ module Internal = {
 
   /* Use opaque instead of [._n] to prevent some optimizations happening */
   external run: ((. unit) => 'a) => 'a = "#run"
-  external opaque: 'a => 'a = "%opaque"
 }
 
 /**

--- a/jscomp/stdlib-406/sys.res
+++ b/jscomp/stdlib-406/sys.res
@@ -125,7 +125,3 @@ let runtime_warnings_enabled: unit => bool = _ => false
 /* The version string is found in file ../VERSION */
 
 let ocaml_version = "4.06.2+BS"
-
-/* Optimization */
-
-external opaque_identity: 'a => 'a = "%opaque"

--- a/jscomp/stdlib-406/sys.resi
+++ b/jscomp/stdlib-406/sys.resi
@@ -302,22 +302,3 @@ let enable_runtime_warnings: bool => unit
 
     @since 4.03.0 */
 let runtime_warnings_enabled: unit => bool
-
-/* {1 Optimization} */
-
-/** For the purposes of optimization, [opaque_identity] behaves like an
-    unknown (and thus possibly side-effecting) function.
-
-    At runtime, [opaque_identity] disappears altogether.
-
-    A typical use of this function is to prevent pure computations from being
-    optimized away in benchmarking loops.  For example:
-    {[
-      for _round = 1 to 100_000 do
-        ignore (Sys.opaque_identity (my_pure_computation ()))
-      done
-    ]}
-
-    @since 4.03.0
-*/
-external opaque_identity: 'a => 'a = "%opaque"

--- a/lib/es6/belt_internalBuckets.js
+++ b/lib/es6/belt_internalBuckets.js
@@ -3,19 +3,6 @@
 import * as Belt_Array from "./belt_Array.js";
 import * as Caml_option from "./caml_option.js";
 
-function copyBucket(c) {
-  if (c === undefined) {
-    return c;
-  }
-  let head = {
-    key: c.key,
-    value: c.value,
-    next: undefined
-  };
-  copyAuxCont(c.next, head);
-  return head;
-}
-
 function copyAuxCont(_c, _prec) {
   while(true) {
     let prec = _prec;
@@ -33,6 +20,19 @@ function copyAuxCont(_c, _prec) {
     _c = c.next;
     continue;
   };
+}
+
+function copyBucket(c) {
+  if (c === undefined) {
+    return c;
+  }
+  let head = {
+    key: c.key,
+    value: c.value,
+    next: undefined
+  };
+  copyAuxCont(c.next, head);
+  return head;
 }
 
 function copyBuckets(buckets) {

--- a/lib/js/belt_internalBuckets.js
+++ b/lib/js/belt_internalBuckets.js
@@ -3,19 +3,6 @@
 let Belt_Array = require("./belt_Array.js");
 let Caml_option = require("./caml_option.js");
 
-function copyBucket(c) {
-  if (c === undefined) {
-    return c;
-  }
-  let head = {
-    key: c.key,
-    value: c.value,
-    next: undefined
-  };
-  copyAuxCont(c.next, head);
-  return head;
-}
-
 function copyAuxCont(_c, _prec) {
   while(true) {
     let prec = _prec;
@@ -33,6 +20,19 @@ function copyAuxCont(_c, _prec) {
     _c = c.next;
     continue;
   };
+}
+
+function copyBucket(c) {
+  if (c === undefined) {
+    return c;
+  }
+  let head = {
+    key: c.key,
+    value: c.value,
+    next: undefined
+  };
+  copyAuxCont(c.next, head);
+  return head;
 }
 
 function copyBuckets(buckets) {


### PR DESCRIPTION
This was used for uncurried application, but does not seem to be needed now. And for some esoteric `Sys. opaque_identity` function.

Just one less bit of magic.