### PR TITLE
Fix uppercase exotic field format

### DIFF
--- a/jscomp/core/js_dump_property.ml
+++ b/jscomp/core/js_dump_property.ml
@@ -84,6 +84,7 @@ let property_access f s =
 let property_key (s : J.property_name) : string =
   match s with
   | Lit s ->
+      let s = Ext_ident.unwrap_uppercase_exotic s in
       if obj_property_no_need_quot s then s
       else Js_dump_string.escape_to_string s
   | Symbol_name -> {|[Symbol.for("name")]|}

--- a/jscomp/syntax/tests/oprint/expected/oprint.resi.txt
+++ b/jscomp/syntax/tests/oprint/expected/oprint.resi.txt
@@ -170,7 +170,7 @@ type t22 = [#"Variant ⛰"]
 type \"let" = int
 type \"type" = [#"Point🗿"(\"let", float)]
 type t23 = [#1 | #"10space" | #123]
-type exoticUser = {\"let": string, \"type": float}
+type exoticUser = {\"let": string, \"type": float, \"Upper": int}
 type arity1a = unit => int
 type arity1b = int => int
 type arity2 = (int, int) => int
@@ -184,6 +184,7 @@ type obj6 = {"a": int}
 type obj7 = {"a": int}
 type obj8<'a> = 'a
   constraint 'a = {.."a": int}
+type obj9 = {"A": int}
 type objUser = {"age": int, "name": string}
 type objUserWithLongFields = {
   "age": int,
@@ -192,6 +193,7 @@ type objUserWithLongFields = {
   "name": string,
   "x": int,
 }
+type objUserWithUppsercaseKeys = {"AGE": int, "NAME": string}
 type objectCoordinate = {"x": float, "y": float}
 type threeDimensionalCoordinate = {"x": float, "y": float, "z": float}
 type differentSpreadedCoordinate = {

--- a/jscomp/syntax/tests/oprint/oprint.res
+++ b/jscomp/syntax/tests/oprint/oprint.res
@@ -215,7 +215,8 @@ type t23 = [
 
 type exoticUser = {
   \"let": string,
-  \"type": float
+  \"type": float,
+  \"Upper": int
 }
 
 type arity1a = (. ()) => int
@@ -230,9 +231,11 @@ type obj5<'a> = {..} as 'a
 type obj6 = {"a": int}
 type obj7 = {. "a": int}
 type obj8<'a> = {.. "a": int} as 'a
+type obj9 = {"A": int}
 
 type objUser = {"name": string, "age": int}
 type objUserWithLongFields = {"name": string, "x": int, "age": int, "looooooongFiiiiiiiieeeeeeeldName": string, "anoooooooooooooooootherLongFiiiiiieeeeeeeldName": int}
+type objUserWithUppsercaseKeys = {"NAME": string, "AGE": int}
 
 type objectCoordinate =  {"x": float, "y": float}
 type threeDimensionalCoordinate = {...objectCoordinate, "z": float}

--- a/jscomp/syntax/tests/printer/expr/exoticIdent.res
+++ b/jscomp/syntax/tests/printer/expr/exoticIdent.res
@@ -52,3 +52,13 @@ assert(\"let")
 let x = 1
 
 let x = <div \"aria-foo"=\"type"> \"module" \"let" </div>;
+
+type dict = {
+  \"key": int,
+  \"KEY": int,
+}
+
+let dict = {
+  \"key": 42,
+  \"KEY": 42,
+}

--- a/jscomp/syntax/tests/printer/expr/expected/exoticIdent.res.txt
+++ b/jscomp/syntax/tests/printer/expr/expected/exoticIdent.res.txt
@@ -64,3 +64,13 @@ let x =
     \"module"
     \"let"
   </div>
+
+type dict = {
+  key: int,
+  \"KEY": int,
+}
+
+let dict = {
+  key: 42,
+  \"KEY": 42,
+}

--- a/jscomp/test/exotic_labels_test.js
+++ b/jscomp/test/exotic_labels_test.js
@@ -6,5 +6,11 @@ function fn1(v) {
   return v.field;
 }
 
+let dict = {
+  key: 1,
+  KEY: 1
+};
+
 exports.fn1 = fn1;
+exports.dict = dict;
 /* No side effect */

--- a/jscomp/test/exotic_labels_test.res
+++ b/jscomp/test/exotic_labels_test.res
@@ -8,3 +8,13 @@ type \"Type4" = {
   field: string,
 }
 let fn1 = v => v.field
+
+type dict = {
+  \"key": int,
+  \"KEY": int,
+}
+
+let dict = {
+  \"key": 1,
+  \"KEY": 1,
+}


### PR DESCRIPTION
Fixed #6882

The ident format has changed in #6777 for exotic uppercase names, but the change is not applied to the backend in the previous PR.