### PR TITLE
Playground: rescript-react 0.13.0

### DIFF
--- a/packages/playground-bundling/package-lock.json
+++ b/packages/playground-bundling/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@rescript/core": "^1.5.2",
-        "@rescript/react": "^0.12.1"
+        "@rescript/react": "^0.13.0"
       }
     },
     "node_modules/@rescript/core": {
@@ -22,9 +22,9 @@
       }
     },
     "node_modules/@rescript/react": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.12.1.tgz",
-      "integrity": "sha512-ZD7nhDr5FZgLYqRH9s4CNM+LRz/3IMuTb+LH12fd2Akk0xYkYUP+DZveB2VQUC2UohJnTf/c8yPSNsiFihVCCg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.13.0.tgz",
+      "integrity": "sha512-YSIWIyMlyF9ZaP6Q3hScl1h3wRbdIP4+Cb7PlDt7Y1PG8M8VWYhLoIgLb78mbBHcwFbZu0d5zAt1LSX5ilOiWQ==",
       "peerDependencies": {
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
@@ -106,9 +106,9 @@
       "requires": {}
     },
     "@rescript/react": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.12.1.tgz",
-      "integrity": "sha512-ZD7nhDr5FZgLYqRH9s4CNM+LRz/3IMuTb+LH12fd2Akk0xYkYUP+DZveB2VQUC2UohJnTf/c8yPSNsiFihVCCg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@rescript/react/-/react-0.13.0.tgz",
+      "integrity": "sha512-YSIWIyMlyF9ZaP6Q3hScl1h3wRbdIP4+Cb7PlDt7Y1PG8M8VWYhLoIgLb78mbBHcwFbZu0d5zAt1LSX5ilOiWQ==",
       "requires": {}
     },
     "js-tokens": {

--- a/packages/playground-bundling/package.json
+++ b/packages/playground-bundling/package.json
@@ -12,6 +12,6 @@
   "license": "ISC",
   "dependencies": {
     "@rescript/core": "^1.5.2",
-    "@rescript/react": "^0.12.1"
+    "@rescript/react": "^0.13.0"
   }
 }


### PR DESCRIPTION
Upgrade `@rescript/react` dependency in the playground to 0.13.0 (the version without `%external`).