### PR TITLE
CI: don't run npm pack twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,11 +432,8 @@ jobs:
       - name: Move artifacts
         run: ./scripts/moveArtifacts.sh
 
-      - name: Check artifact list
-        run: node ./scripts/makeArtifactList.js -check
-
-      - name: npm pack (rescript)
-        run: npm pack
+      - name: npm pack (rescript) + check artifact list
+        run: node ./scripts/npmPack.js
 
       - name: Copy JS files to stdlib package
         run: mkdir -p packages/std/lib && cp -R lib/es6 lib/js packages/std/lib

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ lib: build node_modules/.bin/semver
 	./scripts/prebuilt.js
 
 artifacts: lib
-	./scripts/makeArtifactList.js
+	./scripts/npmPack.js -updateArtifactList
 
 # Builds the core playground bundle (without the relevant cmijs files for the runtime)
 playground:

--- a/scripts/npmPack.js
+++ b/scripts/npmPack.js
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 // @ts-check
 
-// This script creates the list of the files that go into the rescript npm package.
+// This performs `npm pack` and retrieves the list of artifact files from the output.
 //
-// In local dev, invoke it without any args after adding or removing files.
-// It will then recreate the list and make sure that the exes for all platforms
-// are in the list, even if not present locally.
+// In local dev, invoke it with `-updateArtifactList` to perform a dry run of `npm pack`
+// and recreate `packages/artifacts.txt`.
+// The exes for all platforms will then be included in the list, even if not present locally.
 //
-// In CI, it is invoked with -check. It then recreates the list and verifies
-// that it has no changes compared to the committed state.
+// In CI, the scripts is invoked without options. It then performs `npm pack` for real,
+// recreates the artifact list and verifies that it has no changes compared to the committed state.
 
 /**
  * @typedef {{

--- a/scripts/npmPack.js
+++ b/scripts/npmPack.js
@@ -10,6 +10,22 @@
 // In CI, it is invoked with -check. It then recreates the list and verifies
 // that it has no changes compared to the committed state.
 
+/**
+ * @typedef {{
+ *   path: string,
+ *   size: number,
+ *   mode: number,
+ * }} PackOutputFile
+ *
+ * @typedef {{
+ *   files: PackOutputFile[],
+ *   entryCount: number,
+ *   bundled: unknown[],
+ * }} PackOutputEntry
+ *
+ * @typedef {[PackOutputEntry]} PackOutput
+ */
+
 const { spawnSync, execSync } = require("child_process");
 const path = require("path");
 const fs = require("fs");
@@ -30,8 +46,9 @@ const output = spawnSync(
   },
 ).stdout;
 
-const [{ files }] = JSON.parse(output);
-let filePaths = files.map((/** @type {{ path: string; }} */ file) => file.path);
+/** @type {PackOutput} */
+const parsedOutput = JSON.parse(output);
+let filePaths = parsedOutput[0].files.map(file => file.path);
 
 if (mode === "updateArtifactList") {
   filePaths = Array.from(new Set(filePaths.concat(getFilesAddedByCI())));


### PR DESCRIPTION
`npm pack` was run twice. Once with `--dry-run` to check the artifact list, and one more time for the actual package creation.

Doing it only once saves another 12s in CI.