### PR TITLE
Build static Linux arm64 binaries without docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,49 +89,6 @@ jobs:
           name: rewatch-${{env.artifact_dir_name}}
           path: ${{ env.artifact_dir_name }}
 
-  # Build statically linked Linux binaries in an Alpine-based Docker container
-  # See https://ocamlpro.com/blog/2021_09_02_generating_static_and_portable_executables_with_ocaml
-  # for more info.
-  # The container already comes with all required tools pre-installed
-  # (see https://github.com/rescript-lang/docker-rescript-ci-build/blob/main/Dockerfile).
-  # Note: Static ARM64 binaries cannot be built directly on Ubuntu runner because of
-  # https://github.com/ocaml/opam-repository/issues/26216
-  build-compiler-linux-arm:
-    runs-on: buildjet-2vcpu-ubuntu-2204-arm
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Build compiler binaries
-        uses: docker://ghcr.io/rescript-lang/rescript-ci-build:alpine-3.20-ocaml-5.2.0-01
-        with:
-          args: opam exec -- dune build --display quiet --profile static
-
-      - name: Build ninja binary
-        uses: docker://ghcr.io/rescript-lang/rescript-ci-build:alpine-3.20-ocaml-5.2.0-01
-        with:
-          args: sh -c "cd ninja && LDFLAGS=-static python configure.py --bootstrap"
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-
-      - name: Get artifact dir name
-        run: node .github/workflows/get_artifact_dir_name.js
-
-      - name: Copy exes to platform bin dir
-        run: |
-          node ./scripts/copyExes.js -compiler
-          node ./scripts/copyExes.js -ninja
-
-      - name: "Upload artifacts: binaries"
-        uses: actions/upload-artifact@v4
-        with:
-          name: binaries-${{ env.artifact_dir_name }}
-          path: ${{ env.artifact_dir_name }}
-
   build-compiler:
     strategy:
       fail-fast: false
@@ -143,6 +100,9 @@ jobs:
             upload_libs: true
             # Build the playground compiler on the fastest runner
             build_playground: true
+          - os: buildjet-2vcpu-ubuntu-2204-arm # ARM
+            ocaml_compiler: ocaml-variants.5.2.0+options,ocaml-option-static
+            upload_binaries: true
           - os: macos-13 # x64
             ocaml_compiler: 5.2.0
             upload_binaries: true
@@ -224,6 +184,8 @@ jobs:
         uses: ocaml/setup-ocaml@v3.0.0
         if: steps.cache-opam-env.outputs.cache-hit != 'true'
         with:
+          opam-repositories: |
+            default: https://github.com/rescript-lang/opam-repository.git
           ocaml-compiler: ${{matrix.ocaml_compiler}}
           opam-pin: false
 
@@ -422,7 +384,6 @@ jobs:
   package:
     needs:
       - build-compiler
-      - build-compiler-linux-arm
       - build-rewatch
   
     runs-on: ubuntu-latest


### PR DESCRIPTION
Use our own fork of opam-repository containing this fix:
https://github.com/ocaml/opam-repository/pull/26323

This way, we do not need Docker anymore for the Linux arm64 build. So we can treat Linux arm64 exactly the same as the other architectures, get the benefit of the caching implemented by @cometkim, and do not need to create new Docker images for new OCaml versions anymore.