### PR TITLE
Remove leftover Fn_uncurry_arity and no_auto_uncurried_arg_types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 - Reunify JsxC/JsxU -> Jsx etc. https://github.com/rescript-lang/rescript-compiler/pull/6895
 - Remove the transformation of `foo(1,2)` into `Js.Internal.opaqueFullApply(Internal.opaque(f), 1, 2)`, and change the back-end to treat all applications as uncurried. https://github.com/rescript-lang/rescript-compiler/pull/6893
 - Remove `@uncurry` from ReScript sources (others, tests). https://github.com/rescript-lang/rescript-compiler/pull/6938
+- Remove leftover Fn_uncurry_arity and no_auto_uncurried_arg_types. https://github.com/rescript-lang/rescript-compiler/pull/6939
 
 #### :nail_care: Polish
 

--- a/jscomp/core/lam.ml
+++ b/jscomp/core/lam.ml
@@ -758,7 +758,6 @@ let sequand l r = if_ l r false_
 let rec no_auto_uncurried_arg_types (xs : External_arg_spec.params) =
   match xs with
   | [] -> true
-  | { arg_type = Fn_uncurry_arity _ } :: _ -> false
   | _ :: xs -> no_auto_uncurried_arg_types xs
 
 let result_wrap loc (result_type : External_ffi_types.return_wrapper) result =
@@ -774,10 +773,6 @@ let result_wrap loc (result_type : External_ffi_types.return_wrapper) result =
 let rec transform_uncurried_arg_type loc (arg_types : External_arg_spec.params)
     (args : t list) =
   match (arg_types, args) with
-  | { arg_type = Fn_uncurry_arity n; arg_label } :: xs, y :: ys ->
-      let o_arg_types, o_args = transform_uncurried_arg_type loc xs ys in
-      ( { External_arg_spec.arg_type = Nothing; arg_label } :: o_arg_types,
-        prim ~primitive:(Pjs_fn_make n) ~args:[ y ] loc :: o_args )
   | x :: xs, y :: ys -> (
       match x with
       | { arg_type = Arg_cst _ } ->

--- a/jscomp/core/lam.ml
+++ b/jscomp/core/lam.ml
@@ -748,18 +748,6 @@ let sequor l r = if_ l true_ r
 (** [l && r ] *)
 let sequand l r = if_ l r false_
 
-(******************************************************************)
-(* only [handle_bs_non_obj_ffi] will be used outside *)
-(*
-   [no_auto_uncurried_arg_types xs]
-   check if the FFI have @uncurry attribute.
-   if it does not we wrap it in a nomral way otherwise
-*)
-let rec no_auto_uncurried_arg_types (xs : External_arg_spec.params) =
-  match xs with
-  | [] -> true
-  | _ :: xs -> no_auto_uncurried_arg_types xs
-
 let result_wrap loc (result_type : External_ffi_types.return_wrapper) result =
   match result_type with
   | Return_replaced_with_unit -> seq result unit
@@ -770,27 +758,7 @@ let result_wrap loc (result_type : External_ffi_types.return_wrapper) result =
       prim ~primitive:Pundefined_to_opt ~args:[ result ] loc
   | Return_unset | Return_identity -> result
 
-let rec transform_uncurried_arg_type loc (arg_types : External_arg_spec.params)
-    (args : t list) =
-  match (arg_types, args) with
-  | x :: xs, y :: ys -> (
-      match x with
-      | { arg_type = Arg_cst _ } ->
-          let o_arg_types, o_args = transform_uncurried_arg_type loc xs args in
-          (x :: o_arg_types, o_args)
-      | _ ->
-          let o_arg_types, o_args = transform_uncurried_arg_type loc xs ys in
-          (x :: o_arg_types, y :: o_args))
-  | ([], [] | _ :: _, [] | [], _ :: _) as ok -> ok
-
 let handle_bs_non_obj_ffi (arg_types : External_arg_spec.params)
     (result_type : External_ffi_types.return_wrapper) ffi args loc prim_name ~dynamic_import =
-  if no_auto_uncurried_arg_types arg_types then
     result_wrap loc result_type
       (prim ~primitive:(Pjs_call { prim_name; arg_types; ffi; dynamic_import }) ~args loc)
-  else
-    let n_arg_types, n_args = transform_uncurried_arg_type loc arg_types args in
-    result_wrap loc result_type
-      (prim
-         ~primitive:(Pjs_call { prim_name; arg_types = n_arg_types; ffi; dynamic_import })
-         ~args:n_args loc)

--- a/jscomp/core/lam_compile_external_call.ml
+++ b/jscomp/core/lam_compile_external_call.ml
@@ -106,7 +106,6 @@ let ocaml_to_js_eff ~(arg_label : External_arg_spec.label_noname)
   in
   match arg_type with
   | Arg_cst _ -> assert false
-  | Fn_uncurry_arity _ -> assert false
   (* has to be preprocessed by {!Lam} module first *)
   | Extern_unit ->
       ( (if arg_label = Arg_empty then Splice0 else Splice1 E.unit),

--- a/jscomp/frontend/ast_external_process.ml
+++ b/jscomp/frontend/ast_external_process.ml
@@ -527,9 +527,6 @@ let process_obj (loc : Location.t) (st : external_desc) (prim_name : string)
                       [],
                       Ast_literal.type_string ~loc () )
                   :: result_types )
-              | Fn_uncurry_arity _ ->
-                Location.raise_errorf ~loc
-                  "The combination of %@obj, %@uncurry is not supported yet"
               | Extern_unit -> assert false
               | Poly_var _ ->
                 Location.raise_errorf ~loc
@@ -596,9 +593,6 @@ let process_obj (loc : Location.t) (st : external_desc) (prim_name : string)
               | Arg_cst _ ->
                 Location.raise_errorf ~loc
                   "%@as is not supported with optional yet"
-              | Fn_uncurry_arity _ ->
-                Location.raise_errorf ~loc
-                  "The combination of %@obj, %@uncurry is not supported yet"
               | Extern_unit -> assert false
               | Poly_var _ ->
                 Location.raise_errorf ~loc

--- a/jscomp/frontend/external_arg_spec.ml
+++ b/jscomp/frontend/external_arg_spec.ml
@@ -54,7 +54,6 @@ type attr =
   (* `a does not have any value*)
   | Int of (string * int) list (* ([`a | `b ] [@int])*)
   | Arg_cst of cst
-  | Fn_uncurry_arity of int (* annotated with [@uncurry ] or [@uncurry 2]*)
   (* maybe we can improve it as a combination of {!Asttypes.constant} and tuple *)
   | Extern_unit
   | Nothing

--- a/jscomp/frontend/external_arg_spec.mli
+++ b/jscomp/frontend/external_arg_spec.mli
@@ -31,7 +31,6 @@ type attr =
   | Poly_var of {descr: (string * string) list option}
   | Int of (string * int) list (* ([`a | `b ] [@int])*)
   | Arg_cst of cst
-  | Fn_uncurry_arity of int (* annotated with [@uncurry ] or [@uncurry 2]*)
   (* maybe we can improve it as a combination of {!Asttypes.constant} and tuple *)
   | Extern_unit
   | Nothing


### PR DESCRIPTION
Fn_uncurry_arity is not constructed anywhere.
After removing it, no_auto_uncurried_arg_types always returns true, so can be removed as well.