### PR TITLE
Remove constant flag from extension constructor

### DIFF
--- a/jscomp/ml/datarepr.ml
+++ b/jscomp/ml/datarepr.ml
@@ -201,7 +201,7 @@ let extension_descr path_ext ext =
       cstr_existentials = existentials;
       cstr_args;
       cstr_arity = List.length cstr_args;
-      cstr_tag = Cstr_extension(path_ext, cstr_args = []);
+      cstr_tag = Cstr_extension(path_ext);
       cstr_consts = -1;
       cstr_nonconsts = -1;
       cstr_private = ext.ext_private;

--- a/jscomp/ml/env.ml
+++ b/jscomp/ml/env.ml
@@ -549,7 +549,7 @@ let is_ident = function
   | Pdot _ | Papply _ -> false
 
 let is_local_ext = function
-  | {cstr_tag = Cstr_extension(p, _)} -> is_ident p
+  | {cstr_tag = Cstr_extension(p)} -> is_ident p
   | _ -> false
 
 let diff env1 env2 =

--- a/jscomp/ml/matching.ml
+++ b/jscomp/ml/matching.ml
@@ -2279,7 +2279,7 @@ let get_extension_cases tag_lambda_list =
     | (cstr, act) :: rem ->
         let nonconsts = split_rec rem in
         match cstr with
-        | Cstr_extension(path, _) -> ((path, act) :: nonconsts)
+        | Cstr_extension(path) -> ((path, act) :: nonconsts)
         | _ -> assert false in
   split_rec tag_lambda_list
 

--- a/jscomp/ml/rec_check.ml
+++ b/jscomp/ml/rec_check.ml
@@ -240,7 +240,7 @@ let rec expression : Env.env -> Typedtree.expression -> Use.t =
   | Texp_construct (_, desc, exprs) ->
       let access_constructor =
         match desc.cstr_tag with
-        | Cstr_extension (pth, _) -> Use.inspect (path env pth)
+        | Cstr_extension (pth) -> Use.inspect (path env pth)
         | _ -> Use.empty
       in
       let use =

--- a/jscomp/ml/translcore.ml
+++ b/jscomp/ml/translcore.ml
@@ -905,7 +905,7 @@ and transl_exp0 (e : Typedtree.expression) : Lambda.lambda =
             in
             try Lconst (Const_block (tag_info, List.map extract_constant ll))
             with Not_constant -> Lprim (Pmakeblock tag_info, ll, e.exp_loc))
-        | Cstr_extension (path, _) ->
+        | Cstr_extension (path) ->
             Lprim
               ( Pmakeblock Blk_extension,
                 transl_extension_path e.exp_env path :: ll,

--- a/jscomp/ml/typecore.ml
+++ b/jscomp/ml/typecore.ml
@@ -2839,7 +2839,7 @@ and type_expect_ ?type_clash_context ?in_function ?(recarg=Rejected) env sexp ty
                } ] ->
           let path =
             match (Typetexp.find_constructor env lid.loc lid.txt).cstr_tag with
-            | Cstr_extension (path, _) -> path
+            | Cstr_extension (path) -> path
             | _ -> raise (Error (lid.loc, env, Not_an_extension_constructor))
           in
           rue {

--- a/jscomp/ml/typedecl.ml
+++ b/jscomp/ml/typedecl.ml
@@ -1531,7 +1531,7 @@ let transl_extension_constructor env type_path type_params
         end;
         let path =
           match cdescr.cstr_tag with
-            Cstr_extension(path, _) -> path
+            Cstr_extension(path) -> path
           | _ -> assert false
         in
         let args =

--- a/jscomp/ml/types.ml
+++ b/jscomp/ml/types.ml
@@ -281,16 +281,15 @@ and constructor_tag =
     Cstr_constant of int                (* Constant constructor (an int) *)
   | Cstr_block of int                   (* Regular constructor (a block) *)
   | Cstr_unboxed                        (* Constructor of an unboxed type *)
-  | Cstr_extension of Path.t * bool     (* Extension constructor
-                                           true if a constant false if a block*)
+  | Cstr_extension of Path.t            (* Extension constructor *)
 
 let equal_tag t1 t2 = 
   match (t1, t2) with
   | Cstr_constant i1, Cstr_constant i2 -> i2 = i1
   | Cstr_block i1, Cstr_block i2 -> i2 = i1
   | Cstr_unboxed, Cstr_unboxed -> true
-  | Cstr_extension (path1, b1), Cstr_extension (path2, b2) -> 
-      Path.same path1 path2 && b1 = b2
+  | Cstr_extension (path1), Cstr_extension (path2) -> 
+      Path.same path1 path2
   | (Cstr_constant _|Cstr_block _|Cstr_unboxed|Cstr_extension _), _ -> false
 
 let may_equal_constr c1 c2 = match c1.cstr_tag,c2.cstr_tag with

--- a/jscomp/ml/types.mli
+++ b/jscomp/ml/types.mli
@@ -433,8 +433,7 @@ and constructor_tag =
     Cstr_constant of int                (* Constant constructor (an int) *)
   | Cstr_block of int                   (* Regular constructor (a block) *)
   | Cstr_unboxed                        (* Constructor of an unboxed type *)
-  | Cstr_extension of Path.t * bool     (* Extension constructor
-                                           true if a constant false if a block*)
+  | Cstr_extension of Path.t            (* Extension constructor *)
 
 (* Constructors are the same *)
 val equal_tag :  constructor_tag -> constructor_tag -> bool


### PR DESCRIPTION
Branched from https://github.com/rescript-lang/rescript-compiler/pull/6942 with the additional removal of the constant flag, which became unneeded