### PR TITLE
Skip trailing comma in explicit partial application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
   - Removed empty line at the end of `switch` statement
   - Removed empty `default` case from `switch` statement in the generated code
 
+#### :bug: Bug Fix
+- Fix issue where long layout break added a trailing comma in partial application `...`. https://github.com/rescript-lang/rescript-compiler/pull/6949
+
 # 12.0.0-alpha.1
 
 #### :rocket: New Feature

--- a/jscomp/syntax/src/res_parsetree_viewer.ml
+++ b/jscomp/syntax/src/res_parsetree_viewer.ml
@@ -57,6 +57,13 @@ let process_partial_app_attribute attrs =
   in
   process false [] attrs
 
+let has_partial_attribute attrs =
+  List.exists
+    (function
+      | {Location.txt = "res.partial"}, _ -> true
+      | _ -> false)
+    attrs
+
 type function_attributes_info = {async: bool; attributes: Parsetree.attributes}
 
 let process_function_attributes attrs =

--- a/jscomp/syntax/src/res_parsetree_viewer.mli
+++ b/jscomp/syntax/src/res_parsetree_viewer.mli
@@ -17,6 +17,8 @@ val functor_type :
 val process_partial_app_attribute :
   Parsetree.attributes -> bool * Parsetree.attributes
 
+val has_partial_attribute : Parsetree.attributes -> bool
+
 type function_attributes_info = {async: bool; attributes: Parsetree.attributes}
 
 (* determines whether a function is async and/or uncurried based on the given attributes *)

--- a/jscomp/syntax/src/res_printer.ml
+++ b/jscomp/syntax/src/res_printer.ml
@@ -4146,7 +4146,13 @@ and print_pexp_apply ~state expr cmt_tbl =
     let partial, attrs = ParsetreeViewer.process_partial_app_attribute attrs in
     let args =
       if partial then
-        let dummy = Ast_helper.Exp.constant (Ast_helper.Const.int 0) in
+        let loc =
+          {Asttypes.txt = "res.partial"; Asttypes.loc = expr.pexp_loc}
+        in
+        let attr = (loc, Parsetree.PTyp (Ast_helper.Typ.any ())) in
+        let dummy =
+          Ast_helper.Exp.constant ~attrs:[attr] (Ast_helper.Const.int 0)
+        in
         args @ [(Asttypes.Labelled "...", dummy)]
       else args
     in
@@ -4734,11 +4740,9 @@ and print_arguments ~state ?(partial = false)
     let hasDotDotDot, printed_args =
       List.fold_right
         (fun arg (flag, acc) ->
-          let arg_lbl, _ = arg in
+          let _, expr = arg in
           let hasDotDotDot =
-            match arg_lbl with
-            | Asttypes.Labelled "..." -> true
-            | _ -> false
+            ParsetreeViewer.has_partial_attribute expr.Parsetree.pexp_attributes
           in
           let doc = print_argument ~state arg cmt_tbl in
           (flag || hasDotDotDot, doc :: acc))

--- a/jscomp/syntax/src/res_printer.ml
+++ b/jscomp/syntax/src/res_printer.ml
@@ -4737,15 +4737,15 @@ and print_arguments ~state ?(partial = false)
     Doc.concat [Doc.lparen; arg_doc; Doc.rparen]
   | args ->
     (* Avoid printing trailing comma when there is ... in function application *)
-    let hasDotDotDot, printed_args =
+    let has_partial_attr, printed_args =
       List.fold_right
         (fun arg (flag, acc) ->
           let _, expr = arg in
-          let hasDotDotDot =
+          let has_partial_attr =
             ParsetreeViewer.has_partial_attribute expr.Parsetree.pexp_attributes
           in
           let doc = print_argument ~state arg cmt_tbl in
-          (flag || hasDotDotDot, doc :: acc))
+          (flag || has_partial_attr, doc :: acc))
         args (false, [])
     in
     Doc.group
@@ -4758,7 +4758,7 @@ and print_arguments ~state ?(partial = false)
                   Doc.soft_line;
                   Doc.join ~sep:(Doc.concat [Doc.comma; Doc.line]) printed_args;
                 ]);
-           (if partial || hasDotDotDot then Doc.nil else Doc.trailing_comma);
+           (if partial || has_partial_attr then Doc.nil else Doc.trailing_comma);
            Doc.soft_line;
            Doc.rparen;
          ])

--- a/jscomp/syntax/tests/printer/expr/apply.res
+++ b/jscomp/syntax/tests/printer/expr/apply.res
@@ -73,3 +73,37 @@ f(. {
 
 resolve(.)
 resolve(. ())
+
+let g =  f(
+  a => LongModuleName.functionWithAlongNameThatWrapsTheEditorToTheNextLinexxxxxxxxxxxxxxxxxxxxxx(a),
+  b,
+  c
+)
+
+let g =  f(
+  a => LongModuleName.functionWithAlongNameThatWrapsTheEditorToTheNextLinexxxxxxxxxxxxxxxxxxxxxx(a),
+  b,
+  c, 
+  ...
+)
+
+let g =  f(
+  a => LongModuleName.functionWithAlongNameThatWrapsTheEditorToTheNextLinexxxxxxxxxxxxxxxxxxxxxx(a),
+  b,
+  c => LongModuleName.functionWithAlongNameThatWrapsTheEditorToTheNextLinexxxxxxxxxxxxxxxxxxxxxx(d, ...),
+  ...
+)
+
+let g =  f(
+  a => LongModuleName.functionWithAlongNameThatWrapsTheEditorToTheNextLinexxxxxxxxxxxxxxxxxxxxxx(a, ...),
+  b,
+  c => LongModuleName.functionWithAlongNameThatWrapsTheEditorToTheNextLinexxxxxxxxxxxxxxxxxxxxxx(d),
+  ...
+)
+
+
+let g =  f(
+  a => LongModuleName.functionWithAlongNameThatWrapsTheEditorToTheNextLinexxxxxxxxxxxxxxxxxxxxxx(a),
+  b,
+  c => LongModuleName.functionWithAlongNameThatWrapsTheEditorToTheNextLinexxxxxxxxxxxxxxxxxxxxxx(d, ...)
+)

--- a/jscomp/syntax/tests/printer/expr/expected/apply.res.txt
+++ b/jscomp/syntax/tests/printer/expr/expected/apply.res.txt
@@ -93,3 +93,54 @@ f({
 
 resolve()
 resolve()
+
+let g = f(
+  a => LongModuleName.functionWithAlongNameThatWrapsTheEditorToTheNextLinexxxxxxxxxxxxxxxxxxxxxx(a),
+  b,
+  c,
+)
+
+let g =
+  f(
+    a =>
+      LongModuleName.functionWithAlongNameThatWrapsTheEditorToTheNextLinexxxxxxxxxxxxxxxxxxxxxx(a),
+    b,
+    c,
+    ...
+  )
+
+let g =
+  f(
+    a =>
+      LongModuleName.functionWithAlongNameThatWrapsTheEditorToTheNextLinexxxxxxxxxxxxxxxxxxxxxx(a),
+    b,
+    c =>
+      LongModuleName.functionWithAlongNameThatWrapsTheEditorToTheNextLinexxxxxxxxxxxxxxxxxxxxxx(
+        d,
+        ...
+      ),
+    ...
+  )
+
+let g =
+  f(
+    a =>
+      LongModuleName.functionWithAlongNameThatWrapsTheEditorToTheNextLinexxxxxxxxxxxxxxxxxxxxxx(
+        a,
+        ...
+      ),
+    b,
+    c =>
+      LongModuleName.functionWithAlongNameThatWrapsTheEditorToTheNextLinexxxxxxxxxxxxxxxxxxxxxx(d),
+    ...
+  )
+
+let g = f(
+  a => LongModuleName.functionWithAlongNameThatWrapsTheEditorToTheNextLinexxxxxxxxxxxxxxxxxxxxxx(a),
+  b,
+  c =>
+    LongModuleName.functionWithAlongNameThatWrapsTheEditorToTheNextLinexxxxxxxxxxxxxxxxxxxxxx(
+      d,
+      ...
+    ),
+)


### PR DESCRIPTION
Fix #6948 