### PR TITLE
Add Dockerfile for development container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,9 @@ clean:
 
 clean-all: clean clean-gentype
 
+dev-container:
+	docker build -t rescript-dev-container docker
+
 .DEFAULT_GOAL := build
 
-.PHONY: build watch rewatch ninja bench dce test test-syntax test-syntax-roundtrip test-gentype test-all lib playground playground-cmijs playground-release artifacts format checkformat clean-gentype clean clean-all
+.PHONY: build watch rewatch ninja bench dce test test-syntax test-syntax-roundtrip test-gentype test-all lib playground playground-cmijs playground-release artifacts format checkformat clean-gentype clean clean-all dev-container

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM rust:1.80.1-bullseye
+LABEL org.opencontainers.image.authors="Christoph Knittel <ck@cca.io>"
+LABEL org.opencontainers.image.description="Docker image for ReScript development."
+
+RUN apt update && apt install -y --no-install-recommends ca-certificates curl git rsync opam musl-tools python3 python-is-python3
+
+# Node.js
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
+RUN apt install -y nodejs
+
+# OCaml
+RUN opam init -y --bare --disable-sandboxing git+https://github.com/rescript-lang/opam-repository
+RUN opam switch create 5.2.0 --packages ocaml-option-static
+RUN opam install -y dune cppo=1.6.9 js_of_ocaml-compiler=5.8.1 ocamlformat=0.26.2 ounit2=2.2.7 reanalyze=2.25.1


### PR DESCRIPTION
See #6851 - people were asking for a dev container. 

This adds a `Dockerfile` and a `Makefile` entry for building a container with all the required dependencies installed.
I am not familiar with the [Development Containers](https://containers.dev/) spec as such and leaving that to someone else.

Example usage:

```sh
make dev-container
docker run --rm -it -v `pwd`:/data -w /data rescript-dev-container bash
opam exec -- make
opam exec -- make lib
opam exec -- make test
# etc.
```