### PR TITLE
Fix formatting of external with `as` attribute and `_` placeholder

### DIFF
--- a/jscomp/syntax/src/res_parsetree_viewer.ml
+++ b/jscomp/syntax/src/res_parsetree_viewer.ml
@@ -1,13 +1,8 @@
 open Parsetree
 
 let arrow_type ?(arity = max_int) ct =
-  let has_as attrs =
+  let has_as_attr attrs =
     Ext_list.exists attrs (fun (x, _) -> x.Asttypes.txt = "as")
-  in
-  let is_any ctyp =
-    match ctyp with
-    | {ptyp_desc = Ptyp_any} -> true
-    | _ -> false
   in
   let rec process attrs_before acc typ arity =
     match typ with
@@ -32,15 +27,21 @@ let arrow_type ?(arity = max_int) ct =
     | {
      ptyp_desc = Ptyp_arrow (((Labelled _ | Optional _) as lbl), typ1, typ2);
      ptyp_attributes = attrs;
-    } -> (
-      match typ1 with
-      | {ptyp_desc = Ptyp_any; ptyp_attributes = attrs1} when has_as attrs1 ->
-        let arg = (attrs, lbl, typ1) in
-        let arity = if is_any typ2 then arity - 1 else arity in
-        process attrs_before (arg :: acc) typ2 arity
-      | _ ->
-        let arg = (attrs, lbl, typ1) in
-        process attrs_before (arg :: acc) typ2 (arity - 1))
+    } ->
+      (* Res_core.parse_es6_arrow_type has a workaround that removed an extra arity for the function if the
+         argument is a Ptyp_any with @as attribute i.e. ~x: @as(`{prop: value}`) _.
+
+         When this case is encountered we add that missing arity so the arrow is printed properly.
+      *)
+      let arity =
+        match typ1 with
+        | {ptyp_desc = Ptyp_any; ptyp_attributes = attrs1}
+          when has_as_attr attrs1 ->
+          arity
+        | _ -> arity - 1
+      in
+      let arg = (attrs, lbl, typ1) in
+      process attrs_before (arg :: acc) typ2 arity
     | typ -> (attrs_before, List.rev acc, typ)
   in
   match ct with


### PR DESCRIPTION
Fix https://github.com/rescript-lang/rescript-compiler/issues/6966

This cause of the issue had to do with how `@as` attribute is handled with external.

`external foo: (~x: int, ~y: int) => _ = ""`, `foo` has arity of 2. However, `external foo: (~x: @as(true) _, ~y: int) => _  = ""`, `foo` here has arity of 1. 

It happens here, 

https://github.com/rescript-lang/rescript-compiler/blob/897cc228d0c2e259dde1628f2d9ccd2305b8194d/jscomp/syntax/src/res_core.ml#L4324-L4338
