### PR TITLE
Fix comment removed when function signature has type keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Fix incorrect incorrect printing of module binding with signature. https://github.com/rescript-lang/rescript-compiler/pull/6963
 - Fix incorrect printing of external with `@as` attribute and `_` placholder (fixed argument). https://github.com/rescript-lang/rescript-compiler/pull/6970
 - Disallow spreading anything but regular variants inside of other variants. https://github.com/rescript-lang/rescript-compiler/pull/6980
+- Fix comment removed when function signature has `type` keyword. https://github.com/rescript-lang/rescript-compiler/pull/6997
 
 #### :house: Internal
 

--- a/jscomp/syntax/src/res_comments_table.ml
+++ b/jscomp/syntax/src/res_comments_table.ml
@@ -1452,6 +1452,8 @@ and walk_expression expr t comments =
         attach t.leading expr.pexp_loc leading;
         walk_expression expr t inside;
         attach t.trailing expr.pexp_loc trailing
+    | Pexp_construct ({txt = Longident.Lident "Function$"}, Some return_expr) ->
+      walk_expression return_expr t comments
     | _ ->
       if is_block_expr return_expr then walk_expression return_expr t comments
       else

--- a/jscomp/syntax/tests/printer/comments/expected/expr.res.txt
+++ b/jscomp/syntax/tests/printer/comments/expected/expr.res.txt
@@ -226,10 +226,10 @@ let f = (
   /* c6 */ ~x=?,
 ) => /* c7 */ ()
 
-let multiply = (type /* c-2 */ t /* c-1 */, m1 /* c1 */, /* c2 */ m2 /* c3 */) => ()
+let multiply = (type /* c-2 */ t /* c-1 */, /* c0 */ m1 /* c1 */, /* c2 */ m2 /* c3 */) => ()
 let multiply = (
   type /* c-4 */ t /* c-3 */,
-  m1 /* c1 */,
+  /* c0 */ m1 /* c1 */,
   type /* c-2 */ s /* c-1 */,
   /* c2 */ m2 /* c3 */,
 ) => ()


### PR DESCRIPTION
Fix https://github.com/rescript-lang/rescript-compiler/issues/6890