### PR TITLE
Activate stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,8 +13,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          debug-only: true # dry-run
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
           stale-issue-label: stale
-          days-before-stale: 120
+          days-before-stale: 360
           days-before-close: 7


### PR DESCRIPTION
Stale action was running in debug mode first. Activate it now so that it actually marks issues as stale.

Looking at the issues that would have been marked as stale, let's maybe be a bit more conservative now and use 360 days before stale. We can always reduce that value later.

Closes #6977.