### PR TITLE
Fix parse error on doc comment before "and" in type def

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Fix incorrect printing of external with `@as` attribute and `_` placholder (fixed argument). https://github.com/rescript-lang/rescript-compiler/pull/6970
 - Disallow spreading anything but regular variants inside of other variants. https://github.com/rescript-lang/rescript-compiler/pull/6980
 - Fix comment removed when function signature has `type` keyword. https://github.com/rescript-lang/rescript-compiler/pull/6997
+- Fix parse error on doc comment before "and" in type def. https://github.com/rescript-lang/rescript-compiler/pull/7001
 
 #### :house: Internal
 

--- a/jscomp/syntax/src/res_core.ml
+++ b/jscomp/syntax/src/res_core.ml
@@ -2511,7 +2511,7 @@ and parse_attributes_and_binding (p : Parser.t) =
   let comments = p.comments in
 
   match p.Parser.token with
-  | At -> (
+  | At | DocComment (_, _) -> (
     let attrs = parse_attributes p in
     match p.Parser.token with
     | And -> attrs

--- a/jscomp/syntax/tests/parsing/other/docComments.res
+++ b/jscomp/syntax/tests/parsing/other/docComments.res
@@ -15,3 +15,7 @@ let q = 11
   multiline doc comment
   */
 type h = int
+
+type pathItem = {}
+/** Issue 6844: doc comment before "and" */
+and operation =  {}

--- a/jscomp/syntax/tests/parsing/other/expected/docComments.res.txt
+++ b/jscomp/syntax/tests/parsing/other/expected/docComments.res.txt
@@ -5,3 +5,7 @@ let z = 34[@@res.doc " This is a doc \226\156\133 comment "]
 let q = 11[@@res.doc {js|And this is a res.doc ✅ annotation|js}]
 type nonrec h = int[@@res.doc
                      " This\n  * is a multi-line\n  multiline doc comment\n  "]
+type nonrec pathItem = {
+  }
+and operation = {
+  }[@@res.doc " Issue 6844: doc comment before \"and\" "]

--- a/jscomp/syntax/tests/printer/comments/docComments.res
+++ b/jscomp/syntax/tests/printer/comments/docComments.res
@@ -27,3 +27,7 @@ type h = int
 
 /** doc comment and 0 attributes */
 let x = 10
+
+type pathItem = {}
+/** Issue 6844: doc comment before "and" */
+and operation =  {}

--- a/jscomp/syntax/tests/printer/comments/expected/docComments.res.txt
+++ b/jscomp/syntax/tests/printer/comments/expected/docComments.res.txt
@@ -31,3 +31,6 @@ let x = 10
 
 /** doc comment and 0 attributes */
 let x = 10
+
+type pathItem = {}
+/** Issue 6844: doc comment before "and" */ and operation = {}


### PR DESCRIPTION
Fixes #6844 