### PR TITLE
Add missing HTML attribute capture to JsxDOM.res

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@
 - Deprecate `%external` extension, which has never been officially introduced. https://github.com/rescript-lang/rescript-compiler/pull/6906
 - Deprecate `xxxU` functions in Belt. https://github.com/rescript-lang/rescript-compiler/pull/6941
 - Improve error messages for function arity errors. https://github.com/rescript-lang/rescript-compiler/pull/6990
+- Add missing HTML attribute capture to JsxDOM.res. https://github.com/rescript-lang/rescript-compiler/pull/7006
 
 # 11.1.3
 

--- a/jscomp/others/jsxDOM.res
+++ b/jscomp/others/jsxDOM.res
@@ -136,6 +136,7 @@ type domProps = {
   defaultValue?: string,
   /* global html attributes */
   accessKey?: string,
+  capture?: [#user | #environment],
   className?: string /* substitute for "class" */,
   contentEditable?: bool,
   contextMenu?: string,


### PR DESCRIPTION
Adding the `capture` attribute to JsxDOM.res

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/capture