### PR TITLE
CI: fix stale action config for PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   stale:
@@ -15,5 +16,7 @@ jobs:
         with:
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
           stale-issue-label: stale
+          stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
+          stale-pr-label: stale
           days-before-stale: 360
           days-before-close: 7


### PR DESCRIPTION
The stale action also marks PRs as stale, not just issues.
I was not really able to deactivate that feature (but I think it's ok to have it).

Related configuration (permissions) was missing though, causing errors on action runs.