### PR TITLE
Fix tuple coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 # 12.0.0-alpha.4 (Unreleased)
 
+#### :bug: Bug fix
+- Fix tuple coercion. https://github.com/rescript-lang/rescript-compiler/pull/7024
+
 # 12.0.0-alpha.3
 
 #### :bug: Bug fix

--- a/jscomp/syntax/src/res_core.ml
+++ b/jscomp/syntax/src/res_core.ml
@@ -1823,6 +1823,7 @@ and parse_constrained_expr_region p =
   | token when Grammar.is_expr_start token -> (
     let expr = parse_expr p in
     match p.Parser.token with
+    | ColonGreaterThan -> Some (parse_coerced_expr ~expr p)
     | Colon ->
       Parser.next p;
       let typ = parse_typ_expr p in

--- a/jscomp/syntax/tests/parsing/grammar/expressions/coerce.res
+++ b/jscomp/syntax/tests/parsing/grammar/expressions/coerce.res
@@ -1,3 +1,11 @@
 let foo = (x:int) => (x :> int)
 
 let foo = x => (x : t :> int)
+
+let _ = (x : int)
+
+let foo = (x : int, y :> float)
+
+let foo = (x : int, y :> float, z :> int)
+
+let foo = (x : int, y, z :> int)

--- a/jscomp/syntax/tests/parsing/grammar/expressions/expected/coerce.res.txt
+++ b/jscomp/syntax/tests/parsing/grammar/expressions/expected/coerce.res.txt
@@ -1,2 +1,6 @@
 let foo = ((Function$ (fun (x : int) -> (x :> int)))[@res.arity 1])
 let foo = ((Function$ (fun x -> ((x : t) :> int)))[@res.arity 1])
+let _ = (x : int)
+let foo = ((x : int), (y :> float))
+let foo = ((x : int), (y :> float), (z :> int))
+let foo = ((x : int), y, (z :> int))


### PR DESCRIPTION
Fix https://github.com/rescript-lang/rescript-compiler/issues/7003. 

It was only handled for the first argument in the tuple. This handles for the rest of the args in the tuple.