### PR TITLE
Fix @this attribute dropping parens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 #### :bug: Bug fix
 
 - Fix tuple coercion. https://github.com/rescript-lang/rescript-compiler/pull/7024
+- Fix attribute printing. https://github.com/rescript-lang/rescript-compiler/pull/7025
 
 #### :nail_care: Polish
 

--- a/jscomp/syntax/src/res_parsetree_viewer.ml
+++ b/jscomp/syntax/src/res_parsetree_viewer.ml
@@ -1,5 +1,30 @@
 open Parsetree
 
+let attrs_string attrs =
+  List.map (fun (attr, _) -> print_endline attr.Asttypes.txt) attrs
+
+let ident_string ident =
+  match ident with
+  | Longident.Lident v -> v
+  | Longident.Ldot (_, v) -> v
+  | Longident.Lapply _ -> "Lapply"
+
+let print_ct ct =
+  match ct with
+  | {ptyp_desc = Ptyp_constr (ident, _); ptyp_attributes = attrs} ->
+    let _ =
+      print_endline
+        ("Ptyp_constr: " ^ ident_string ident.txt ^ " attrs: "
+        ^ string_of_int (List.length attrs))
+    in
+    let _ = attrs_string attrs in
+    ()
+  | {ptyp_desc = Ptyp_arrow _; ptyp_attributes = attrs} ->
+    print_endline
+      ("Ptyp_arrow: " ^ " attrs: " ^ string_of_int (List.length attrs))
+  | {ptyp_desc = Ptyp_variant _} -> print_endline "Ptyp_variant"
+  | _ -> print_endline "Something else"
+
 let arrow_type ?(arity = max_int) ct =
   let has_as_attr attrs =
     Ext_list.exists attrs (fun (x, _) -> x.Asttypes.txt = "as")

--- a/jscomp/syntax/src/res_parsetree_viewer.ml
+++ b/jscomp/syntax/src/res_parsetree_viewer.ml
@@ -1,30 +1,5 @@
 open Parsetree
 
-let attrs_string attrs =
-  List.map (fun (attr, _) -> print_endline attr.Asttypes.txt) attrs
-
-let ident_string ident =
-  match ident with
-  | Longident.Lident v -> v
-  | Longident.Ldot (_, v) -> v
-  | Longident.Lapply _ -> "Lapply"
-
-let print_ct ct =
-  match ct with
-  | {ptyp_desc = Ptyp_constr (ident, _); ptyp_attributes = attrs} ->
-    let _ =
-      print_endline
-        ("Ptyp_constr: " ^ ident_string ident.txt ^ " attrs: "
-        ^ string_of_int (List.length attrs))
-    in
-    let _ = attrs_string attrs in
-    ()
-  | {ptyp_desc = Ptyp_arrow _; ptyp_attributes = attrs} ->
-    print_endline
-      ("Ptyp_arrow: " ^ " attrs: " ^ string_of_int (List.length attrs))
-  | {ptyp_desc = Ptyp_variant _} -> print_endline "Ptyp_variant"
-  | _ -> print_endline "Something else"
-
 let arrow_type ?(arity = max_int) ?(attrs = []) ct =
   let has_as_attr attrs =
     Ext_list.exists attrs (fun (x, _) -> x.Asttypes.txt = "as")
@@ -72,7 +47,7 @@ let arrow_type ?(arity = max_int) ?(attrs = []) ct =
   match ct with
   | {ptyp_desc = Ptyp_arrow (Nolabel, _typ1, _typ2); ptyp_attributes = attrs1}
     as typ ->
-    let attrs = List.concat [attrs; attrs1] in
+    let attrs = attrs @ attrs1 in
     process attrs [] {typ with ptyp_attributes = []} arity
   | typ -> process attrs [] typ arity
 

--- a/jscomp/syntax/src/res_parsetree_viewer.ml
+++ b/jscomp/syntax/src/res_parsetree_viewer.ml
@@ -25,7 +25,7 @@ let print_ct ct =
   | {ptyp_desc = Ptyp_variant _} -> print_endline "Ptyp_variant"
   | _ -> print_endline "Something else"
 
-let arrow_type ?(arity = max_int) ct =
+let arrow_type ?(arity = max_int) ?(attrs = []) ct =
   let has_as_attr attrs =
     Ext_list.exists attrs (fun (x, _) -> x.Asttypes.txt = "as")
   in
@@ -70,10 +70,11 @@ let arrow_type ?(arity = max_int) ct =
     | typ -> (attrs_before, List.rev acc, typ)
   in
   match ct with
-  | {ptyp_desc = Ptyp_arrow (Nolabel, _typ1, _typ2); ptyp_attributes = attrs} as
-    typ ->
+  | {ptyp_desc = Ptyp_arrow (Nolabel, _typ1, _typ2); ptyp_attributes = attrs1}
+    as typ ->
+    let attrs = List.concat [attrs; attrs1] in
     process attrs [] {typ with ptyp_attributes = []} arity
-  | typ -> process [] [] typ arity
+  | typ -> process attrs [] typ arity
 
 let functor_type modtype =
   let rec process acc modtype =

--- a/jscomp/syntax/src/res_parsetree_viewer.mli
+++ b/jscomp/syntax/src/res_parsetree_viewer.mli
@@ -3,6 +3,7 @@
    * we restructure the tree into (a, b, c) and its returnType d *)
 val arrow_type :
   ?arity:int ->
+  ?attrs:Parsetree.attributes ->
   Parsetree.core_type ->
   Parsetree.attributes
   * (Parsetree.attributes * Asttypes.arg_label * Parsetree.core_type) list

--- a/jscomp/syntax/src/res_parsetree_viewer.mli
+++ b/jscomp/syntax/src/res_parsetree_viewer.mli
@@ -9,8 +9,6 @@ val arrow_type :
   * (Parsetree.attributes * Asttypes.arg_label * Parsetree.core_type) list
   * Parsetree.core_type
 
-val print_ct : Parsetree.core_type -> unit
-
 val functor_type :
   Parsetree.module_type ->
   (Parsetree.attributes * string Asttypes.loc * Parsetree.module_type option)

--- a/jscomp/syntax/src/res_parsetree_viewer.mli
+++ b/jscomp/syntax/src/res_parsetree_viewer.mli
@@ -8,6 +8,8 @@ val arrow_type :
   * (Parsetree.attributes * Asttypes.arg_label * Parsetree.core_type) list
   * Parsetree.core_type
 
+val print_ct : Parsetree.core_type -> unit
+
 val functor_type :
   Parsetree.module_type ->
   (Parsetree.attributes * string Asttypes.loc * Parsetree.module_type option)

--- a/jscomp/syntax/src/res_printer.ml
+++ b/jscomp/syntax/src/res_printer.ml
@@ -1591,17 +1591,13 @@ and print_label_declaration ~state (ld : Parsetree.label_declaration) cmt_tbl =
        ])
 
 and print_typ_expr ~(state : State.t) (typ_expr : Parsetree.core_type) cmt_tbl =
-  let parent_has_attrs =
+  let parent_attrs =
     let attrs = ParsetreeViewer.filter_parsing_attrs typ_expr.ptyp_attributes in
-    if Ast_uncurried.core_type_is_uncurried_fun typ_expr && not (attrs = [])
-    then
-      let arity, _ = Ast_uncurried.core_type_extract_uncurried_fun typ_expr in
-      arity > 0
-    else false
+    if Ast_uncurried.core_type_is_uncurried_fun typ_expr then attrs else []
   in
   let print_arrow ?(arity = max_int) typ_expr =
     let attrs_before, args, return_type =
-      ParsetreeViewer.arrow_type ~arity typ_expr
+      ParsetreeViewer.arrow_type ~arity ~attrs:parent_attrs typ_expr
     in
     let return_type_needs_parens =
       match return_type.ptyp_desc with
@@ -1634,7 +1630,7 @@ and print_typ_expr ~(state : State.t) (typ_expr : Parsetree.core_type) cmt_tbl =
            [
              Doc.group attrs;
              Doc.group
-               (if has_attrs_before || parent_has_attrs then
+               (if has_attrs_before then
                   Doc.concat
                     [
                       Doc.lparen;
@@ -1849,6 +1845,8 @@ and print_typ_expr ~(state : State.t) (typ_expr : Parsetree.core_type) cmt_tbl =
   in
   let should_print_its_own_attributes =
     match typ_expr.ptyp_desc with
+    | Ptyp_constr _ when Ast_uncurried.core_type_is_uncurried_fun typ_expr ->
+      true
     | Ptyp_arrow _ (* es6 arrow types print their own attributes *) -> true
     | _ -> false
   in

--- a/jscomp/syntax/src/res_printer.ml
+++ b/jscomp/syntax/src/res_printer.ml
@@ -1591,7 +1591,14 @@ and print_label_declaration ~state (ld : Parsetree.label_declaration) cmt_tbl =
        ])
 
 and print_typ_expr ~(state : State.t) (typ_expr : Parsetree.core_type) cmt_tbl =
-  let parent_has_attrs = Ast_uncurried.core_type_is_uncurried_fun typ_expr  && not (typ_expr.ptyp_attributes = []) in
+  let parent_has_attrs =
+    let attrs = ParsetreeViewer.filter_parsing_attrs typ_expr.ptyp_attributes in
+    if Ast_uncurried.core_type_is_uncurried_fun typ_expr && not (attrs = [])
+    then
+      let arity, _ = Ast_uncurried.core_type_extract_uncurried_fun typ_expr in
+      arity > 0
+    else false
+  in
   let print_arrow ?(arity = max_int) typ_expr =
     let attrs_before, args, return_type =
       ParsetreeViewer.arrow_type ~arity typ_expr

--- a/jscomp/syntax/src/res_printer.ml
+++ b/jscomp/syntax/src/res_printer.ml
@@ -1591,6 +1591,7 @@ and print_label_declaration ~state (ld : Parsetree.label_declaration) cmt_tbl =
        ])
 
 and print_typ_expr ~(state : State.t) (typ_expr : Parsetree.core_type) cmt_tbl =
+  let parent_has_attrs = Ast_uncurried.core_type_is_uncurried_fun typ_expr  && not (typ_expr.ptyp_attributes = []) in
   let print_arrow ?(arity = max_int) typ_expr =
     let attrs_before, args, return_type =
       ParsetreeViewer.arrow_type ~arity typ_expr
@@ -1626,7 +1627,7 @@ and print_typ_expr ~(state : State.t) (typ_expr : Parsetree.core_type) cmt_tbl =
            [
              Doc.group attrs;
              Doc.group
-               (if has_attrs_before then
+               (if has_attrs_before || parent_has_attrs then
                   Doc.concat
                     [
                       Doc.lparen;

--- a/jscomp/syntax/tests/printer/typexpr/expected/arrow.res.txt
+++ b/jscomp/syntax/tests/printer/typexpr/expected/arrow.res.txt
@@ -125,13 +125,13 @@ type t = (
 type t = (@attr string, @attr float) => unit
 type t = (@attr @attr2 string, @attr @attr2 float, @attr3 int) => unit
 
-type t = @attr string => unit
+type t = @attr (string => unit)
 type t = @attr (foo, bar, baz) => unit
 type t = @attr (foo, @attr2 ~f: bar, @attr3 ~f: baz) => unit
 
-type t = @attr string => @attr int => unit
+type t = @attr (string => @attr (int => unit))
 type t = @attr (string, int) => @attr (int, float) => unit
-type t = @attr int => @attr (int, float) => @attr unit => unit => unit
+type t = @attr (int => @attr (int, float) => @attr (unit => unit => unit))
 type t = @attr (@attr2 ~f: int, @attr3 ~g: float) => unit
 
 type f = (
@@ -144,50 +144,50 @@ type f = (
   @attr3 ~h: ccccrazysldkfjslkdjflksdjkf=?,
 ) => unit
 
-type t = @attr
-stringWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong => @attr2
-floatWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong => @attr3
-intWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong => unitWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong
+type t = @attr (
+  stringWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong => @attr2 (
+    floatWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong => @attr3 (
+      intWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong => unitWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong
+    )
+  )
+)
 
-type t = @attr
-(
+type t = @attr (
   fooWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong,
   barWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong,
   bazWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong,
-) => @attr2
-(
+) => @attr2 (
   stringWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong,
   floatWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong,
 ) => unit
 
 type t = @attr
 @attrWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong
-@attrWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong
-(
+@attrWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong (
   fooWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong,
   barWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong,
   bazWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong,
 ) => @attr2
 @attrWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong
-@attrWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong
-(
+@attrWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong (
   stringWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong,
   floatWithSuperLongIdentifierNameLoooooooooooooooooooooooooooooooooooooooooooooong,
 ) => unit
 
 external debounce: (int, @meth unit) => unit = "debounce"
 
-external debounce: int => @meth unit => unit = "debounce"
+external debounce: int => @meth (unit => unit) = "debounce"
 
-external debounce: (int, @meth unit => unit) => @meth unit => unit = "debounce"
+external debounce: (int, @meth (unit => unit)) => @meth (unit => unit) = "debounce"
 
-external debounce: (int, @meth unit => unit, @meth unit => unit) => @meth unit => unit = "debounce"
+external debounce: (int, @meth (unit => unit), @meth (unit => unit)) => @meth (unit => unit) =
+  "debounce"
 
 external debounce: (
   int,
-  @meth unit => unit,
-  @meth unit => @meth unit => unit,
-) => @meth unit => unit = "debounce"
+  @meth (unit => unit),
+  @meth (unit => @meth (unit => unit)),
+) => @meth (unit => unit) = "debounce"
 
 type returnTyp = (int, int) => @magic float
 type returnTyp = (
@@ -214,7 +214,7 @@ type t = (@attrOnInt int, @attrOnInt int, @attrOnInt int, @attrOnInt int) => int
 type t = (@attr ~x: int, ~y: int, @attr ~z: int, @attr ~omega: int) => unit
 
 @val external requestAnimationFrame: (float => unit) => unit = "requestAnimationFrame"
-@val external requestAnimationFrame: @attr (float => unit) => unit = "requestAnimationFrame"
+@val external requestAnimationFrame: @attr ((float => unit) => unit) = "requestAnimationFrame"
 
 type arrows = (int, (float => unit) => unit, float) => unit
 

--- a/jscomp/test/reasonReact.res
+++ b/jscomp/test/reasonReact.res
@@ -117,8 +117,7 @@ and oldNewSelf<'state, 'retainedProps, 'action> = {
 type rec jsComponentThis<'state, 'props, 'retainedProps, 'action> = {
   "state": totalState<'state, 'retainedProps, 'action>,
   "props": {"reasonProps": 'props},
-  "setState": @meth
-  (
+  "setState": @meth (
     (
       totalState<'state, 'retainedProps, 'action>,
       'props,


### PR DESCRIPTION
Fix https://github.com/rescript-lang/rescript-compiler/issues/6638

@cknitt Can you look at the diff output for the test and see whether they are acceptable in terms of formatting changes? They look okay to me. https://github.com/rescript-lang/rescript-compiler/pull/7025/files#diff-2333e082552a974a4c2fc20db5dbd0415ae96a46b675d967a6d9804f7497ad08

I've checked all the attributes we have here (https://rescript-lang.org/syntax-lookup) and there are only a few that is at field level (e.g. `@as`, `@this`, etc).

I had worked on this during the retreat but Max preferred not to hard code attribute value for the check, so this PR try to generalize the check without checking for specific attribute. (Prev PR: https://github.com/rescript-lang/rescript-compiler/pull/6773).