### PR TITLE
Improve error messages for pattern matching mismatches for options/concrete values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 #### :nail_care: Polish
 
+- Improve error messages for pattern matching on option vs non-option, and vice versa. https://github.com/rescript-lang/rescript-compiler/pull/7035
 - Improve bigint literal comparison. https://github.com/rescript-lang/rescript-compiler/pull/7029
 - Improve output of `@variadic` bindings. https://github.com/rescript-lang/rescript-compiler/pull/7030
 

--- a/jscomp/build_tests/super_errors/expected/pattern_matching_on_option_but_value_not_option.res.expected
+++ b/jscomp/build_tests/super_errors/expected/pattern_matching_on_option_but_value_not_option.res.expected
@@ -1,0 +1,15 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/pattern_matching_on_option_but_value_not_option.res[0m:[2m4:3-9[0m
+
+  2 [2m│[0m 
+  3 [2m│[0m switch x {
+  [1;31m4[0m [2m│[0m | [1;31mSome(1)[0m => ()
+  5 [2m│[0m }
+  6 [2m│[0m 
+
+  This pattern matches values of type [1;31moption<'a>[0m
+  but a pattern was expected which matches values of type [1;33mint[0m
+  
+  You're expecting the value you're pattern matching on to be an [1;33moption[0m, but the value is actually not an option.
+  Change your pattern match to work on the concrete value (remove [1;31mSome(_)[0m or [1;31mNone[0m from the pattern) to make it work.

--- a/jscomp/build_tests/super_errors/expected/pattern_matching_on_value_but_is_option.res.expected
+++ b/jscomp/build_tests/super_errors/expected/pattern_matching_on_value_but_is_option.res.expected
@@ -1,0 +1,15 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/pattern_matching_on_value_but_is_option.res[0m:[2m4:3[0m
+
+  2 [2m│[0m 
+  3 [2m│[0m switch x {
+  [1;31m4[0m [2m│[0m | [1;31m1[0m => ()
+  5 [2m│[0m }
+  6 [2m│[0m 
+
+  This pattern matches values of type [1;31mint[0m
+  but a pattern was expected which matches values of type [1;33moption<int>[0m
+  
+  The value you're pattern matching on here is wrapped in an [1;33moption[0m, but you're trying to match on the actual value.
+  Wrap the highlighted pattern in [1;33mSome()[0m to make it work.

--- a/jscomp/build_tests/super_errors/fixtures/pattern_matching_on_option_but_value_not_option.res
+++ b/jscomp/build_tests/super_errors/fixtures/pattern_matching_on_option_but_value_not_option.res
@@ -1,0 +1,5 @@
+let x = 1
+
+switch x {
+| Some(1) => ()
+}

--- a/jscomp/build_tests/super_errors/fixtures/pattern_matching_on_value_but_is_option.res
+++ b/jscomp/build_tests/super_errors/fixtures/pattern_matching_on_value_but_is_option.res
@@ -1,0 +1,5 @@
+let x = Some(1)
+
+switch x {
+| 1 => ()
+}

--- a/jscomp/ml/printtyp.ml
+++ b/jscomp/ml/printtyp.ml
@@ -1471,7 +1471,7 @@ let super_trace ppf =
     | _ -> ()
   in super_trace true ppf
 
-let super_unification_error unif tr txt1 ppf txt2 = begin
+let super_unification_error ?print_extra_info unif tr txt1 ppf txt2 = begin
   reset ();
   trace_same_names tr;
   let tr = List.map (fun (t, t') -> (t, hide_variant_name t')) tr in
@@ -1490,18 +1490,20 @@ let super_unification_error unif tr txt1 ppf txt2 = begin
           @[<hov 2>%t@ %a@]\
           %a\
           %t\
+          %t\
         @]"
         txt1 (super_type_expansion ~tag:"error" t1) t1'
         txt2 (super_type_expansion ~tag:"info" t2) t2'
         super_trace tr
-        (explanation unif mis);
+        (explanation unif mis)
+        (fun ppf -> match print_extra_info with | None -> () | Some f -> f ppf t1 t2);
     with exn ->
       raise exn
 end
 
-let super_report_unification_error ppf env ?(unif=true)
+let super_report_unification_error ?print_extra_info ppf env ?(unif=true)
     tr txt1 txt2 =
-  wrap_printing_env env (fun () -> super_unification_error unif tr txt1 ppf txt2)
+  wrap_printing_env env (fun () -> super_unification_error ?print_extra_info unif tr txt1 ppf txt2)
 ;;
 
 

--- a/jscomp/ml/printtyp.mli
+++ b/jscomp/ml/printtyp.mli
@@ -75,6 +75,7 @@ val report_unification_error:
 
 
 val super_report_unification_error:
+    ?print_extra_info:(formatter -> type_expr -> type_expr -> unit) ->
     formatter -> Env.t -> ?unif:bool -> (type_expr * type_expr) list ->
     (formatter -> unit) -> (formatter -> unit) ->
     unit

--- a/jscomp/ml/typecore.ml
+++ b/jscomp/ml/typecore.ml
@@ -3771,6 +3771,7 @@ let report_error env ppf = function
   | Pattern_type_clash trace ->
     (* modified *)
     super_report_unification_error ppf env trace
+      ~print_extra_info:Error_message_utils.print_contextual_unification_error
       (function ppf ->
          fprintf ppf "This pattern matches values of type")
       (function ppf ->


### PR DESCRIPTION
This expands error messages when matching on options/non-options or non-options/options to better explain what's going wrong, and how you can solve it.

![image](https://github.com/user-attachments/assets/2b564bba-c91d-4e28-83d4-9e23b3b9d04b)
![image](https://github.com/user-attachments/assets/6b1f8322-e74d-40d0-b66f-f4aeac159209)


Part of https://github.com/rescript-lang/rescript-compiler/issues/6975