### PR TITLE
JSX component error message improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Improve error messages for pattern matching on option vs non-option, and vice versa. https://github.com/rescript-lang/rescript-compiler/pull/7035
 - Improve bigint literal comparison. https://github.com/rescript-lang/rescript-compiler/pull/7029
 - Improve output of `@variadic` bindings. https://github.com/rescript-lang/rescript-compiler/pull/7030
+- Improve error messages around JSX components. https://github.com/rescript-lang/rescript-compiler/pull/7038
 
 # 12.0.0-alpha.3
 

--- a/jscomp/build_tests/super_errors/expected/component_invalid_prop.res.expected
+++ b/jscomp/build_tests/super_errors/expected/component_invalid_prop.res.expected
@@ -1,0 +1,11 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/component_invalid_prop.res[0m:[2m7:5-8[0m
+
+  5 [2m│[0m 
+  6 [2m│[0m   let make = (): props<'name> => {
+  [1;31m7[0m [2m│[0m     [1;31mtest[0m: false,
+  8 [2m│[0m   }
+  9 [2m│[0m }
+
+  The prop [1;31mtest[0m does not belong to the JSX component

--- a/jscomp/build_tests/super_errors/expected/component_missing_prop.res.expected
+++ b/jscomp/build_tests/super_errors/expected/component_missing_prop.res.expected
@@ -1,12 +1,12 @@
 
   [1;31mWe've found a bug for you![0m
-  [36m/.../fixtures/component_missing_prop.res[0m:[2m5:34-35[0m
+  [36m/.../fixtures/component_missing_prop.res[0m:[2m6:34-35[0m
 
-  3 [2m│[0m   type props<'name> = {name: 'name}
-  4 [2m│[0m 
-  [1;31m5[0m [2m│[0m   let make = (): props<'name> => [1;31m{}[0m
-  6 [2m│[0m }
-  7 [2m│[0m 
+  4 [2m│[0m   type props<'name> = {name: 'name}
+  5 [2m│[0m 
+  [1;31m6[0m [2m│[0m   let make = (): props<'name> => [1;31m{}[0m
+  7 [2m│[0m }
+  8 [2m│[0m 
 
-  Some required record fields are missing:
-  name. If this is a component, add the missing props.
+  The component is missing these required props:
+   name

--- a/jscomp/build_tests/super_errors/expected/component_prop_passed_multiple_times.res.expected
+++ b/jscomp/build_tests/super_errors/expected/component_prop_passed_multiple_times.res.expected
@@ -1,10 +1,10 @@
 
   [1;31mWe've found a bug for you![0m
-  [36m/.../fixtures/component_prop_passed_multiple_times.res[0m:[2m8:11-17[0m
+  [36m/.../fixtures/component_prop_passed_multiple_times.res[0m:[2m8:5-8[0m
 
    6 [2m│[0m   let make = (): props<'name> => {
    7 [2m│[0m     name: "hello",
-   [1;31m8[0m [2m│[0m     name: [1;31m"world"[0m,
+   [1;31m8[0m [2m│[0m     [1;31mname[0m: "world",
    9 [2m│[0m   }
   10 [2m│[0m }
 

--- a/jscomp/build_tests/super_errors/expected/component_prop_passed_multiple_times.res.expected
+++ b/jscomp/build_tests/super_errors/expected/component_prop_passed_multiple_times.res.expected
@@ -1,0 +1,14 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/component_prop_passed_multiple_times.res[0m:[2m6:34-9:3[0m
+
+   4 [2m│[0m   type props<'name> = {name: 'name}
+   5 [2m│[0m 
+   [1;31m6[0m [2m│[0m   let make = (): props<'name> => [1;31m{[0m
+   [1;31m7[0m [2m│[0m [1;31m    name: "hello",[0m
+   [1;31m8[0m [2m│[0m [1;31m    name: "world",[0m
+   [1;31m9[0m [2m│[0m [1;31m  }[0m
+  10 [2m│[0m }
+  11 [2m│[0m 
+
+  The prop [1;33mname[0m is passed several times to the component

--- a/jscomp/build_tests/super_errors/expected/component_prop_passed_multiple_times.res.expected
+++ b/jscomp/build_tests/super_errors/expected/component_prop_passed_multiple_times.res.expected
@@ -1,14 +1,12 @@
 
   [1;31mWe've found a bug for you![0m
-  [36m/.../fixtures/component_prop_passed_multiple_times.res[0m:[2m6:34-9:3[0m
+  [36m/.../fixtures/component_prop_passed_multiple_times.res[0m:[2m8:11-17[0m
 
-   4 [2m│[0m   type props<'name> = {name: 'name}
-   5 [2m│[0m 
-   [1;31m6[0m [2m│[0m   let make = (): props<'name> => [1;31m{[0m
-   [1;31m7[0m [2m│[0m [1;31m    name: "hello",[0m
-   [1;31m8[0m [2m│[0m [1;31m    name: "world",[0m
-   [1;31m9[0m [2m│[0m [1;31m  }[0m
+   6 [2m│[0m   let make = (): props<'name> => {
+   7 [2m│[0m     name: "hello",
+   [1;31m8[0m [2m│[0m     name: [1;31m"world"[0m,
+   9 [2m│[0m   }
   10 [2m│[0m }
-  11 [2m│[0m 
 
-  The prop [1;33mname[0m is passed several times to the component
+  The prop [1;33mname[0m has already been passed to the component 
+You can't pass the same prop more than once.

--- a/jscomp/build_tests/super_errors/fixtures/component_invalid_prop.res
+++ b/jscomp/build_tests/super_errors/fixtures/component_invalid_prop.res
@@ -1,0 +1,9 @@
+// Since the React transform isn't active in the tests, mimic what the transform outputs.
+module Component = {
+  @res.jsxComponentProps
+  type props<'name> = {name: 'name}
+
+  let make = (): props<'name> => {
+    test: false,
+  }
+}

--- a/jscomp/build_tests/super_errors/fixtures/component_missing_prop.res
+++ b/jscomp/build_tests/super_errors/fixtures/component_missing_prop.res
@@ -1,5 +1,6 @@
 // Since the React transform isn't active in the tests, mimic what the transform outputs.
 module Component = {
+  @res.jsxComponentProps
   type props<'name> = {name: 'name}
 
   let make = (): props<'name> => {}

--- a/jscomp/build_tests/super_errors/fixtures/component_prop_passed_multiple_times.res
+++ b/jscomp/build_tests/super_errors/fixtures/component_prop_passed_multiple_times.res
@@ -1,0 +1,10 @@
+// Since the React transform isn't active in the tests, mimic what the transform outputs.
+module Component = {
+  @res.jsxComponentProps
+  type props<'name> = {name: 'name}
+
+  let make = (): props<'name> => {
+    name: "hello",
+    name: "world",
+  }
+}

--- a/jscomp/ml/error_message_utils.ml
+++ b/jscomp/ml/error_message_utils.ml
@@ -288,3 +288,9 @@ let print_component_labels_missing_error ppf labels
   fprintf ppf "is missing these required props:@\n";
   labels |> List.iter (fun lbl -> fprintf ppf "@ %s" lbl);
   fprintf ppf "@]"
+
+let get_jsx_component_error_info ~extract_concrete_typedecl opath env ty_record () =
+  match opath with
+  | Some (p, _) ->
+    get_jsx_component_props ~extract_concrete_typedecl env ty_record p
+  | None -> None

--- a/jscomp/ml/error_message_utils.ml
+++ b/jscomp/ml/error_message_utils.ml
@@ -1,3 +1,6 @@
+type extract_concrete_typedecl =
+  Env.t -> Types.type_expr -> Path.t * Path.t * Types.type_declaration
+
 type type_clash_statement = FunctionCall
 type type_clash_context =
   | SetRecordField
@@ -237,3 +240,31 @@ let print_contextual_unification_error ppf t1 t2 =
         @{<info>option@}, but you're trying to match on the actual value.@ Wrap \
         the highlighted pattern in @{<info>Some()@} to make it work.@]"
   | _ -> ()
+
+let get_jsx_component_props
+    ~(extract_concrete_typedecl : extract_concrete_typedecl) env ty p =
+  match Path.last p with
+  | "props" -> (
+    try
+      match extract_concrete_typedecl env ty with
+      | ( _p0,
+          _p,
+          {Types.type_kind = Type_record (fields, _repr); type_attributes} )
+        when type_attributes
+            |> List.exists (fun ({Location.txt}, _) ->
+                    txt = "res.jsxComponentProps") ->
+        Some fields
+      | _ -> None
+    with _ -> None)
+  | _ -> None
+
+let print_component_wrong_prop_error ppf (p : Path.t)
+    (_fields : Types.label_declaration list) name =
+  fprintf ppf "@[<v>";
+  fprintf ppf "@[<2>The prop @{<error>%s@} does not belong to the JSX component"
+    name;
+  (match p |> Path.name |> String.split_on_char '.' |> List.rev with
+  | "props" :: component_name :: _ ->
+    fprintf ppf " @{<info><%s />@}" component_name
+  | _ -> ());
+  fprintf ppf "@]@,@,"

--- a/jscomp/ml/error_message_utils.ml
+++ b/jscomp/ml/error_message_utils.ml
@@ -246,6 +246,10 @@ type jsx_prop_error_info = {
   props_record_path: Path.t;
 }
 
+let attributes_include_jsx_component_props (attrs : Parsetree.attributes) =
+  attrs
+  |> List.exists (fun ({Location.txt}, _) -> txt = "res.jsxComponentProps")
+
 let path_to_jsx_component_name p =
   match p |> Path.name |> String.split_on_char '.' |> List.rev with
   | "props" :: component_name :: _ -> Some component_name
@@ -260,9 +264,7 @@ let get_jsx_component_props
       | ( _p0,
           _p,
           {Types.type_kind = Type_record (fields, _repr); type_attributes} )
-        when type_attributes
-              |> List.exists (fun ({Location.txt}, _) ->
-                    txt = "res.jsxComponentProps") ->
+        when attributes_include_jsx_component_props type_attributes ->
         Some {props_record_path = p; fields}
       | _ -> None
     with _ -> None)

--- a/jscomp/ml/error_message_utils.ml
+++ b/jscomp/ml/error_message_utils.ml
@@ -241,6 +241,16 @@ let print_contextual_unification_error ppf t1 t2 =
         the highlighted pattern in @{<info>Some()@} to make it work.@]"
   | _ -> ()
 
+type jsx_prop_error_info = {
+  fields: Types.label_declaration list;
+  props_record_path: Path.t;
+}
+
+let path_to_jsx_component_name p =
+  match p |> Path.name |> String.split_on_char '.' |> List.rev with
+  | "props" :: component_name :: _ -> Some component_name
+  | _ -> None
+
 let get_jsx_component_props
     ~(extract_concrete_typedecl : extract_concrete_typedecl) env ty p =
   match Path.last p with
@@ -251,20 +261,30 @@ let get_jsx_component_props
           _p,
           {Types.type_kind = Type_record (fields, _repr); type_attributes} )
         when type_attributes
-            |> List.exists (fun ({Location.txt}, _) ->
+              |> List.exists (fun ({Location.txt}, _) ->
                     txt = "res.jsxComponentProps") ->
-        Some fields
+        Some {props_record_path = p; fields}
       | _ -> None
     with _ -> None)
   | _ -> None
 
+let print_component_name ppf (p : Path.t) =
+  match path_to_jsx_component_name p with
+  | Some component_name -> fprintf ppf "@{<info><%s />@} " component_name
+  | None -> ()
+
 let print_component_wrong_prop_error ppf (p : Path.t)
     (_fields : Types.label_declaration list) name =
   fprintf ppf "@[<v>";
-  fprintf ppf "@[<2>The prop @{<error>%s@} does not belong to the JSX component"
-    name;
-  (match p |> Path.name |> String.split_on_char '.' |> List.rev with
-  | "props" :: component_name :: _ ->
-    fprintf ppf " @{<info><%s />@}" component_name
-  | _ -> ());
+  fprintf ppf
+    "@[<2>The prop @{<error>%s@} does not belong to the JSX component " name;
+  print_component_name ppf p;
   fprintf ppf "@]@,@,"
+
+let print_component_labels_missing_error ppf labels
+    (error_info : jsx_prop_error_info) =
+  fprintf ppf "@[<hov>The component ";
+  print_component_name ppf error_info.props_record_path;
+  fprintf ppf "is missing these required props:@\n";
+  labels |> List.iter (fun lbl -> fprintf ppf "@ %s" lbl);
+  fprintf ppf "@]"

--- a/jscomp/ml/typecore.ml
+++ b/jscomp/ml/typecore.ml
@@ -963,12 +963,12 @@ let type_label_a_list ?labels loc closed env type_lbl_a opath lid_a_list k =
 let check_recordpat_labels ~get_jsx_component_error_info loc lbl_pat_list closed =
   match lbl_pat_list with
   | [] -> ()                            (* should not happen *)
-  | (_, label1, _) :: _ ->
+  | (_, label1, (tpat: Typedtree.pattern)) :: _ ->
       let all = label1.lbl_all in
       let defined = Array.make (Array.length all) false in
       let check_defined (_, label, _) =
         if defined.(label.lbl_pos)
-        then raise(Error(loc, Env.empty, Label_multiply_defined {
+        then raise(Error(tpat.pat_loc, Env.empty, Label_multiply_defined {
           label = label.lbl_name; 
           jsx_component_info = get_jsx_component_error_info ();
         }))
@@ -1902,8 +1902,8 @@ let duplicate_ident_types caselist env =
 (* note: check_duplicates would better be implemented in
          type_label_a_list directly *)  
 let rec check_duplicates ~get_jsx_component_error_info loc env = function
-  | (_, lbl1, _) :: (_, lbl2, _) :: _ when lbl1.lbl_pos = lbl2.lbl_pos ->
-    raise(Error(loc, env, Label_multiply_defined {
+  | (_, lbl1, _) :: (_, lbl2, (texp: Typedtree.expression)) :: _ when lbl1.lbl_pos = lbl2.lbl_pos ->
+    raise(Error(texp.exp_loc, env, Label_multiply_defined {
       label = lbl1.lbl_name; 
       jsx_component_info = get_jsx_component_error_info();
       }))
@@ -3858,8 +3858,9 @@ let report_error env ppf = function
           This argument cannot be applied %a@]"
         type_expr ty print_label l
   | Label_multiply_defined {label; jsx_component_info = Some jsx_component_info} ->
-      fprintf ppf "The prop @{<info>%s@} is passed several times to the component " label;
+      fprintf ppf "The prop @{<info>%s@} has already been passed to the component " label;
       print_component_name ppf jsx_component_info.props_record_path;
+      fprintf ppf "@,@,You can't pass the same prop more than once.";
   | Label_multiply_defined {label} ->
     fprintf ppf "The record field label %s is defined several times" label
   | Labels_missing {labels; jsx_component_info = Some jsx_component_info} ->

--- a/jscomp/ml/typecore.ml
+++ b/jscomp/ml/typecore.ml
@@ -963,12 +963,12 @@ let type_label_a_list ?labels loc closed env type_lbl_a opath lid_a_list k =
 let check_recordpat_labels ~get_jsx_component_error_info loc lbl_pat_list closed =
   match lbl_pat_list with
   | [] -> ()                            (* should not happen *)
-  | (_, label1, (tpat: Typedtree.pattern)) :: _ ->
+  | ((l: Longident.t loc), label1, _) :: _ ->
       let all = label1.lbl_all in
       let defined = Array.make (Array.length all) false in
       let check_defined (_, label, _) =
         if defined.(label.lbl_pos)
-        then raise(Error(tpat.pat_loc, Env.empty, Label_multiply_defined {
+        then raise(Error(l.loc, Env.empty, Label_multiply_defined {
           label = label.lbl_name; 
           jsx_component_info = get_jsx_component_error_info ();
         }))
@@ -1902,8 +1902,8 @@ let duplicate_ident_types caselist env =
 (* note: check_duplicates would better be implemented in
          type_label_a_list directly *)  
 let rec check_duplicates ~get_jsx_component_error_info loc env = function
-  | (_, lbl1, _) :: (_, lbl2, (texp: Typedtree.expression)) :: _ when lbl1.lbl_pos = lbl2.lbl_pos ->
-    raise(Error(texp.exp_loc, env, Label_multiply_defined {
+  | (_, lbl1, _) :: ((l: Longident.t loc), lbl2, _) :: _ when lbl1.lbl_pos = lbl2.lbl_pos ->
+    raise(Error(l.loc, env, Label_multiply_defined {
       label = lbl1.lbl_name; 
       jsx_component_info = get_jsx_component_error_info();
       }))

--- a/jscomp/ml/typecore.ml
+++ b/jscomp/ml/typecore.ml
@@ -3857,6 +3857,9 @@ let report_error env ppf = function
   | Label_not_mutable lid ->
       fprintf ppf "The record field %a is not mutable" longident lid
   | Wrong_name (eorp, ty, kind, p, name, valid_names) ->
+    (match get_jsx_component_props ~extract_concrete_typedecl env ty p with 
+    | Some fields -> print_component_wrong_prop_error ppf p fields name; spellcheck ppf name valid_names;
+    | None ->
     (* modified *)
     if Path.is_constructor_typath p then begin
       fprintf ppf "@[The field %s is not part of the record \
@@ -3876,6 +3879,7 @@ let report_error env ppf = function
       fprintf ppf "@]";      
     end;
     spellcheck ppf name valid_names;
+  )
   | Name_type_mismatch (kind, lid, tp, tpl) ->
       let name = label_of_kind kind in
       report_ambiguous_type_error ppf env tp tpl

--- a/jscomp/ml/typecore.mli
+++ b/jscomp/ml/typecore.mli
@@ -70,7 +70,7 @@ type error =
   | Apply_non_function of type_expr
   | Apply_wrong_label of arg_label * type_expr
   | Label_multiply_defined of string
-  | Labels_missing of string list * bool
+  | Labels_missing of {labels: string list; jsx_component_info: Error_message_utils.jsx_prop_error_info option}
   | Label_not_mutable of Longident.t
   | Wrong_name of string * type_expr * string * Path.t * string * string list
   | Name_type_mismatch of

--- a/jscomp/ml/typecore.mli
+++ b/jscomp/ml/typecore.mli
@@ -69,7 +69,7 @@ type error =
   | Expr_type_clash of (type_expr * type_expr) list * (Error_message_utils.type_clash_context option)
   | Apply_non_function of type_expr
   | Apply_wrong_label of arg_label * type_expr
-  | Label_multiply_defined of string
+  | Label_multiply_defined of {label: string; jsx_component_info: Error_message_utils.jsx_prop_error_info option}
   | Labels_missing of {labels: string list; jsx_component_info: Error_message_utils.jsx_prop_error_info option}
   | Label_not_mutable of Longident.t
   | Wrong_name of string * type_expr * string * Path.t * string * string list

--- a/jscomp/syntax/src/jsx_v4.ml
+++ b/jscomp/syntax/src/jsx_v4.ml
@@ -310,7 +310,8 @@ let make_label_decls named_type_list =
     | hd :: tl ->
       if mem_label hd tl then
         let _, label, _, loc, _ = hd in
-        Jsx_common.raise_error ~loc "JSX: found the duplicated prop `%s`" label
+        Jsx_common.raise_error ~loc
+          "The prop `%s` is defined several times in this component." label
       else check_duplicated_label tl
   in
   let () = named_type_list |> List.rev |> check_duplicated_label in

--- a/jscomp/syntax/src/jsx_v4.ml
+++ b/jscomp/syntax/src/jsx_v4.ml
@@ -367,7 +367,10 @@ let make_props_record_type ~core_type_of_attr ~external_ ~typ_vars_of_core_type
 (* type props<'x, 'y, ...> = { x: 'x, y?: 'y, ... } *)
 let make_props_record_type_sig ~core_type_of_attr ~external_
     ~typ_vars_of_core_type props_name loc named_type_list =
-  let attrs = if external_ then [live_attr] else [] in
+  let attrs =
+    if external_ then [jsx_component_props_attr; live_attr]
+    else [jsx_component_props_attr]
+  in
   Sig.type_ Nonrecursive
     (match core_type_of_attr with
     | None -> make_type_decls ~attrs props_name loc named_type_list

--- a/jscomp/syntax/src/jsx_v4.ml
+++ b/jscomp/syntax/src/jsx_v4.ml
@@ -347,11 +347,16 @@ let make_type_decls_with_core_type props_name loc core_type typ_vars =
   ]
 
 let live_attr = ({txt = "live"; loc = Location.none}, PStr [])
+let jsx_component_props_attr =
+  ({txt = "res.jsxComponentProps"; loc = Location.none}, PStr [])
 
 (* type props<'x, 'y, ...> = { x: 'x, y?: 'y, ... } *)
 let make_props_record_type ~core_type_of_attr ~external_ ~typ_vars_of_core_type
     props_name loc named_type_list =
-  let attrs = if external_ then [live_attr] else [] in
+  let attrs =
+    if external_ then [jsx_component_props_attr; live_attr]
+    else [jsx_component_props_attr]
+  in
   Str.type_ Nonrecursive
     (match core_type_of_attr with
     | None -> make_type_decls ~attrs props_name loc named_type_list

--- a/jscomp/syntax/tests/ppx/react/expected/aliasProps.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/aliasProps.res.txt
@@ -1,6 +1,7 @@
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module C0 = {
+  @res.jsxComponentProps
   type props<'priority, 'text> = {priority: 'priority, text?: 'text}
 
   let make = ({priority: _, text: ?__text, _}: props<_, _>) => {
@@ -19,6 +20,7 @@ module C0 = {
 }
 
 module C1 = {
+  @res.jsxComponentProps
   type props<'priority, 'text> = {priority: 'priority, text?: 'text}
 
   let make = ({priority: p, text: ?__text, _}: props<_, _>) => {
@@ -37,6 +39,7 @@ module C1 = {
 }
 
 module C2 = {
+  @res.jsxComponentProps
   type props<'foo> = {foo?: 'foo}
 
   let make = ({foo: ?__bar, _}: props<_>) => {
@@ -55,6 +58,7 @@ module C2 = {
 }
 
 module C3 = {
+  @res.jsxComponentProps
   type props<'foo, 'a, 'b> = {foo?: 'foo, a?: 'a, b: 'b}
 
   let make = ({foo: ?__bar, a: ?__a, b, _}: props<_, _, _>) => {
@@ -79,6 +83,7 @@ module C3 = {
 }
 
 module C4 = {
+  @res.jsxComponentProps
   type props<'a, 'x> = {a: 'a, x?: 'x}
 
   let make = ({a: b, x: ?__x, _}: props<_, _>) => {
@@ -97,6 +102,7 @@ module C4 = {
 }
 
 module C5 = {
+  @res.jsxComponentProps
   type props<'a, 'z> = {a: 'a, z?: 'z}
 
   let make = ({a: (x, y), z: ?__z, _}: props<_, _>) => {
@@ -116,10 +122,12 @@ module C5 = {
 
 module C6 = {
   module type Comp = {
+    @res.jsxComponentProps
     type props = {}
 
     let make: React.componentLike<props, React.element>
   }
+  @res.jsxComponentProps
   type props<'comp, 'x> = {comp: 'comp, x: 'x}
 
   let make = ({comp: module(Comp: Comp), x: (a, b), _}: props<_, _>) => React.jsx(Comp.make, {})

--- a/jscomp/syntax/tests/ppx/react/expected/asyncAwait.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/asyncAwait.res.txt
@@ -1,6 +1,7 @@
 let f = a => Js.Promise.resolve(a + a)
 
 module C0 = {
+  @res.jsxComponentProps
   type props<'a> = {a: 'a}
 
   let make = async ({a, _}: props<_>) => {
@@ -15,6 +16,7 @@ module C0 = {
 }
 
 module C1 = {
+  @res.jsxComponentProps
   type props<'status> = {status: 'status}
 
   let make = async ({status, _}: props<_>) => {

--- a/jscomp/syntax/tests/ppx/react/expected/commentAtTop.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/commentAtTop.res.txt
@@ -1,3 +1,4 @@
+@res.jsxComponentProps
 type props<'msg> = {msg: 'msg} // test React JSX file
 
 let make = ({msg, _}: props<_>) => {

--- a/jscomp/syntax/tests/ppx/react/expected/defaultValueProp.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/defaultValueProp.res.txt
@@ -1,4 +1,5 @@
 module C0 = {
+  @res.jsxComponentProps
   type props<'a, 'b> = {a?: 'a, b?: 'b}
   let make = ({a: ?__a, b: ?__b, _}: props<_, _>) => {
     let a = switch __a {
@@ -19,6 +20,7 @@ module C0 = {
 }
 
 module C1 = {
+  @res.jsxComponentProps
   type props<'a, 'b> = {a?: 'a, b: 'b}
 
   let make = ({a: ?__a, b, _}: props<_, _>) => {
@@ -38,6 +40,7 @@ module C1 = {
 
 module C2 = {
   let a = "foo"
+  @res.jsxComponentProps
   type props<'a> = {a?: 'a}
 
   let make = ({a: ?__a, _}: props<_>) => {
@@ -56,6 +59,7 @@ module C2 = {
 }
 
 module C3 = {
+  @res.jsxComponentProps
   type props<'disabled> = {disabled?: 'disabled}
 
   let make = ({disabled: ?__everythingDisabled, _}: props<bool>) => {

--- a/jscomp/syntax/tests/ppx/react/expected/externalWithCustomName.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/externalWithCustomName.res.txt
@@ -13,7 +13,7 @@ let t = React.createElement(Foo.component, Foo.componentProps(~a=1, ~b={"1"}, ()
 @@jsxConfig({version: 4, mode: "classic"})
 
 module Foo = {
-  @live
+  @res.jsxComponentProps @live
   type props<'a, 'b> = {a: 'a, b: 'b}
 
   @module("Foo")
@@ -25,7 +25,7 @@ let t = React.createElement(Foo.component, {a: 1, b: "1"})
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module Foo = {
-  @live
+  @res.jsxComponentProps @live
   type props<'a, 'b> = {a: 'a, b: 'b}
 
   @module("Foo")

--- a/jscomp/syntax/tests/ppx/react/expected/externalWithRef.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/externalWithRef.res.txt
@@ -18,7 +18,7 @@ module V3 = {
 @@jsxConfig({version: 4, mode: "classic"})
 
 module V4C = {
-  @live
+  @res.jsxComponentProps @live
   type props<'x, 'ref> = {
     x: 'x,
     ref?: 'ref,
@@ -30,7 +30,7 @@ module V4C = {
 }
 
 module type V4CType = {
-  @live
+  @res.jsxComponentProps @live
   type props<'x, 'y> = {
     x: 'x,
     y: 'y,
@@ -43,7 +43,7 @@ module type V4CType = {
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module V4C = {
-  @live
+  @res.jsxComponentProps @live
   type props<'x, 'ref> = {
     x: 'x,
     ref?: 'ref,

--- a/jscomp/syntax/tests/ppx/react/expected/externalWithTypeVariables.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/externalWithTypeVariables.res.txt
@@ -16,7 +16,7 @@ module V3 = {
 @@jsxConfig({version: 4, mode: "classic"})
 
 module V4C = {
-  @live
+  @res.jsxComponentProps @live
   type props<'x, 'children> = {
     x: 'x,
     children: 'children,
@@ -29,7 +29,7 @@ module V4C = {
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module V4C = {
-  @live
+  @res.jsxComponentProps @live
   type props<'x, 'children> = {
     x: 'x,
     children: 'children,

--- a/jscomp/syntax/tests/ppx/react/expected/fileLevelConfig.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/fileLevelConfig.res.txt
@@ -18,6 +18,7 @@ module V3 = {
 @@jsxConfig({version: 4, mode: "classic"})
 
 module V4C = {
+  @res.jsxComponentProps
   type props<'msg> = {msg: 'msg}
 
   let make = ({msg, _}: props<_>) => {
@@ -33,6 +34,7 @@ module V4C = {
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module V4A = {
+  @res.jsxComponentProps
   type props<'msg> = {msg: 'msg}
 
   let make = ({msg, _}: props<_>) => {

--- a/jscomp/syntax/tests/ppx/react/expected/firstClassModules.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/firstClassModules.res.txt
@@ -57,6 +57,7 @@ module Select = {
     type key
     type t
   }
+  @res.jsxComponentProps
   type props<'model, 'selected, 'onChange, 'items> = {
     model: 'model,
     selected: 'selected,
@@ -88,7 +89,7 @@ module External = {
     type key
     type t
   }
-  @live
+  @res.jsxComponentProps @live
   type props<'model, 'selected, 'onChange, 'items> = {
     model: 'model,
     selected: 'selected,

--- a/jscomp/syntax/tests/ppx/react/expected/firstClassModules.resi.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/firstClassModules.resi.txt
@@ -38,6 +38,7 @@ module Select: {
     type key
     type t
   }
+  @res.jsxComponentProps
   type props<'model, 'selected, 'onChange, 'items> = {
     model: 'model,
     selected: 'selected,

--- a/jscomp/syntax/tests/ppx/react/expected/forwardRef.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/forwardRef.res.txt
@@ -69,6 +69,7 @@ module V3 = {
 
 module V4C = {
   module FancyInput = {
+    @res.jsxComponentProps
     type props<'className, 'children, 'ref> = {
       className?: 'className,
       children: 'children,
@@ -100,6 +101,7 @@ module V4C = {
       \"ForwardRef$V4C$FancyInput"
     })
   }
+  @res.jsxComponentProps
   type props = {}
 
   let make = (_: props) => {
@@ -124,6 +126,7 @@ module V4C = {
 
 module V4CUncurried = {
   module FancyInput = {
+    @res.jsxComponentProps
     type props<'className, 'children, 'ref> = {
       className?: 'className,
       children: 'children,
@@ -155,6 +158,7 @@ module V4CUncurried = {
       \"ForwardRef$V4CUncurried$FancyInput"
     })
   }
+  @res.jsxComponentProps
   type props = {}
 
   let make = (_: props) => {
@@ -181,6 +185,7 @@ module V4CUncurried = {
 
 module V4A = {
   module FancyInput = {
+    @res.jsxComponentProps
     type props<'className, 'children, 'ref> = {
       className?: 'className,
       children: 'children,
@@ -210,6 +215,7 @@ module V4A = {
       \"ForwardRef$V4A$FancyInput"
     })
   }
+  @res.jsxComponentProps
   type props = {}
 
   let make = (_: props) => {
@@ -233,6 +239,7 @@ module V4A = {
 
 module V4AUncurried = {
   module FancyInput = {
+    @res.jsxComponentProps
     type props<'className, 'children, 'ref> = {
       className?: 'className,
       children: 'children,
@@ -262,6 +269,7 @@ module V4AUncurried = {
       \"ForwardRef$V4AUncurried$FancyInput"
     })
   }
+  @res.jsxComponentProps
   type props = {}
 
   let make = (_: props) => {

--- a/jscomp/syntax/tests/ppx/react/expected/forwardRef.resi.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/forwardRef.resi.txt
@@ -42,6 +42,7 @@ module V3: {
 
 module V4C: {
   module FancyInput: {
+    @res.jsxComponentProps
     type props<'className, 'children, 'ref> = {
       className?: 'className,
       children: 'children,
@@ -55,6 +56,7 @@ module V4C: {
   }
 
   module ForwardRef: {
+    @res.jsxComponentProps
     type props<'ref> = {ref?: 'ref}
 
     let make: React.componentLike<props<React.ref<Js.Nullable.t<inputRef>>>, React.element>
@@ -63,6 +65,7 @@ module V4C: {
 
 module V4CUncurried: {
   module FancyInput: {
+    @res.jsxComponentProps
     type props<'className, 'children, 'ref> = {
       className?: 'className,
       children: 'children,
@@ -76,6 +79,7 @@ module V4CUncurried: {
   }
 
   module ForwardRef: {
+    @res.jsxComponentProps
     type props<'ref> = {ref?: 'ref}
 
     let make: React.componentLike<props<React.ref<Js.Nullable.t<inputRef>>>, React.element>
@@ -86,6 +90,7 @@ module V4CUncurried: {
 
 module V4A: {
   module FancyInput: {
+    @res.jsxComponentProps
     type props<'className, 'children, 'ref> = {
       className?: 'className,
       children: 'children,
@@ -99,6 +104,7 @@ module V4A: {
   }
 
   module ForwardRef: {
+    @res.jsxComponentProps
     type props<'ref> = {ref?: 'ref}
 
     let make: React.componentLike<props<React.ref<Js.Nullable.t<inputRef>>>, React.element>
@@ -107,6 +113,7 @@ module V4A: {
 
 module V4AUncurried: {
   module FancyInput: {
+    @res.jsxComponentProps
     type props<'className, 'children, 'ref> = {
       className?: 'className,
       children: 'children,
@@ -120,6 +127,7 @@ module V4AUncurried: {
   }
 
   module ForwardRef: {
+    @res.jsxComponentProps
     type props<'ref> = {ref?: 'ref}
 
     let make: React.componentLike<props<React.ref<Js.Nullable.t<inputRef>>>, React.element>

--- a/jscomp/syntax/tests/ppx/react/expected/interface.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/interface.res.txt
@@ -1,4 +1,5 @@
 module A = {
+  @res.jsxComponentProps
   type props<'x> = {x: 'x}
   let make = ({x, _}: props<_>) => React.string(x)
   let make = {
@@ -8,6 +9,7 @@ module A = {
 }
 
 module NoProps = {
+  @res.jsxComponentProps
   type props = {}
 
   let make = (_: props) => ReactDOM.jsx("div", {})

--- a/jscomp/syntax/tests/ppx/react/expected/interface.resi.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/interface.resi.txt
@@ -1,9 +1,11 @@
 module A: {
+  @res.jsxComponentProps
   type props<'x> = {x: 'x}
   let make: React.componentLike<props<string>, React.element>
 }
 
 module NoProps: {
+  @res.jsxComponentProps
   type props = {}
 
   let make: React.componentLike<props, React.element>

--- a/jscomp/syntax/tests/ppx/react/expected/interfaceWithRef.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/interfaceWithRef.res.txt
@@ -1,4 +1,4 @@
-type props<'x, 'ref> = {x: 'x, ref?: 'ref}
+@res.jsxComponentProps type props<'x, 'ref> = {x: 'x, ref?: 'ref}
 let make = (
   {x, _}: props<string, ReactDOM.Ref.currentDomRef>,
   ref: Js.Nullable.t<ReactDOM.Ref.currentDomRef>,

--- a/jscomp/syntax/tests/ppx/react/expected/interfaceWithRef.resi.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/interfaceWithRef.resi.txt
@@ -1,2 +1,2 @@
-type props<'x, 'ref> = {x: 'x, ref?: 'ref}
+@res.jsxComponentProps type props<'x, 'ref> = {x: 'x, ref?: 'ref}
 let make: React.componentLike<props<string, ReactDOM.Ref.currentDomRef>, React.element>

--- a/jscomp/syntax/tests/ppx/react/expected/mangleKeyword.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/mangleKeyword.res.txt
@@ -37,6 +37,7 @@ let c3a1 = React.createElement(C3A1.make, C3A1.makeProps(~_open="x", ~_type="t",
 @@jsxConfig({version: 4, mode: "classic"})
 
 module C4C0 = {
+  @res.jsxComponentProps
   type props<'T_open, 'T_type> = {@as("open") _open: 'T_open, @as("type") _type: 'T_type}
 
   let make = ({@as("open") _open, @as("type") _type, _}: props<_, string>) => React.string(_open)
@@ -47,7 +48,7 @@ module C4C0 = {
   }
 }
 module C4C1 = {
-  @live
+  @res.jsxComponentProps @live
   type props<'T_open, 'T_type> = {@as("open") _open: 'T_open, @as("type") _type: 'T_type}
 
   external make: @as("open") React.componentLike<props<string, string>, React.element> = "default"
@@ -59,6 +60,7 @@ let c4c1 = React.createElement(C4C1.make, {_open: "x", _type: "t"})
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module C4A0 = {
+  @res.jsxComponentProps
   type props<'T_open, 'T_type> = {@as("open") _open: 'T_open, @as("type") _type: 'T_type}
 
   let make = ({@as("open") _open, @as("type") _type, _}: props<_, string>) => React.string(_open)
@@ -69,7 +71,7 @@ module C4A0 = {
   }
 }
 module C4A1 = {
-  @live
+  @res.jsxComponentProps @live
   type props<'T_open, 'T_type> = {@as("open") _open: 'T_open, @as("type") _type: 'T_type}
 
   external make: @as("open") React.componentLike<props<string, string>, React.element> = "default"

--- a/jscomp/syntax/tests/ppx/react/expected/nested.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/nested.res.txt
@@ -1,7 +1,9 @@
 module Outer = {
+  @res.jsxComponentProps
   type props = {}
   let make = (_: props) => {
     module Inner = {
+      @res.jsxComponentProps
       type props = {}
 
       let make = (_: props) => ReactDOM.jsx("div", {})

--- a/jscomp/syntax/tests/ppx/react/expected/newtype.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/newtype.res.txt
@@ -24,6 +24,7 @@ module V3 = {
 @@jsxConfig({version: 4, mode: "classic"})
 
 module V4C = {
+  @res.jsxComponentProps
   type props<'a, 'b, 'c> = {a: 'a, b: 'b, c: 'c}
 
   let make = (type a, {a, b, c, _}: props<a, array<option<[#Foo(a)]>>, 'a>) =>
@@ -38,6 +39,7 @@ module V4C = {
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module V4A = {
+  @res.jsxComponentProps
   type props<'a, 'b, 'c> = {a: 'a, b: 'b, c: 'c}
 
   let make = (type a, {a, b, c, _}: props<a, array<option<[#Foo(a)]>>, 'a>) =>
@@ -50,6 +52,7 @@ module V4A = {
 }
 
 module V4A1 = {
+  @res.jsxComponentProps
   type props<'a, 'b, 'c> = {a: 'a, b: 'b, c: 'c}
 
   let make = (type x y, {a, b, c, _}: props<x, array<y>, 'a>) => ReactDOM.jsx("div", {})
@@ -65,6 +68,7 @@ module type T = {
 }
 
 module V4A2 = {
+  @res.jsxComponentProps
   type props<'foo> = {foo: 'foo}
 
   let make = (type a, {foo: (foo: module(T with type t = a)), _}: props<_>) => {
@@ -79,6 +83,7 @@ module V4A2 = {
 }
 
 module V4A3 = {
+  @res.jsxComponentProps
   type props<'foo> = {foo: 'foo}
 
   let make = (type a, {foo, _}: props<_>) => {
@@ -91,6 +96,7 @@ module V4A3 = {
     \"Newtype$V4A3"
   }
 }
+@res.jsxComponentProps
 type props<'x, 'q> = {x: 'x, q: 'q}
 
 let make = ({x, q, _}: props<('a, 'b), 'a>) => [fst(x), q]
@@ -103,6 +109,7 @@ let make = {
 @@uncurried
 
 module Uncurried = {
+  @res.jsxComponentProps
   type props<'foo> = {foo?: 'foo}
 
   let make = (type a, {?foo, _}: props<_>) => React.null

--- a/jscomp/syntax/tests/ppx/react/expected/noPropsWithKey.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/noPropsWithKey.res.txt
@@ -1,6 +1,7 @@
 @@jsxConfig({version: 4, mode: "classic"})
 
 module V4CA = {
+  @res.jsxComponentProps
   type props = {}
 
   let make = (_: props) => ReactDOM.createDOMElementVariadic("div", [])
@@ -12,7 +13,7 @@ module V4CA = {
 }
 
 module V4CB = {
-  @live
+  @res.jsxComponentProps @live
   type props = {}
 
   @module("c")
@@ -20,6 +21,7 @@ module V4CB = {
 }
 
 module V4C = {
+  @res.jsxComponentProps
   type props = {}
 
   let make = (_: props) =>
@@ -41,6 +43,7 @@ module V4C = {
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module V4CA = {
+  @res.jsxComponentProps
   type props = {}
 
   let make = (_: props) => ReactDOM.jsx("div", {})
@@ -52,7 +55,7 @@ module V4CA = {
 }
 
 module V4CB = {
-  @live
+  @res.jsxComponentProps @live
   type props = {}
 
   @module("c")
@@ -60,6 +63,7 @@ module V4CB = {
 }
 
 module V4C = {
+  @res.jsxComponentProps
   type props = {}
 
   let make = (_: props) =>

--- a/jscomp/syntax/tests/ppx/react/expected/optimizeAutomaticMode.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/optimizeAutomaticMode.res.txt
@@ -4,6 +4,7 @@ module User = {
   type t = {firstName: string, lastName: string}
 
   let format = user => "Dr." ++ user.lastName
+  @res.jsxComponentProps
   type props<'doctor> = {doctor: 'doctor}
 
   let make = ({doctor, _}: props<_>) => {

--- a/jscomp/syntax/tests/ppx/react/expected/removedKeyProp.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/removedKeyProp.res.txt
@@ -1,6 +1,7 @@
 @@jsxConfig({version: 4, mode: "classic"})
 
 module Foo = {
+  @res.jsxComponentProps
   type props<'x, 'y> = {x: 'x, y: 'y}
 
   let make = ({x, y, _}: props<_, _>) => React.string(x ++ y)
@@ -12,6 +13,7 @@ module Foo = {
 }
 
 module HasChildren = {
+  @res.jsxComponentProps
   type props<'children> = {children: 'children}
 
   let make = ({children, _}: props<_>) => React.createElement(React.fragment, {children: children})
@@ -21,6 +23,7 @@ module HasChildren = {
     \"RemovedKeyProp$HasChildren"
   }
 }
+@res.jsxComponentProps
 type props = {}
 
 let make = (_: props) =>

--- a/jscomp/syntax/tests/ppx/react/expected/topLevel.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/topLevel.res.txt
@@ -22,6 +22,7 @@ module V3 = {
 @@jsxConfig({version: 4, mode: "classic"})
 
 module V4C = {
+  @res.jsxComponentProps
   type props<'a, 'b> = {a: 'a, b: 'b}
 
   let make = ({a, b, _}: props<_, _>) => {
@@ -38,6 +39,7 @@ module V4C = {
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module V4A = {
+  @res.jsxComponentProps
   type props<'a, 'b> = {a: 'a, b: 'b}
 
   let make = ({a, b, _}: props<_, _>) => {

--- a/jscomp/syntax/tests/ppx/react/expected/typeConstraint.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/typeConstraint.res.txt
@@ -16,6 +16,7 @@ module V3 = {
 @@jsxConfig({version: 4, mode: "classic"})
 
 module V4C = {
+  @res.jsxComponentProps
   type props = {}
 
   let make = (type a, _: props) => (~a, ~b, _) => ReactDOM.createDOMElementVariadic("div", [])
@@ -29,6 +30,7 @@ module V4C = {
 @@jsxConfig({version: 4, mode: "automatic"})
 
 module V4A = {
+  @res.jsxComponentProps
   type props = {}
 
   let make = (type a, _: props) => (~a, ~b, _) => ReactDOM.jsx("div", {})

--- a/jscomp/syntax/tests/ppx/react/expected/uncurriedProps.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/uncurriedProps.res.txt
@@ -1,4 +1,5 @@
 @@jsxConfig({version: 4})
+@res.jsxComponentProps
 type props<'a> = {a?: 'a}
 
 let make = ({a: ?__a, _}: props<unit => unit>) => {
@@ -26,6 +27,7 @@ func(~callback=(str, a, b) => {
 }, ())
 
 module Foo = {
+  @res.jsxComponentProps
   type props<'callback> = {callback?: 'callback}
 
   let make = ({callback: ?__callback, _}: props<(string, bool, bool) => unit>) => {
@@ -46,6 +48,7 @@ module Foo = {
 }
 
 module Bar = {
+  @res.jsxComponentProps
   type props = {}
 
   let make = (_: props) => React.jsx(Foo.make, {callback: (_, _, _) => ()})

--- a/jscomp/syntax/tests/ppx/react/expected/v4.res.txt
+++ b/jscomp/syntax/tests/ppx/react/expected/v4.res.txt
@@ -1,3 +1,4 @@
+@res.jsxComponentProps
 type props<'x, 'y> = {x: 'x, y: 'y} // Component with type constraint
 let make = ({x, y, _}: props<string, string>) => React.string(x ++ y)
 let make = {
@@ -6,6 +7,7 @@ let make = {
 }
 
 module AnotherName = {
+  @res.jsxComponentProps
   type // Component with another name than "make"
   props<'x> = {x: 'x}
 
@@ -18,6 +20,7 @@ module AnotherName = {
 }
 
 module Uncurried = {
+  @res.jsxComponentProps
   type props<'x> = {x: 'x}
 
   let make = ({x, _}: props<_>) => React.string(x)
@@ -29,26 +32,28 @@ module Uncurried = {
 }
 
 module type TUncurried = {
+  @res.jsxComponentProps
   type props<'x> = {x: 'x}
 
   let make: React.componentLike<props<string>, React.element>
 }
 
 module E = {
-  @live
+  @res.jsxComponentProps @live
   type props<'x> = {x: 'x}
 
   external make: React.componentLike<props<string>, React.element> = "default"
 }
 
 module EUncurried = {
-  @live
+  @res.jsxComponentProps @live
   type props<'x> = {x: 'x}
 
   external make: React.componentLike<props<string>, React.element> = "default"
 }
 
 module Rec = {
+  @res.jsxComponentProps
   type props = {}
 
   let rec make = {
@@ -66,6 +71,7 @@ module Rec = {
 }
 
 module Rec1 = {
+  @res.jsxComponentProps
   type props = {}
 
   let rec make = {
@@ -83,6 +89,7 @@ module Rec1 = {
 }
 
 module Rec2 = {
+  @res.jsxComponentProps
   type props = {}
 
   let rec make = {


### PR DESCRIPTION
This tries to improve the error messages around JSX components by specializing them, instead of having them be the generic record error messages. It's a pre-cursor to improving the interface file mismatch error messages for components.

Some examples:
![image](https://github.com/user-attachments/assets/974e3b25-d632-41d0-a34f-6c1b3c1c6fde)
![image](https://github.com/user-attachments/assets/1037bead-8507-4765-89f2-c4e488f27b48)
![image](https://github.com/user-attachments/assets/9bb41597-d6a7-4821-90d1-7b5e0c9e0ef1)


Part of https://github.com/rescript-lang/rescript-compiler/issues/6975