### PR TITLE
Deprecate JSX 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix comment removed when function signature has `type` keyword. https://github.com/rescript-lang/rescript-compiler/pull/6997
 - Fix parse error on doc comment before "and" in type def. https://github.com/rescript-lang/rescript-compiler/pull/7001
 - Fix tuple coercion. https://github.com/rescript-lang/rescript-compiler/pull/7024
+- Deprecate JSX 3 https://github.com/rescript-lang/rescript-compiler/pull/7042
 
 # 11.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 > - :house: [Internal]
 > - :nail_care: [Polish]
 
+# 11.1.5 (Unreleased)
+
+- Deprecate JSX 3 https://github.com/rescript-lang/rescript-compiler/pull/7042
+
 # 11.1.4
 
 - Fix issue where long layout break added a trailing comma in partial application `...`. https://github.com/rescript-lang/rescript-compiler/pull/6949
@@ -19,7 +23,6 @@
 - Fix comment removed when function signature has `type` keyword. https://github.com/rescript-lang/rescript-compiler/pull/6997
 - Fix parse error on doc comment before "and" in type def. https://github.com/rescript-lang/rescript-compiler/pull/7001
 - Fix tuple coercion. https://github.com/rescript-lang/rescript-compiler/pull/7024
-- Deprecate JSX 3 https://github.com/rescript-lang/rescript-compiler/pull/7042
 
 # 11.1.3
 

--- a/jscomp/bsb/bsb_jsx.ml
+++ b/jscomp/bsb/bsb_jsx.ml
@@ -48,7 +48,7 @@ let from_map map =
                     {loc with Lexing.pos_cnum = loc.Lexing.pos_cnum + 1}
                   in
                   let loc = {Warnings.loc_start = loc; loc_end; loc_ghost = false} in
-                  Location.deprecated loc "deprecated: jsx 3 is deprecated, use jsx 4 instead";
+                  Location.deprecated loc "jsx 3 is deprecated, use jsx 4 instead";
                   version := Some Jsx_v3
                | "4" -> version := Some Jsx_v4
                | _ -> Bsb_exception.errorf ~loc "Unsupported jsx version %s" flo

--- a/jscomp/bsb/bsb_jsx.ml
+++ b/jscomp/bsb/bsb_jsx.ml
@@ -43,7 +43,13 @@ let from_map map =
            match m.?(Bsb_build_schemas.jsx_version) with
            | Some (Flo { loc; flo }) -> (
                match flo with
-               | "3" -> version := Some Jsx_v3
+               | "3" ->
+                  let loc_end =
+                    {loc with Lexing.pos_cnum = loc.Lexing.pos_cnum + 1}
+                  in
+                  let loc = {Warnings.loc_start = loc; loc_end; loc_ghost = false} in
+                  Location.deprecated loc "deprecated: jsx 3 is deprecated, use jsx 4 instead";
+                  version := Some Jsx_v3
                | "4" -> version := Some Jsx_v4
                | _ -> Bsb_exception.errorf ~loc "Unsupported jsx version %s" flo
                )


### PR DESCRIPTION
resolved https://github.com/rescript-lang/rescript-compiler/issues/6982

Deprecate JSX 3 from v11

<img width="512" alt="image" src="https://github.com/user-attachments/assets/a19f33e3-08ba-4d14-9c09-54e6b9d4d6b7">

