### PR TITLE
Special JSX children error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 #### :nail_care: Polish
 
+- Improve error message when passing `children` prop to a component that doesn't accept it. https://github.com/rescript-lang/rescript-compiler/pull/7044
 - Improve error messages for pattern matching on option vs non-option, and vice versa. https://github.com/rescript-lang/rescript-compiler/pull/7035
 - Improve bigint literal comparison. https://github.com/rescript-lang/rescript-compiler/pull/7029
 - Improve output of `@variadic` bindings. https://github.com/rescript-lang/rescript-compiler/pull/7030

--- a/jscomp/build_tests/super_errors/expected/component_missing_prop_children.res.expected
+++ b/jscomp/build_tests/super_errors/expected/component_missing_prop_children.res.expected
@@ -1,0 +1,11 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/component_missing_prop_children.res[0m:[2m6:35-42[0m
+
+  4 [2m│[0m   type props<'name> = {name: 'name}
+  5 [2m│[0m 
+  [1;31m6[0m [2m│[0m   let make = (): props<'name> => {[1;31mchildren[0m: ""}
+  7 [2m│[0m }
+  8 [2m│[0m 
+
+  This JSX component does not accept child elements. It has no [1;31mchildren[0m prop

--- a/jscomp/build_tests/super_errors/fixtures/component_missing_prop_children.res
+++ b/jscomp/build_tests/super_errors/fixtures/component_missing_prop_children.res
@@ -1,0 +1,7 @@
+// Since the React transform isn't active in the tests, mimic what the transform outputs.
+module Component = {
+  @res.jsxComponentProps
+  type props<'name> = {name: 'name}
+
+  let make = (): props<'name> => {children: ""}
+}

--- a/jscomp/ml/error_message_utils.ml
+++ b/jscomp/ml/error_message_utils.ml
@@ -278,8 +278,13 @@ let print_component_name ppf (p : Path.t) =
 let print_component_wrong_prop_error ppf (p : Path.t)
     (_fields : Types.label_declaration list) name =
   fprintf ppf "@[<v>";
-  fprintf ppf
-    "@[<2>The prop @{<error>%s@} does not belong to the JSX component " name;
+  (match name with
+  | "children" ->
+    fprintf ppf
+      "@[<2>This JSX component does not accept child elements. It has no @{<error>children@} prop "
+  | _ ->
+    fprintf ppf
+      "@[<2>The prop @{<error>%s@} does not belong to the JSX component " name);
   print_component_name ppf p;
   fprintf ppf "@]@,@,"
 


### PR DESCRIPTION
This special cases the error message you get when you pass `children` to a JSX component that does not accept them. The big reason for special casing just this prop is that _passing it_ is already special cased in the syntax (`<div>{React.string("this is children")}</div>`) vs passing a regular prop ( `<div className="this is a regular prop" />`).

I think this makes it clearer, but I'd love to hear some feedback.

Part of https://github.com/rescript-lang/rescript-compiler/issues/6975