### PR TITLE
Add context to error message when unit is expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Improve output of `@variadic` bindings. https://github.com/rescript-lang/rescript-compiler/pull/7030
 - Improve error messages around JSX components. https://github.com/rescript-lang/rescript-compiler/pull/7038
 - Improve output of record copying. https://github.com/rescript-lang/rescript-compiler/pull/7043
+- Provide additional context in error message when `unit` is expected. https://github.com/rescript-lang/rescript-compiler/pull/7045
 
 # 12.0.0-alpha.3
 

--- a/jscomp/build_tests/super_errors/expected/function_call_mismatch.res.expected
+++ b/jscomp/build_tests/super_errors/expected/function_call_mismatch.res.expected
@@ -10,3 +10,6 @@
 
   This function call returns: [1;31mstring[0m
   But it's expected to return: [1;33munit[0m
+
+  - Did you mean to assign this to a variable?
+  - If you don't care about the result of this expression, you can assign it to [1;33m_[0m via [1;33mlet _ = ...[0m or pipe it to [1;33mignore[0m via [1;33mexpression->ignore[0m

--- a/jscomp/build_tests/super_errors/expected/warnings2.res.expected
+++ b/jscomp/build_tests/super_errors/expected/warnings2.res.expected
@@ -9,3 +9,6 @@
 
   This has type: [1;31mint[0m
   But it's expected to have type: [1;33munit[0m
+
+  - Did you mean to assign this to a variable?
+  - If you don't care about the result of this expression, you can assign it to [1;33m_[0m via [1;33mlet _ = ...[0m or pipe it to [1;33mignore[0m via [1;33mexpression->ignore[0m

--- a/jscomp/ml/error_message_utils.ml
+++ b/jscomp/ml/error_message_utils.ml
@@ -165,6 +165,15 @@ let print_extra_type_clash_help ppf trace type_clash_context =
       \  - Use a tuple, if your array is of fixed length. Tuples can mix types \
        freely, and compiles to a JavaScript array. Example of a tuple: `let \
        myTuple = (10, \"hello\", 15.5, true)"
+  | ( _,
+  [
+    ({Types.desc = Tconstr (_p1, _, _)}, _); ({desc = Tconstr (p2, _, _)}, _);
+  ] )
+    when Path.same Predef.path_unit p2 ->
+    fprintf ppf
+    "\n\n\
+    \  - Did you mean to assign this to a variable?\n\
+    \  - If you don't care about the result of this expression, you can assign it to @{<info>_@} via @{<info>let _ = ...@} or pipe it to @{<info>ignore@} via @{<info>expression->ignore@}\n\n"
   | _ -> ()
 
 let type_clash_context_from_function sexp sfunct =


### PR DESCRIPTION
Adds some simple context to error messages when `unit` is expected. I _would_ like to also add a contextual message "Did you mean to return this value from the function? Make sure it's the final expression in the function body to return it" but that requires tracking if the error happens inside of a function or not, and that's a lot more work, so skipping for now.

Part of https://github.com/rescript-lang/rescript-compiler/issues/6975