### PR TITLE
Fix dynamic Import issue with function-defined externals

### DIFF
--- a/jscomp/core/lam_compile_primitive.ml
+++ b/jscomp/core/lam_compile_primitive.ml
@@ -38,6 +38,7 @@ let ensure_value_unit (st : Lam_compile_context.continuation) e : E.t =
 
 let module_of_expression = function
   | J.Var (J.Qualified (module_id, value)) -> [ (module_id, value) ]
+  | J.Call ({expression_desc = (J.Var (J.Qualified (module_id, value)))}, _, _) -> [ (module_id, value) ]
   | _ -> []
 
 let get_module_system () =

--- a/jscomp/test/import_external.js
+++ b/jscomp/test/import_external.js
@@ -4,5 +4,8 @@
 
 let f8 = import("a").then(m => m.default);
 
+let f9 = import("b").then(m => m.default);
+
 exports.f8 = f8;
+exports.f9 = f9;
 /* f8 Not a pure module */

--- a/jscomp/test/import_external.res
+++ b/jscomp/test/import_external.res
@@ -2,3 +2,8 @@
 external makeA: string = "default"
 
 let f8 = Js.import(makeA)
+
+@module("b")
+external makeB: string => unit = "default"
+
+let f9 = Js.import(makeB)


### PR DESCRIPTION
Fixes https://github.com/rescript-lang/rescript-compiler/issues/6985

This PR fixes that the dynamic imports don't work correctly with `external` declarations that define functions.
```rescript
@module("mylib") external f: string => unit = "default"
let mylibF = Js.import(f)
```
compiled to
```js
let mylibF = import("mylib").then(m => m.default);
```