### PR TITLE
Tweak unbound record field error message

### DIFF
--- a/jscomp/build_tests/super_errors/expected/unbound_record_field.res.expected
+++ b/jscomp/build_tests/super_errors/expected/unbound_record_field.res.expected
@@ -11,6 +11,6 @@
   [1;33msomeUnknownField[0m refers to a record field, but no corresponding record type is in scope.
   
   If it's defined in another module or file, bring it into scope by:
-  - Prefixing it with said module name: [1;33mTheModule.someUnknownField[0m
-  - Or specifying its type:
+  - Prefixing the field name with the module name: [1;33mTheModule.someUnknownField[0m
+  - Or specifying the record type explicitly:
   [1;33mlet theValue: TheModule.theType = {someUnknownField: VALUE}[0m

--- a/jscomp/build_tests/super_errors/expected/unbound_record_field.res.expected
+++ b/jscomp/build_tests/super_errors/expected/unbound_record_field.res.expected
@@ -1,0 +1,16 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/unbound_record_field.res[0m:[2m3:6-21[0m
+
+  1 [2m│[0m let foo = x =>
+  2 [2m│[0m   switch x {
+  [1;31m3[0m [2m│[0m   | {[1;31msomeUnknownField[0m: 123} => ()
+  4 [2m│[0m   }
+  5 [2m│[0m 
+
+  [1;33msomeUnknownField[0m refers to a record field, but the record type it belongs to couldn't be found automatically.
+  
+  If it's defined in another module or file, bring it into scope by:
+  - Prefixing it with said module name: [1;33mTheModule.someUnknownField[0m
+  - Or specifying its type:
+  [1;33mlet theValue: TheModule.theType = {someUnknownField: VALUE}[0m

--- a/jscomp/build_tests/super_errors/expected/unbound_record_field.res.expected
+++ b/jscomp/build_tests/super_errors/expected/unbound_record_field.res.expected
@@ -8,7 +8,7 @@
   4 [2m│[0m   }
   5 [2m│[0m 
 
-  [1;33msomeUnknownField[0m refers to a record field, but the record type it belongs to couldn't be found automatically.
+  [1;33msomeUnknownField[0m refers to a record field, but no corresponding record type is in scope.
   
   If it's defined in another module or file, bring it into scope by:
   - Prefixing it with said module name: [1;33mTheModule.someUnknownField[0m

--- a/jscomp/build_tests/super_errors/fixtures/unbound_record_field.res
+++ b/jscomp/build_tests/super_errors/fixtures/unbound_record_field.res
@@ -1,0 +1,4 @@
+let foo = x =>
+  switch x {
+  | {someUnknownField: 123} => ()
+  }

--- a/jscomp/ml/typetexp.ml
+++ b/jscomp/ml/typetexp.ml
@@ -912,8 +912,8 @@ let report_error env ppf = function
     Format.fprintf ppf "@[<v>\
                         @{<info>%a@} refers to a record field, but no corresponding record type is in scope.@,@,\
                         If it's defined in another module or file, bring it into scope by:@,\
-                        @[- Prefixing it with said module name:@ @{<info>TheModule.%a@}@]@,\
-                        @[- Or specifying its type:@ @{<info>let theValue: TheModule.theType = {%a: VALUE}@}@]\
+                        @[- Prefixing the field name with the module name:@ @{<info>TheModule.%a@}@]@,\
+                        @[- Or specifying the record type explicitly:@ @{<info>let theValue: TheModule.theType = {%a: VALUE}@}@]\
                         @]"
       Printtyp.longident lid
       Printtyp.longident lid

--- a/jscomp/ml/typetexp.ml
+++ b/jscomp/ml/typetexp.ml
@@ -910,7 +910,7 @@ let report_error env ppf = function
   | Unbound_label lid ->
     (* modified *)
     Format.fprintf ppf "@[<v>\
-                        @{<info>The record field %a can't be found.@}@,@,\
+                        @{<info>%a@} refers to a record field, but the record type it belongs to couldn't be found automatically.@,@,\
                         If it's defined in another module or file, bring it into scope by:@,\
                         @[- Prefixing it with said module name:@ @{<info>TheModule.%a@}@]@,\
                         @[- Or specifying its type:@ @{<info>let theValue: TheModule.theType = {%a: VALUE}@}@]\

--- a/jscomp/ml/typetexp.ml
+++ b/jscomp/ml/typetexp.ml
@@ -910,7 +910,7 @@ let report_error env ppf = function
   | Unbound_label lid ->
     (* modified *)
     Format.fprintf ppf "@[<v>\
-                        @{<info>%a@} refers to a record field, but the record type it belongs to couldn't be found automatically.@,@,\
+                        @{<info>%a@} refers to a record field, but no corresponding record type is in scope.@,@,\
                         If it's defined in another module or file, bring it into scope by:@,\
                         @[- Prefixing it with said module name:@ @{<info>TheModule.%a@}@]@,\
                         @[- Or specifying its type:@ @{<info>let theValue: TheModule.theType = {%a: VALUE}@}@]\


### PR DESCRIPTION
Tweaking the error message for unbound record fields slightly. Interested in feedback on if you think this message is an improvement over the current, which reads roughly like:

```
  The record field knownKey can't be found.
 If it's defined in another module or file, bring it into scope by:
  - Prefixing it with said module name: TheModule.knownKey
  - Or specifying its type:
  let theValue: TheModule.theType = {knownKey: VALUE}
```

So, just changing the wording slightly.