### PR TITLE
fix 'make test' in nixos; don't use opam when not needed

### DIFF
--- a/scripts/format_check.sh
+++ b/scripts/format_check.sh
@@ -9,7 +9,7 @@ reset='\033[0m'
 case "$(uname -s)" in
   Darwin|Linux)
     echo "Checking OCaml code formatting..."
-    if opam exec -- dune build @fmt; then
+    if dune build @fmt; then
       printf "${successGreen}✅ OCaml code formatting ok.${reset}\n"
     else
       printf "${warningYellow}⚠️ OCaml code formatting issues found.${reset}\n"


### PR DESCRIPTION
opam is not really needed here. 'make test' with/without the 'opam exec --' is the same given `dune` exists in path. This also helps nixos rescript developers where global package installation is very much discouraged (not possible?). Lastly, the next version of dune will have package management functionality without opam. So opam use will likely be diminished for dune users.