### PR TITLE
Move rescript and bsc wrapper scripts into cli folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ clean-rewatch:
 	cargo clean --manifest-path rewatch/Cargo.toml && rm -f rewatch/rewatch
 
 clean:
-	(cd runtime && ../rescript clean)
+	(cd runtime && ../cli/rescript clean)
 	dune clean
 
 clean-all: clean clean-gentype clean-rewatch 

--- a/cli/bsc
+++ b/cli/bsc
@@ -2,7 +2,7 @@
 "use strict";
 
 var child_process = require("child_process");
-var { bsc_exe } = require("./cli/bin_path");
+var { bsc_exe } = require("./bin_path");
 
 var delegate_args = process.argv.slice(2);
 

--- a/cli/rescript
+++ b/cli/rescript
@@ -8,8 +8,8 @@
  * and its content are file/directories with regard to project root
  */
 
-var { bsc_exe, rescript_exe } = require("./cli/bin_path.js");
-var bsb = require("./cli/rescript_bsb.js");
+var { bsc_exe, rescript_exe } = require("./bin_path.js");
+var bsb = require("./rescript_bsb.js");
 
 var cwd = process.cwd();
 process.env.BSB_PROJECT_ROOT = cwd;
@@ -87,7 +87,7 @@ if (helpArgIndex !== -1 && (firstPositionalArgIndex === -1 || helpArgIndex <= fi
   console.log(helpMessage);
 
 } else if (argPatterns.version.includes(args[0])) {
-  console.log(require("./package.json").version);
+  console.log(require("../package.json").version);
 
 } else if (firstPositionalArgIndex !== -1) {
   const subcmd = args[firstPositionalArgIndex];
@@ -107,7 +107,7 @@ if (helpArgIndex !== -1 && (firstPositionalArgIndex === -1 || helpArgIndex <= fi
       break;
     }
     case "format": {
-      require("./cli/rescript_format.js").main(
+      require("./rescript_format.js").main(
         subcmdArgs,
         rescript_exe,
         bsc_exe
@@ -115,7 +115,7 @@ if (helpArgIndex !== -1 && (firstPositionalArgIndex === -1 || helpArgIndex <= fi
       break;
     }
     case "dump": {
-      require("./cli/rescript_dump.js").main(
+      require("./rescript_dump.js").main(
         subcmdArgs,
         rescript_exe,
         bsc_exe

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "bin": {
-        "bsc": "bsc",
+        "bsc": "cli/bsc",
         "bstracing": "lib/bstracing",
-        "rescript": "rescript",
+        "rescript": "cli/rescript",
         "rewatch": "cli/rewatch"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "node": ">=18"
   },
   "bin": {
-    "bsc": "bsc",
+    "bsc": "cli/bsc",
     "bstracing": "lib/bstracing",
-    "rescript": "rescript",
+    "rescript": "cli/rescript",
     "rewatch": "cli/rewatch"
   },
   "scripts": {
@@ -56,8 +56,6 @@
     "CHANGELOG.md",
     "CREDITS.md",
     "ninja.COPYING",
-    "bsc",
-    "rescript",
     "darwin",
     "darwinarm64",
     "linux",

--- a/packages/artifacts.txt
+++ b/packages/artifacts.txt
@@ -4,8 +4,9 @@ COPYING.LESSER
 CREDITS.md
 LICENSE
 README.md
-bsc
 cli/bin_path.js
+cli/bsc
+cli/rescript
 cli/rescript_arg.js
 cli/rescript_bsb.js
 cli/rescript_dump.js
@@ -863,7 +864,6 @@ linuxarm64/rescript.exe
 linuxarm64/rewatch.exe
 ninja.COPYING
 package.json
-rescript
 win32/bsb_helper.exe
 win32/bsc.exe
 win32/ninja.exe

--- a/scripts/buildRuntime.sh
+++ b/scripts/buildRuntime.sh
@@ -6,7 +6,7 @@ rm -f lib/es6/*.js lib/js/*.js lib/ocaml/*
 mkdir -p lib/es6 lib/js lib/ocaml
 mkdir -p runtime/lib/es6 runtime/lib/js
 
-(cd runtime && ../rescript build)
+(cd runtime && ../cli/rescript build)
 
 cp runtime/lib/es6/*.js lib/es6
 cp runtime/lib/js/*.js lib/js

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -5,4 +5,4 @@ shopt -s extglob
 dune build @fmt --auto-promote
 
 files=$(find runtime tests -type f \( -name "*.res" -o -name "*.resi" \) ! -name "syntaxErrors*")
-./rescript format $files
+./cli/rescript format $files

--- a/scripts/format_check.sh
+++ b/scripts/format_check.sh
@@ -17,8 +17,8 @@ case "$(uname -s)" in
     fi
 
     echo "Checking ReScript code formatting..."
-    files=$(find runtime tests -type f \( -name "*.res" -o -name "*.resi" \) ! -name "syntaxErrors*")
-    if ./rescript format -check $files; then
+    files=$(find runtime tests -type f \( -name "*.res" -o -name "*.resi" \) ! -name "syntaxErrors*" ! -path "tests/gentype_tests/typescript-react-example/node_modules/*")
+    if ./cli/rescript format -check $files; then
       printf "${successGreen}✅ ReScript code formatting ok.${reset}\n"
     else
       printf "${warningYellow}⚠️ ReScript code formatting issues found.${reset}\n"

--- a/tests/build_tests/cli_compile_status/input.js
+++ b/tests/build_tests/cli_compile_status/input.js
@@ -5,7 +5,7 @@ const path = require("path");
 const child_process = require("child_process");
 const { normalizeNewlines } = require("../utils.js");
 
-const rescriptPath = path.join(__dirname, "..", "..", "..", "rescript")
+const rescriptPath = path.join(__dirname, "..", "..", "..", "cli", "rescript")
 
 // Shows compile time for `rescript build` command
 let out = child_process.spawnSync("node", [rescriptPath, "build"], {

--- a/tests/build_tests/cli_help/input.js
+++ b/tests/build_tests/cli_help/input.js
@@ -4,7 +4,7 @@ const assert = require("assert");
 const path = require("path");
 const { exec, normalizeNewlines } = require("../utils.js");
 
-const rescriptPath = path.join(__dirname, "..", "..", "..", "rescript")
+const rescriptPath = path.join(__dirname, "..", "..", "..", "cli", "rescript")
 
 const cliHelp =
   "Usage: rescript <options> <subcommand>\n" +

--- a/tests/gentype_tests/typescript-react-example/package-lock.json
+++ b/tests/gentype_tests/typescript-react-example/package-lock.json
@@ -27,9 +27,9 @@
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "bin": {
-        "bsc": "bsc",
+        "bsc": "cli/bsc",
         "bstracing": "lib/bstracing",
-        "rescript": "rescript",
+        "rescript": "cli/rescript",
         "rewatch": "cli/rewatch"
       },
       "devDependencies": {


### PR DESCRIPTION
This cleans up the root folder a bit. `rescript` and `bsc` (the wrapper scripts, not the native exes) are actually part of the cli and should be in the `cli` folder.