### PR TITLE
Fix js ouput of bigint max, min

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Fix tuple coercion. https://github.com/rescript-lang/rescript-compiler/pull/7024
 - Fix attribute printing. https://github.com/rescript-lang/rescript-compiler/pull/7025
 - Fix "rescript format" with many files. https://github.com/rescript-lang/rescript-compiler/pull/7081
+- Fix bigint max, min https://github.com/rescript-lang/rescript-compiler/pull/7088
 
 #### :nail_care: Polish
 

--- a/jscomp/core/lam_compile_primitive.ml
+++ b/jscomp/core/lam_compile_primitive.ml
@@ -416,7 +416,7 @@ let translate output_prefix loc (cxt : Lam_compile_context.t)
       | _ -> assert false)
   | Pbigintmax -> (
       match args with
-      | [ { expression_desc = Number (Float _) } as a; { expression_desc = Number (Float _) } as b ]
+      | [ { expression_desc = Number (BigInt _) } as a; { expression_desc = Number (BigInt _) } as b ]
         when Js_analyzer.is_okay_to_duplicate a && Js_analyzer.is_okay_to_duplicate b ->
             E.econd (E.js_comp Cgt a b) a b
       | [ a; b ] -> E.runtime_call Primitive_modules.bigint "max" args

--- a/jscomp/core/lam_compile_primitive.ml
+++ b/jscomp/core/lam_compile_primitive.ml
@@ -411,14 +411,14 @@ let translate output_prefix loc (cxt : Lam_compile_context.t)
       match args with
       | [ { expression_desc = Number (BigInt _) } as a; { expression_desc = Number (BigInt _) } as b ]
         when Js_analyzer.is_okay_to_duplicate a && Js_analyzer.is_okay_to_duplicate b ->
-            E.econd (E.js_comp Clt a b) a b
+            E.econd (E.bigint_comp Clt a b) a b
       | [ a; b ] -> E.runtime_call Primitive_modules.bigint "min" args
       | _ -> assert false)
   | Pbigintmax -> (
       match args with
       | [ { expression_desc = Number (BigInt _) } as a; { expression_desc = Number (BigInt _) } as b ]
         when Js_analyzer.is_okay_to_duplicate a && Js_analyzer.is_okay_to_duplicate b ->
-            E.econd (E.js_comp Cgt a b) a b
+            E.econd (E.bigint_comp Cgt a b) a b
       | [ a; b ] -> E.runtime_call Primitive_modules.bigint "max" args
       | _ -> assert false)
   | Pstringorder -> (

--- a/jscomp/core/lam_convert.ml
+++ b/jscomp/core/lam_convert.ml
@@ -305,8 +305,8 @@ let lam_prim ~primitive:(p : Lambda.primitive) ~args loc : Lam.t =
   | Pasrbigint -> prim ~primitive:Pasrbigint ~args loc
   | Pbigintcomp x -> prim ~primitive:(Pbigintcomp x) ~args loc
   | Pbigintorder -> prim ~primitive:Pbigintorder ~args loc
-  | Pbigintmin -> prim ~primitive:Pbigintorder ~args loc
-  | Pbigintmax -> prim ~primitive:Pbigintorder ~args loc
+  | Pbigintmin -> prim ~primitive:Pbigintmin ~args loc
+  | Pbigintmax -> prim ~primitive:Pbigintmax ~args loc
   | Pintcomp x -> prim ~primitive:(Pintcomp x) ~args loc
   | Poffsetint x -> prim ~primitive:(Poffsetint x) ~args loc
   | Poffsetref x -> prim ~primitive:(Poffsetref x) ~args loc

--- a/tests/tests/src/bigint_test.js
+++ b/tests/tests/src/bigint_test.js
@@ -148,6 +148,10 @@ eq("File \"bigint_test.res\", line 165, characters 5-12", (-9n >> 1n), -5n);
 
 eq("File \"bigint_test.res\", line 166, characters 5-12", (-9n >> -1n), -18n);
 
+eq("File \"bigint_test.res\", line 167, characters 5-12", 9n > 1n ? 9n : 1n, 9n);
+
+eq("File \"bigint_test.res\", line 168, characters 5-12", 9n < 1n ? 9n : 1n, 1n);
+
 Mt.from_pair_suites("Bigint_test", suites.contents);
 
 exports.test_id = test_id;

--- a/tests/tests/src/bigint_test.res
+++ b/tests/tests/src/bigint_test.res
@@ -164,6 +164,8 @@ let () = {
   eq(__LOC__, bigint_asr(9n, -1n), 18n)
   eq(__LOC__, bigint_asr(-9n, 1n), -5n)
   eq(__LOC__, bigint_asr(-9n, -1n), -18n)
+  eq(__LOC__, max(9n, 1n), 9n)
+  eq(__LOC__, min(9n, 1n), 1n)
 }
 
 let () = Mt.from_pair_suites(__MODULE__, suites.contents)


### PR DESCRIPTION
This PR fixes the issue where max, min operations generate js ouput incorrectly. It is described in the related issue https://github.com/rescript-lang/rescript-compiler/issues/7062#issuecomment-2395737100

