### PR TITLE
Continuous benchmarking in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches: [master, 11.0_release]
 
+permissions:
+  # allow posting comments to pull request
+  pull-requests: write
+  
 concurrency:
   group: ci-${{ github.ref }}-1
   # Cancel previous builds for pull requests only.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
       # matrix.ocaml_compiler may contain commas
       - name: Get OPAM cache key
         shell: bash
-        run: echo "opam_cache_key=opam-env-v3-${{ matrix.os }}-${{ matrix.ocaml_compiler }}-${{ hashFiles('dune-project') }}" | sed 's/,/-/g' >> $GITHUB_ENV
+        run: echo "opam_cache_key=opam-env-v4-${{ matrix.os }}-${{ matrix.ocaml_compiler }}-${{ hashFiles('dune-project') }}" | sed 's/,/-/g' >> $GITHUB_ENV
 
       - name: Restore OPAM environment
         id: cache-opam-env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,8 @@ jobs:
           key: syntax-benchmark-v1
  
       - name: Store benchmark result
-        if: matrix.benchmarks
+        # Do not run for PRs created from other repos as those won't be able to write to the pull request
+        if: ${{ matrix.benchmarks && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.repository.full_name) }}
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Syntax Benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,7 +340,8 @@ jobs:
         if: matrix.benchmarks
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          tool: "customSmallerIsBetter"
+          name: Syntax Benchmarks
+          tool: customSmallerIsBetter
           output-file-path: tests/benchmark-output.json
           external-data-json-path: ./tests/benchmark-cache/benchmark-data.json
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,13 +321,28 @@ jobs:
         if: runner.os != 'Windows'
         run: make -C tests/gentype_tests/typescript-react-example clean test
 
-      - name: Build playground compiler
+      - name: Run syntax benchmarks
         if: matrix.benchmarks
-        run: |
-          opam exec -- node packages/playground-bundling/scripts/generate_cmijs.js
-          opam exec -- dune build --profile browser
-          cp ./_build/default/compiler/jsoo/jsoo_playground_main.bc.js playground/compiler.js
+        run: ./_build/install/default/bin/syntax_benchmarks | tee tests/benchmark-output.json
 
+      - name: Download previous benchmark data
+        if: matrix.benchmarks
+        uses: actions/cache@v4
+        with:
+          path: ./tests/benchmark-cache
+          key: syntax-benchmark-v1
+ 
+      - name: Store benchmark result
+        if: matrix.benchmarks
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: "customSmallerIsBetter"
+          output-file-path: tests/benchmark-output.json
+          external-data-json-path: ./tests/benchmark-cache/benchmark-data.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          alert-threshold: "150%"
+          comment-always: true
+          comment-on-alert: true
 
       - name: Build playground compiler
         if: matrix.build_playground

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,9 @@ jobs:
             ocaml_compiler: ocaml-variants.5.2.0+options,ocaml-option-static
             upload_binaries: true
             upload_libs: true
-            # Build the playground compiler on the fastest runner
+            # Build the playground compiler and run the benchmarks on the fastest runner
             build_playground: true
+            benchmarks: true
           - os: buildjet-2vcpu-ubuntu-2204-arm # ARM
             ocaml_compiler: ocaml-variants.5.2.0+options,ocaml-option-static
             upload_binaries: true
@@ -319,6 +320,14 @@ jobs:
       - name: Run gentype tests
         if: runner.os != 'Windows'
         run: make -C tests/gentype_tests/typescript-react-example clean test
+
+      - name: Build playground compiler
+        if: matrix.benchmarks
+        run: |
+          opam exec -- node packages/playground-bundling/scripts/generate_cmijs.js
+          opam exec -- dune build --profile browser
+          cp ./_build/default/compiler/jsoo/jsoo_playground_main.bc.js playground/compiler.js
+
 
       - name: Build playground compiler
         if: matrix.build_playground

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,6 +349,7 @@ jobs:
           alert-threshold: "150%"
           comment-always: true
           comment-on-alert: true
+          summary-always: true
 
       - name: Build playground compiler
         if: matrix.build_playground

--- a/dune-project
+++ b/dune-project
@@ -24,6 +24,10 @@
    (and
     :with-test
     (= 0.26.2)))
+  (yojson
+   (and
+    :with-test
+    (= 2.2.2)))
   (ocaml-lsp-server
    (and
     :with-dev-setup

--- a/rescript.opam
+++ b/rescript.opam
@@ -9,6 +9,7 @@ bug-reports: "https://github.com/rescript-lang/rescript-compiler/issues"
 depends: [
   "ocaml" {>= "4.10"}
   "ocamlformat" {with-test & = "0.26.2"}
+  "yojson" {with-test & = "2.2.2"}
   "ocaml-lsp-server" {with-dev-setup & = "1.19.0"}
   "cppo" {= "1.6.9"}
   "js_of_ocaml" {= "5.8.1"}

--- a/tests/syntax_benchmarks/Benchmark.ml
+++ b/tests/syntax_benchmarks/Benchmark.ml
@@ -182,14 +182,8 @@ end = struct
   type action = Parse | Print
   let string_of_action action =
     match action with
-    | Parse -> "parser"
-    | Print -> "printer"
-
-  (* TODO: we could at Reason here *)
-  type lang = Rescript
-  let string_of_lang lang =
-    match lang with
-    | Rescript -> "rescript"
+    | Parse -> "Parse"
+    | Print -> "Print"
 
   let parse_rescript src filename =
     let p = Parser.make src filename in
@@ -197,19 +191,20 @@ end = struct
     assert (p.diagnostics == []);
     structure
 
-  let benchmark filename lang action =
-    let src = IO.read_file filename in
-    let name =
-      filename ^ " " ^ string_of_lang lang ^ " " ^ string_of_action action
-    in
+  let data_dir = "tests/syntax_benchmarks/data"
+
+  let benchmark filename action =
+    let path = Filename.concat data_dir filename in
+    let src = IO.read_file path in
+    let name = string_of_action action ^ " " ^ filename in
     let benchmark_fn =
-      match (lang, action) with
-      | Rescript, Parse ->
+      match action with
+      | Parse ->
         fun _ ->
-          let _ = Sys.opaque_identity (parse_rescript src filename) in
+          let _ = Sys.opaque_identity (parse_rescript src path) in
           ()
-      | Rescript, Print ->
-        let p = Parser.make src filename in
+      | Print ->
+        let p = Parser.make src path in
         let ast = ResParser.parse_implementation p in
         fun _ ->
           let _ =
@@ -226,16 +221,13 @@ end = struct
     Benchmark.report b
 
   let run () =
-    let data_dir = "tests/syntax_benchmarks/data" in
-    benchmark (Filename.concat data_dir "RedBlackTree.res") Rescript Parse;
-    benchmark (Filename.concat data_dir "RedBlackTree.res") Rescript Print;
-    benchmark
-      (Filename.concat data_dir "RedBlackTreeNoComments.res")
-      Rescript Print;
-    benchmark (Filename.concat data_dir "Napkinscript.res") Rescript Parse;
-    benchmark (Filename.concat data_dir "Napkinscript.res") Rescript Print;
-    benchmark (Filename.concat data_dir "HeroGraphic.res") Rescript Parse;
-    benchmark (Filename.concat data_dir "HeroGraphic.res") Rescript Print
+    benchmark "RedBlackTree.res" Parse;
+    benchmark "RedBlackTree.res" Print;
+    benchmark "RedBlackTreeNoComments.res" Print;
+    benchmark "Napkinscript.res" Parse;
+    benchmark "Napkinscript.res" Print;
+    benchmark "HeroGraphic.res" Parse;
+    benchmark "HeroGraphic.res" Print
 end
 
 let () = Benchmarks.run ()

--- a/tests/syntax_benchmarks/Benchmark.ml
+++ b/tests/syntax_benchmarks/Benchmark.ml
@@ -101,9 +101,10 @@ end = struct
     [
       `Assoc
         [
-          ("name", `String (Format.sprintf "%s - avg. time" b.name));
+          ( "name",
+            `String (Format.sprintf "%s - time (%d iterations)" b.name b.n) );
           ("unit", `String "ms");
-          ("value", `Float (Time.print b.duration /. float_of_int b.n));
+          ("value", `Float (Time.print b.duration));
         ];
       `Assoc
         [

--- a/tests/syntax_benchmarks/dune
+++ b/tests/syntax_benchmarks/dune
@@ -9,6 +9,7 @@
  (enabled_if
   (and
    (<> %{profile} browser)
+   (>= %{ocaml_version} "4.14.0")
    (or
     (= %{system} macosx)
     ; or one of Linuxes (see https://github.com/ocaml/ocaml/issues/10613)

--- a/tests/syntax_benchmarks/dune
+++ b/tests/syntax_benchmarks/dune
@@ -22,6 +22,6 @@
  (foreign_stubs
   (language c)
   (names time))
- (libraries syntax))
+ (libraries syntax yojson))
 
 (data_only_dirs data)

--- a/tests/syntax_benchmarks/time.c
+++ b/tests/syntax_benchmarks/time.c
@@ -37,7 +37,7 @@ CAMLprim value caml_mach_absolute_time(value unit) {
 #elif defined(__linux__)
   struct timespec now;
   clock_gettime(CLOCK_MONOTONIC, &now);
-  result = now.tv_sec * 1000 + now.tv_nsec / 1000000;
+  result = now.tv_sec * 1000000000 + now.tv_nsec;
 #endif
 
   return caml_copy_int64(result);


### PR DESCRIPTION
This PR runs the syntax benchmark in CI and uses https://github.com/benchmark-action/github-action-benchmark to have the github-actions bot create a comment with the benchmark results in future PRs. It will also warn if the results diverge too much from the previous ones (currently 150% is set as the alerting threshold, we can fine tune this later).

It cleans up `Benchmark.ml` and modifies it to output JSON for consumption by github-action-benchmark.

It also fixes two bugs in the benchmark logic:

- Incorrect implementation of `caml_mach_absolute_time` for Linux
- The number of allocations for *one* run was divided by the number of runs, instead of the total number of allocations.

Also note that:

- The comment that the bot left in this PR is outdated. It seems it only comments once on PR creation.
- For permission reasons, the bot commenting in the PR will only work for PRs created from branches in the compiler repo, not from branches in forks.