### PR TITLE
Improve error message when an object is passed where a record is expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Improve error messages around JSX components. https://github.com/rescript-lang/rescript-compiler/pull/7038
 - Improve output of record copying. https://github.com/rescript-lang/rescript-compiler/pull/7043
 - Provide additional context in error message when `unit` is expected. https://github.com/rescript-lang/rescript-compiler/pull/7045
+- Improve error message when passing an object where a record is expected. https://github.com/rescript-lang/rescript-compiler/pull/7101
 
 #### :house: Internal
 

--- a/compiler/ml/typecore.ml
+++ b/compiler/ml/typecore.ml
@@ -814,7 +814,8 @@ let print_expr_type_clash ?type_clash_context env trace ppf =
         | ppf -> error_type_text ppf type_clash_context)
       (function
         | ppf -> error_expected_type_text ppf type_clash_context);
-    print_extra_type_clash_help ppf trace type_clash_context;
+    print_extra_type_clash_help ~extract_concrete_typedecl ~env ppf trace
+      type_clash_context;
     show_extra_help ppf env trace
 
 let report_arity_mismatch ~arity_a ~arity_b ppf =

--- a/tests/build_tests/super_errors/expected/object_passed_when_record_expected.res.expected
+++ b/tests/build_tests/super_errors/expected/object_passed_when_record_expected.res.expected
@@ -1,0 +1,15 @@
+
+  [1;31mWe've found a bug for you![0m
+  [36m/.../fixtures/object_passed_when_record_expected.res[0m:[2m4:14-26[0m
+
+  2 [2m│[0m type xx = array<x>
+  3 [2m│[0m 
+  [1;31m4[0m [2m│[0m let x: xx = [[1;31m{"one": true}[0m]
+  5 [2m│[0m 
+
+  This has type: [1;31m{"one": bool}[0m
+  But it's expected to have type: [1;33mx[0m
+
+  You're passing a [1;31mReScript object[0m where a [1;33mrecord[0m is expected. 
+
+  - Did you mean to pass a record instead of an object? Objects are written with quoted keys, and records with unquoted keys. Remove the quotes from the object keys to pass it as a record instead of object.

--- a/tests/build_tests/super_errors/fixtures/object_passed_when_record_expected.res
+++ b/tests/build_tests/super_errors/fixtures/object_passed_when_record_expected.res
@@ -1,0 +1,4 @@
+type x = {one: bool}
+type xx = array<x>
+
+let x: xx = [{"one": true}]


### PR DESCRIPTION
This improves the error message when an object is passed where a record is expected. A scenario that happens from time to time when copy pasting JS/TS stuff.