### PR TITLE
Benchmark cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,7 +346,7 @@ jobs:
           output-file-path: tests/benchmark-output.json
           external-data-json-path: ./tests/benchmark-cache/benchmark-data.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          alert-threshold: "150%"
+          alert-threshold: "120%"
           comment-always: true
           comment-on-alert: true
           summary-always: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,6 @@ on:
   pull_request:
     branches: [master, 11.0_release]
 
-permissions:
-  # allow posting comments to pull request
-  pull-requests: write
-  
 concurrency:
   group: ci-${{ github.ref }}-1
   # Cancel previous builds for pull requests only.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,7 +345,6 @@ jobs:
           alert-threshold: "120%"
           comment-always: true
           comment-on-alert: true
-          summary-always: true
 
       - name: Build playground compiler
         if: matrix.build_playground


### PR DESCRIPTION
* Reduce alert threshold to 120%
* Remove unneeded permissions
* Remove `summary-always: true`, hoping that that fixes build errors on master.