### PR TITLE
Handle absolute paths in typegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,10 @@
 
 - Use FORCE_COLOR environmental variable to force colorized output https://github.com/rescript-lang/rescript-compiler/pull/7033
 - Allow spreads of variants in patterns (`| ...someVariant as v => `) when the variant spread is a subtype of the variant matched on. https://github.com/rescript-lang/rescript-compiler/pull/6721
-- Fix the issue where dynamic imports are not working for function-defined externals. https://github.com/rescript-lang/rescript-compiler/pull/7060 
+- Fix the issue where dynamic imports are not working for function-defined externals. https://github.com/rescript-lang/rescript-compiler/pull/7060
 - Allow pattern matching on dicts. `switch someDict { | dict{"one": 1} => Js.log("one is one") }`. https://github.com/rescript-lang/rescript-compiler/pull/7059
 - "ReScript Core" standard library is now included in the `rescript` npm package. https://github.com/rescript-lang/rescript-compiler/pull/7108
+- Handle absolute filepaths in gentype. https://github.com/rescript-lang/rescript-compiler/pull/7104
 
 #### :bug: Bug fix
 

--- a/compiler/gentype/FindSourceFile.ml
+++ b/compiler/gentype/FindSourceFile.ml
@@ -14,8 +14,17 @@ let rec implementation items =
     | false -> Some str_loc.loc_start.pos_fname)
   | [] -> None
 
+let transform_to_absolute_path (path : string option) =
+  let transform path =
+    if Filename.is_relative path then Filename.concat (Sys.getcwd ()) path
+    else path
+  in
+  Option.map transform path
+
 let cmt cmt_annots =
   match cmt_annots with
-  | Cmt_format.Interface signature -> interface signature.sig_items
-  | Implementation structure -> implementation structure.str_items
+  | Cmt_format.Interface signature ->
+    transform_to_absolute_path (interface signature.sig_items)
+  | Implementation structure ->
+    transform_to_absolute_path (implementation structure.str_items)
   | _ -> None

--- a/compiler/gentype/FindSourceFile.mli
+++ b/compiler/gentype/FindSourceFile.mli
@@ -1,0 +1,8 @@
+val cmt : Cmt_format.binary_annots -> string option
+(** 
+  [cmt annots] given [Cmt_format.binary_annots] it returns an absolute source file path
+  if the file exists, otherwise it returns None.
+  
+  @param annots The binary annotations to be processed.
+  @return An optional absolute path to the source file.
+*)

--- a/compiler/gentype/GenTypeConfig.ml
+++ b/compiler/gentype/GenTypeConfig.ml
@@ -239,6 +239,7 @@ let read_config ~get_config_file ~namespace =
       sources;
     }
   in
+  let default_config = {default with project_root; bsb_project_root} in
   match get_config_file ~project_root with
   | Some bs_config_file -> (
     try
@@ -247,7 +248,7 @@ let read_config ~get_config_file ~namespace =
       | Obj {map = bsconf} -> (
         match bsconf |> get_opt "gentypeconfig" with
         | Some (Obj {map = gtconf}) -> parse_config ~bsconf ~gtconf
-        | _ -> default)
-      | _ -> default
-    with _ -> default)
-  | None -> default
+        | _ -> default_config)
+      | _ -> default_config
+    with _ -> default_config)
+  | None -> default_config

--- a/compiler/gentype/GenTypeMain.ml
+++ b/compiler/gentype/GenTypeMain.ml
@@ -138,8 +138,6 @@ let process_cmt_file cmt =
   if !Debug.basic then Log_.item "Cmt %s\n" cmt;
   let cmt_file = cmt |> Paths.get_cmt_file in
   if cmt_file <> "" then
-    let output_file = cmt |> Paths.get_output_file ~config in
-    let output_file_relative = cmt |> Paths.get_output_file_relative ~config in
     let file_name = cmt |> Paths.get_module_name in
     let is_interface = Filename.check_suffix cmt_file ".cmti" in
     let input_cmt, has_gentype_annotations =
@@ -154,6 +152,10 @@ let process_cmt_file cmt =
         match is_interface with
         | true -> ".resi"
         | false -> ".res")
+    in
+    let output_file = source_file |> Paths.get_output_file ~config in
+    let output_file_relative =
+      source_file |> Paths.get_output_file_relative ~config
     in
     let resolver =
       ModuleResolver.create_lazy_resolver ~config

--- a/compiler/gentype/Paths.ml
+++ b/compiler/gentype/Paths.ml
@@ -34,9 +34,12 @@ let remove_path_prefix ~prefix path =
   let prefix_len = String.length normalized_prefix in
   let path_len = String.length path in
   let is_prefix =
-    prefix_len <= path_len && String.sub path 0 prefix_len = normalized_prefix
+    prefix_len <= path_len
+    && (String.sub path 0 prefix_len [@doesNotRaise]) = normalized_prefix
   in
-  if is_prefix then String.sub path prefix_len (path_len - prefix_len) else path
+  if is_prefix then
+    String.sub path prefix_len (path_len - prefix_len) [@doesNotRaise]
+  else path
 
 let append_suffix ~config source_path =
   (source_path |> handle_namespace)

--- a/compiler/gentype/Paths.ml
+++ b/compiler/gentype/Paths.ml
@@ -46,26 +46,14 @@ let append_suffix ~config source_path =
   ^ ModuleExtension.ts_input_file_suffix ~config
 
 let get_output_file_relative ~(config : Config.t) source_path =
-  if Filename.is_relative source_path then append_suffix ~config source_path
-  else
-    let relative_path =
-      remove_path_prefix ~prefix:config.project_root source_path
-    in
-    append_suffix ~config relative_path
+  let relativePath =
+    remove_path_prefix ~prefix:config.project_root source_path
+  in
+  append_suffix ~config relativePath
 
-let compute_absolute_output_file_path ~(config : Config.t) path =
-  Filename.concat config.project_root (get_output_file_relative ~config path)
-
-let get_output_file ~(config : Config.t) sourcePath =
-  if Filename.is_relative sourcePath then
-    (* assuming a relative path from the project root *)
-    compute_absolute_output_file_path ~config sourcePath
-  else
-    (* for absolute paths we want to place the output beside the source file *)
-    let relative_path =
-      remove_path_prefix ~prefix:config.project_root sourcePath
-    in
-    compute_absolute_output_file_path ~config relative_path
+let get_output_file ~(config : Config.t) source_path =
+  let relative_output_path = get_output_file_relative ~config source_path in
+  Filename.concat config.project_root relative_output_path
 
 let get_module_name cmt =
   cmt |> handle_namespace |> Filename.basename |> ModuleName.from_string_unsafe


### PR DESCRIPTION
Like discussed in [rescript-lang/rewatch#102](https://github.com/rescript-lang/rewatch/issues/102) this PR enables gentype to handle passing of absolute file paths.
Instead of manipulating the path to the `.cmt` file it gets the source file path from the `.cmt` file first.
Then constructs the output file paths from there.