### PR TITLE
Fix some primitives usage

### DIFF
--- a/lib/es6/Error.js
+++ b/lib/es6/Error.js
@@ -1,5 +1,14 @@
 
 
+import * as Primitive_option from "./Primitive_option.js";
+
+function fromException(exn) {
+  if (exn.TAG === "Ok") {
+    return;
+  } else {
+    return Primitive_option.some(exn._0);
+  }
+}
 
 let $$EvalError = {};
 
@@ -18,6 +27,7 @@ function panic(msg) {
 }
 
 export {
+  fromException,
   $$EvalError,
   $$RangeError,
   $$ReferenceError,

--- a/lib/js/Error.js
+++ b/lib/js/Error.js
@@ -1,5 +1,14 @@
 'use strict';
 
+let Primitive_option = require("./Primitive_option.js");
+
+function fromException(exn) {
+  if (exn.TAG === "Ok") {
+    return;
+  } else {
+    return Primitive_option.some(exn._0);
+  }
+}
 
 let $$EvalError = {};
 
@@ -17,6 +26,7 @@ function panic(msg) {
   throw new Error("Panic! " + msg);
 }
 
+exports.fromException = fromException;
 exports.$$EvalError = $$EvalError;
 exports.$$RangeError = $$RangeError;
 exports.$$ReferenceError = $$ReferenceError;

--- a/runtime/Error.res
+++ b/runtime/Error.res
@@ -1,6 +1,10 @@
 type t = Js.Exn.t
 
-external fromException: exn => option<t> = "?as_js_exn"
+let fromException: exn => option<t> = exn =>
+  switch Obj.magic(exn) {
+  | Error(t) => Some(t)
+  | _ => None
+  }
 external toException: t => exn = "%identity"
 
 @get external stack: t => option<string> = "stack"

--- a/runtime/Error.resi
+++ b/runtime/Error.resi
@@ -7,7 +7,7 @@ See [`Error`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/
 /** Represents a JavaScript exception. */
 type t = Js.Exn.t
 
-external fromException: exn => option<t> = "?as_js_exn"
+let fromException: exn => option<t>
 
 /**
 Turns an `Error.t` into an `exn`.

--- a/runtime/Float.res
+++ b/runtime/Float.res
@@ -45,7 +45,7 @@ let fromString = i =>
 external toInt: float => int = "%intoffloat"
 external fromInt: int => float = "%identity"
 
-@unboxed @noalloc external mod: (float, float) => float = "?fmod_float"
+external mod: (float, float) => float = "%modfloat"
 
 let clamp = (~min=?, ~max=?, value): float => {
   let value = switch max {

--- a/runtime/Float.resi
+++ b/runtime/Float.resi
@@ -440,7 +440,7 @@ external fromInt: int => float = "%identity"
 Float.mod(7.0, 4.0) == 3.0
 ```
 */
-external mod: (float, float) => float = "?fmod_float"
+external mod: (float, float) => float = "%modfloat"
 
 /**
 `clamp(~min=?, ~max=?, value)` returns `value`, optionally bounded by `min` and `max`.

--- a/runtime/Pervasives.res
+++ b/runtime/Pervasives.res
@@ -166,7 +166,7 @@ external floor: float => float = "floor"
 external abs_float: float => float = "abs"
 
 @deprecated("Use Core instead. This will be removed in v13")
-external mod_float: float => float = "%modfloat"
+external mod_float: (float, float) => float = "%modfloat"
 
 @deprecated("Use Core instead. This will be removed in v13")
 external float: int => float = "%floatofint"
@@ -549,7 +549,7 @@ async function main() {
 }
 ```
 */
-external import: 'a => promise<'a> = "#import"
+external import: 'a => promise<'a> = "%import"
 
 type null<+'a> = Js.null<'a>
 


### PR DESCRIPTION
While working on adding the Core tests to the compiler repo, I discovered and fixed some issues with primitives.

(Mainly the changes from #6984 not being reflected in Core yet.)