### PR TITLE
Benchmark: report on alert only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,8 +345,8 @@ jobs:
           output-file-path: tests/benchmark-output.json
           external-data-json-path: ./tests/benchmark-cache/benchmark-data.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          alert-threshold: "120%"
-          comment-always: true
+          alert-threshold: "105%"
+          comment-always: false
           comment-on-alert: true
 
       - name: Save benchmark data as new baseline

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,14 +328,14 @@ jobs:
         if: matrix.benchmarks
         run: ./_build/install/default/bin/syntax_benchmarks | tee tests/benchmark-output.json
 
-      - name: Download previous benchmark data
+      - name: Restore previous benchmark data
         if: matrix.benchmarks
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ./tests/benchmark-cache
           key: syntax-benchmark-v1
  
-      - name: Store benchmark result
+      - name: Create new benchmark data and comment on alert
         # Do not run for PRs created from other repos as those won't be able to write to the pull request
         if: ${{ matrix.benchmarks && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.repository.full_name) }}
         uses: benchmark-action/github-action-benchmark@v1
@@ -349,6 +349,13 @@ jobs:
           comment-always: true
           comment-on-alert: true
 
+      - name: Save benchmark data as new baseline
+        if: matrix.benchmarks && github.ref == 'refs/heads/master'
+        uses: actions/cache/save@v4
+        with:
+          path: ./tests/benchmark-cache
+          key: syntax-benchmark-v1
+     
       - name: Build playground compiler
         if: matrix.build_playground
         run: |


### PR DESCRIPTION
In the future, as requested [here](https://github.com/rescript-lang/rescript-compiler/commit/66daccbcef78498257b8176efafc1a9b3c02bb34#commitcomment-148232002), have the bot only comment if there is a >5% difference in benchmark results.