### PR TITLE
Use dict instead of Dict.t everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - Move `syntax_tests` into the `tests` folder. https://github.com/rescript-lang/rescript-compiler/pull/7090 https://github.com/rescript-lang/rescript-compiler/pull/7097
 - Capitalize runtime filenames. https://github.com/rescript-lang/rescript-compiler/pull/7110
 - Build mocha tests as esmodule / .mjs. https://github.com/rescript-lang/rescript-compiler/pull/7115
+- Use dict instead of Dict.t everywhere. https://github.com/rescript-lang/rescript-compiler/pull/7136
 
 # 12.0.0-alpha.3
 

--- a/runtime/Dict.res
+++ b/runtime/Dict.res
@@ -1,28 +1,28 @@
-type t<'a> = Js.Dict.t<'a>
+type t<'a> = dict<'a>
 
-@get_index external getUnsafe: (t<'a>, string) => 'a = ""
-@get_index external get: (t<'a>, string) => option<'a> = ""
-@set_index external set: (t<'a>, string, 'a) => unit = ""
+@get_index external getUnsafe: (dict<'a>, string) => 'a = ""
+@get_index external get: (dict<'a>, string) => option<'a> = ""
+@set_index external set: (dict<'a>, string, 'a) => unit = ""
 @val external delete: 'a => unit = "delete"
 
 let delete = (dict, string) => {
   delete(get(dict, string))
 }
 
-@obj external make: unit => t<'a> = ""
+@obj external make: unit => dict<'a> = ""
 
-@val external fromArray: array<(string, 'a)> => t<'a> = "Object.fromEntries"
-@val external fromIterator: Iterator.t<(string, 'a)> => t<'a> = "Object.fromEntries"
+@val external fromArray: array<(string, 'a)> => dict<'a> = "Object.fromEntries"
+@val external fromIterator: Iterator.t<(string, 'a)> => dict<'a> = "Object.fromEntries"
 
-@val external toArray: t<'a> => array<(string, 'a)> = "Object.entries"
+@val external toArray: dict<'a> => array<(string, 'a)> = "Object.entries"
 
-@val external keysToArray: t<'a> => array<string> = "Object.keys"
+@val external keysToArray: dict<'a> => array<string> = "Object.keys"
 
-@val external valuesToArray: t<'a> => array<'a> = "Object.values"
+@val external valuesToArray: dict<'a> => array<'a> = "Object.values"
 
-@val external assign: (t<'a>, t<'a>) => t<'a> = "Object.assign"
+@val external assign: (dict<'a>, dict<'a>) => dict<'a> = "Object.assign"
 
-@val external copy: (@as(json`{}`) _, t<'a>) => t<'a> = "Object.assign"
+@val external copy: (@as(json`{}`) _, dict<'a>) => dict<'a> = "Object.assign"
 
 let forEach = (dict, f) => {
   dict->valuesToArray->Array.forEach(value => f(value))

--- a/runtime/Dict.resi
+++ b/runtime/Dict.resi
@@ -6,7 +6,7 @@ Compiles to a regular JavaScript object.*/
 /**
 Type representing a dictionary of value `'a`.
 */
-type t<'a> = Js.Dict.t<'a>
+type t<'a> = dict<'a>
 
 /**
 `getUnsafe(dict, key)` Returns the `value` at the provided `key`.
@@ -23,7 +23,7 @@ Console.log(value) // value1
 ```
 */
 @get_index
-external getUnsafe: (t<'a>, string) => 'a = ""
+external getUnsafe: (dict<'a>, string) => 'a = ""
 
 /**
 Returns the value at the provided key, if it exists. Returns an option.
@@ -39,7 +39,7 @@ switch dict->Dict.get("someKey") {
 ```
 */
 @get_index
-external get: (t<'a>, string) => option<'a> = ""
+external get: (dict<'a>, string) => option<'a> = ""
 
 /**
 `set(dictionary, key, value)` sets the value at the provided key to the provided value.
@@ -52,7 +52,7 @@ dict->Dict.set("someKey", "someValue")
 ```
 */
 @set_index
-external set: (t<'a>, string, 'a) => unit = ""
+external set: (dict<'a>, string, 'a) => unit = ""
 
 /**
 `delete(dictionary, key)` deletes the value at `key`, if it exists.
@@ -64,21 +64,21 @@ let dict = Dict.fromArray([("someKey", "someValue")])
 dict->Dict.delete("someKey")
 ```
 */
-let delete: (t<'a>, string) => unit
+let delete: (dict<'a>, string) => unit
 
 /**
 `make()` creates a new, empty dictionary.
 
 ## Examples
 ```rescript
-let dict1: Dict.t<int> = Dict.make() // You can annotate the type of the values of your dict yourself if you want
+let dict1: dict<int> = Dict.make() // You can annotate the type of the values of your dict yourself if you want
 
 let dict2 = Dict.make() // Or you can let ReScript infer it via usage.
 dict2->Dict.set("someKey", 12)
 ```
 */
 @obj
-external make: unit => t<'a> = ""
+external make: unit => dict<'a> = ""
 
 /**
 `fromArray(entries)` creates a new dictionary from the provided array of key/value pairs.
@@ -89,7 +89,7 @@ let dict = Dict.fromArray([("key1", "value1"), ("key2", "value2")])
 ```
 */
 @val
-external fromArray: array<(string, 'a)> => t<'a> = "Object.fromEntries"
+external fromArray: array<(string, 'a)> => dict<'a> = "Object.fromEntries"
 
 /**
 `fromIterator(entries)` creates a new dictionary from the provided iterator of key/value pairs.
@@ -99,11 +99,11 @@ external fromArray: array<(string, 'a)> => t<'a> = "Object.fromEntries"
 // Pretend we have an iterator of the correct shape
 @val external someIterator: Iterator.t<(string, int)> = "someIterator"
 
-let dict = Dict.fromIterator(someIterator) // Dict.t<int>
+let dict = Dict.fromIterator(someIterator) // dict<int>
 ```
 */
 @val
-external fromIterator: Iterator.t<(string, 'a)> => t<'a> = "Object.fromEntries"
+external fromIterator: Iterator.t<(string, 'a)> => dict<'a> = "Object.fromEntries"
 
 /**
 `toArray(dictionary)` returns an array of all the key/value pairs of the dictionary.
@@ -118,7 +118,7 @@ Console.log(asArray) // Logs `[["someKey", 1], ["someKey2", 2]]` to the console
 ```
 */
 @val
-external toArray: t<'a> => array<(string, 'a)> = "Object.entries"
+external toArray: dict<'a> => array<(string, 'a)> = "Object.entries"
 
 /**
 `keysToArray(dictionary)` returns an array of all the keys of the dictionary.
@@ -133,7 +133,7 @@ Console.log(keys) // Logs `["someKey", "someKey2"]` to the console
 ```
 */
 @val
-external keysToArray: t<'a> => array<string> = "Object.keys"
+external keysToArray: dict<'a> => array<string> = "Object.keys"
 
 /**
 `valuesToArray(dictionary)` returns an array of all the values of the dictionary.
@@ -148,7 +148,7 @@ Console.log(values) // Logs `[1, 2]` to the console
 ```
 */
 @val
-external valuesToArray: t<'a> => array<'a> = "Object.values"
+external valuesToArray: dict<'a> => array<'a> = "Object.values"
 
 /**
 `assign(dictionary1, dictionary2)` [shallowly](https://developer.mozilla.org/en-US/docs/Glossary/Shallow_copy) merges dictionary2 into dictionary1, and returns dictionary1.
@@ -172,7 +172,7 @@ Console.log(dict1->Dict.keysToArray) // Logs `["firstKey", "someKey", "someKey2"
 ```
 */
 @val
-external assign: (t<'a>, t<'a>) => t<'a> = "Object.assign"
+external assign: (dict<'a>, dict<'a>) => dict<'a> = "Object.assign"
 
 /**
 `copy(dictionary)` [shallowly copies](https://developer.mozilla.org/en-US/docs/Glossary/Shallow_copy) the provided dictionary to a new dictionary.
@@ -187,7 +187,7 @@ Console.log2(dict->Dict.keysToArray, dict2->Dict.keysToArray)
 ```
 */
 @val
-external copy: (@as(json`{}`) _, t<'a>) => t<'a> = "Object.assign"
+external copy: (@as(json`{}`) _, dict<'a>) => dict<'a> = "Object.assign"
 
 /**
 `forEach(dictionary, f)` iterates through all values of the dict.
@@ -203,7 +203,7 @@ dict->Dict.forEach(value => {
 })
 ```
 */
-let forEach: (t<'a>, 'a => unit) => unit
+let forEach: (dict<'a>, 'a => unit) => unit
 
 /**
 `forEachWithKey(dictionary, f)` iterates through all values of the dict, including the key for each value.
@@ -217,7 +217,7 @@ dict->Dict.forEachWithKey((value, key) => {
 })
 ```
 */
-let forEachWithKey: (t<'a>, ('a, string) => unit) => unit
+let forEachWithKey: (dict<'a>, ('a, string) => unit) => unit
 
 /**
 `mapValues(dictionary, f)` returns a new dictionary with the same keys, and `f` applied to each value in the original dictionary.
@@ -231,4 +231,4 @@ dict->Dict.mapValues(v => v + 10)->Dict.toArray // [("key1", 11), ("key2", 12)]
 dict->Dict.mapValues(v => Int.toString(v))->Dict.toArray // [("key1", "1"), ("key2", "2")]
 ```
 */
-let mapValues: (t<'a>, 'a => 'b) => t<'b>
+let mapValues: (dict<'a>, 'a => 'b) => dict<'b>

--- a/runtime/JSON.res
+++ b/runtime/JSON.res
@@ -4,7 +4,7 @@ type rec t = Js.Json.t =
   | @as(null) Null
   | String(string)
   | Number(float)
-  | Object(Dict.t<t>)
+  | Object(dict<t>)
   | Array(array<t>)
 
 @unboxed
@@ -47,7 +47,7 @@ module Classify = {
     | Null
     | String(string)
     | Number(float)
-    | Object(Dict.t<t>)
+    | Object(dict<t>)
     | Array(array<t>)
 
   @val external _internalClass: 'a => string = "Object.prototype.toString.call"
@@ -55,7 +55,7 @@ module Classify = {
   external _asString: 'a => string = "%identity"
   external _asFloat: 'a => float = "%identity"
   external _asArray: 'a => array<Js.Json.t> = "%identity"
-  external _asDict: 'a => Dict.t<Js.Json.t> = "%identity"
+  external _asDict: 'a => dict<Js.Json.t> = "%identity"
 
   let classify = value => {
     switch _internalClass(value) {
@@ -75,7 +75,7 @@ module Encode = {
   external string: string => t = "%identity"
   external int: int => t = "%identity"
   external float: float => t = "%identity"
-  external object: Dict.t<t> => t = "%identity"
+  external object: dict<t> => t = "%identity"
   external array: array<t> => t = "%identity"
 }
 
@@ -86,7 +86,7 @@ module Decode = {
   let float = (json: t) => Type.typeof(json) === #number ? Some((Obj.magic(json): float)) : None
   let object = (json: t) =>
     if Type.typeof(json) === #object && !Array.isArray(json) && !(Obj.magic(json) === Null.null) {
-      Some((Obj.magic(json): Dict.t<t>))
+      Some((Obj.magic(json): dict<t>))
     } else {
       None
     }

--- a/runtime/JSON.resi
+++ b/runtime/JSON.resi
@@ -11,7 +11,7 @@ type rec t = Js.Json.t =
   | @as(null) Null
   | String(string)
   | Number(float)
-  | Object(Dict.t<t>)
+  | Object(dict<t>)
   | Array(array<t>)
 
 @unboxed
@@ -578,7 +578,7 @@ module Classify: {
     | Null
     | String(string)
     | Number(float)
-    | Object(Dict.t<t>)
+    | Object(dict<t>)
     | Array(array<t>)
 
   /**
@@ -660,7 +660,7 @@ module Encode: {
   JSON.Encode.object(dict)
   ```
   */
-  external object: Dict.t<t> => t = "%identity"
+  external object: dict<t> => t = "%identity"
 
   /**
   Returns an array as a JSON object.
@@ -733,7 +733,7 @@ module Decode: {
   let float: t => option<float>
 
   /**
-  Decodes a single JSON value. If the value is an object, it will return `Some(Dict.t)` - otherwise it will return `None`.
+  Decodes a single JSON value. If the value is an object, it will return `Some(dict)` - otherwise it will return `None`.
 
   ## Examples
   ```rescript
@@ -744,7 +744,7 @@ module Decode: {
   // None
   ```
   */
-  let object: t => option<Dict.t<t>>
+  let object: t => option<dict<t>>
 
   /**
   Decodes a single JSON value. If the value is an array, it will return `Some(array)` - otherwise it will return `None`.

--- a/runtime/Js_json.res
+++ b/runtime/Js_json.res
@@ -30,7 +30,7 @@ type rec t =
   | @as(null) Null
   | String(string)
   | Number(float)
-  | Object(Js_dict.t<t>)
+  | Object(dict<t>)
   | Array(array<t>)
 
 module Kind = {
@@ -38,7 +38,7 @@ module Kind = {
   type rec t<_> =
     | String: t<Js_string.t>
     | Number: t<float>
-    | Object: t<Js_dict.t<json>>
+    | Object: t<dict<json>>
     | Array: t<array<json>>
     | Boolean: t<bool>
     | Null: t<Js_types.null_val>
@@ -50,7 +50,7 @@ type tagged_t =
   | JSONNull
   | JSONString(string)
   | JSONNumber(float)
-  | JSONObject(Js_dict.t<t>)
+  | JSONObject(dict<t>)
   | JSONArray(array<t>)
 
 let classify = (x: t): tagged_t => {
@@ -105,7 +105,7 @@ let decodeObject = json =>
       (!Js_array2.isArray(json) &&
       !((Obj.magic(json): Js_null.t<'a>) === Js_extern.null))
   ) {
-    Some((Obj.magic((json: t)): Js_dict.t<t>))
+    Some((Obj.magic((json: t)): dict<t>))
   } else {
     None
   }
@@ -143,7 +143,7 @@ let decodeNull = (json): option<Js_null.t<_>> =>
 external string: string => t = "%identity"
 external number: float => t = "%identity"
 external boolean: bool => t = "%identity"
-external object_: Js_dict.t<t> => t = "%identity"
+external object_: dict<t> => t = "%identity"
 
 /* external array_ : t array -> t = "%identity" */
 
@@ -151,7 +151,7 @@ external array: array<t> => t = "%identity"
 external stringArray: array<string> => t = "%identity"
 external numberArray: array<float> => t = "%identity"
 external booleanArray: array<bool> => t = "%identity"
-external objectArray: array<Js_dict.t<t>> => t = "%identity"
+external objectArray: array<dict<t>> => t = "%identity"
 @val @scope("JSON") external stringify: t => string = "stringify"
 @val @scope("JSON") external stringifyWithSpace: (t, @as(json`null`) _, int) => string = "stringify"
 

--- a/runtime/Js_json.resi
+++ b/runtime/Js_json.resi
@@ -36,7 +36,7 @@ type rec t =
   | @as(null) Null
   | String(string)
   | Number(float)
-  | Object(Js_dict.t<t>)
+  | Object(dict<t>)
   | Array(array<t>)
 
 module Kind: {
@@ -45,7 +45,7 @@ module Kind: {
   type rec t<_> =
     | String: t<Js_string.t>
     | Number: t<float>
-    | Object: t<Js_dict.t<json>>
+    | Object: t<dict<json>>
     | Array: t<array<json>>
     | Boolean: t<bool>
     | Null: t<Js_types.null_val>
@@ -57,7 +57,7 @@ type tagged_t =
   | JSONNull
   | JSONString(string)
   | JSONNumber(float)
-  | JSONObject(Js_dict.t<t>)
+  | JSONObject(dict<t>)
   | JSONArray(array<t>)
 
 /* ## Accessors */
@@ -82,7 +82,7 @@ let decodeNumber: t => option<float>
 /**
 `decodeObject(json)` returns `Some(o)` if `json` is an `object`, `None` otherwise.
 */
-let decodeObject: t => option<Js_dict.t<t>>
+let decodeObject: t => option<dict<t>>
 
 /**
 `decodeArray(json)` returns `Some(a)` if `json` is an `array`, `None` otherwise.
@@ -118,8 +118,8 @@ external number: float => t = "%identity"
 /** `boolean(b)` makes a JSON boolean of the `bool` `b`. */
 external boolean: bool => t = "%identity"
 
-/** `object_(dict)` makes a JSON object of the `Js.Dict.t` `dict`. */
-external object_: Js_dict.t<t> => t = "%identity"
+/** `object_(dict)` makes a JSON object of the `dict`. */
+external object_: dict<t> => t = "%identity"
 
 /** `array_(a)` makes a JSON array of the `Js.Json.t` array `a`. */
 external array: array<t> => t = "%identity"
@@ -140,7 +140,7 @@ external numberArray: array<float> => t = "%identity"
 external booleanArray: array<bool> => t = "%identity"
 
 /** `objectArray(a) makes a JSON array of the `JsDict.t` array `a`. */
-external objectArray: array<Js_dict.t<t>> => t = "%identity"
+external objectArray: array<dict<t>> => t = "%identity"
 
 /* ## String conversion */
 
@@ -178,7 +178,7 @@ let getIds = s => {
 
   switch Js.Json.classify(json) {
   | Js.Json.JSONObject(value) =>
-    /* In this branch, compiler infer value : Js.Json.t Js.Dict.t */
+    /* In this branch, compiler infer value : Js.Json.t dict */
     switch Js.Dict.get(value, "ids") {
     | Some(ids) =>
       switch Js.Json.classify(ids) {

--- a/tests/gentype_tests/typescript-react-example/package-lock.json
+++ b/tests/gentype_tests/typescript-react-example/package-lock.json
@@ -22,7 +22,7 @@
     },
     "../../..": {
       "name": "rescript",
-      "version": "12.0.0-alpha.4",
+      "version": "12.0.0-alpha.5",
       "dev": true,
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",

--- a/tests/gentype_tests/typescript-react-example/src/Core.res
+++ b/tests/gentype_tests/typescript-react-example/src/Core.res
@@ -17,10 +17,10 @@ let undefined0 = (x: Js.undefined<int>) => x
 let undefined1 = (x: Undefined.t<int>) => x
 
 @genType
-let dict0 = (x: Js.Dict.t<string>) => x
+let dict0 = (x: dict<string>) => x
 
 @genType
-let dict1 = (x: Dict.t<string>) => x
+let dict1 = (x: dict<string>) => x
 
 @genType
 let promise0 = (x: promise<string>) => x

--- a/tests/gentype_tests/typescript-react-example/src/Dict.res
+++ b/tests/gentype_tests/typescript-react-example/src/Dict.res
@@ -1,1 +1,1 @@
-type t<'a> = Js.Dict.t<'a>
+type t<'a> = dict<'a>

--- a/tests/gentype_tests/typescript-react-example/src/nested/Types.res
+++ b/tests/gentype_tests/typescript-react-example/src/nested/Types.res
@@ -60,7 +60,7 @@ type opaqueVariant =
 @gentype
 type genTypeMispelled = int
 
-@genType type dictString = Js.Dict.t<string>
+@genType type dictString = dict<string>
 
 @genType let jsonStringify = Js.Json.stringify
 

--- a/tests/syntax_tests/data/idempotency/bs-css/CssEmotion.res
+++ b/tests/syntax_tests/data/idempotency/bs-css/CssEmotion.res
@@ -14,7 +14,7 @@ include Css_Legacy_Core.Make({
   external injectRaw: (. string) => unit = "injectGlobal"
 
   @module("emotion")
-  external makeKeyFrames: (. Js.Dict.t<Js.Json.t>) => string = "keyframes"
+  external makeKeyFrames: (. dict<Js.Json.t>) => string = "keyframes"
 })
 
 type cache

--- a/tests/syntax_tests/data/idempotency/bs-css/CssEmotionJs.res
+++ b/tests/syntax_tests/data/idempotency/bs-css/CssEmotionJs.res
@@ -14,7 +14,7 @@ include Css_Js_Core.Make({
   external injectRaw: (. string) => unit = "injectGlobal"
 
   @module("emotion")
-  external makeKeyFrames: (. Js.Dict.t<Js.Json.t>) => string = "keyframes"
+  external makeKeyFrames: (. dict<Js.Json.t>) => string = "keyframes"
 })
 
 type cache

--- a/tests/syntax_tests/data/idempotency/bs-css/Css_Core.res
+++ b/tests/syntax_tests/data/idempotency/bs-css/Css_Core.res
@@ -3,5 +3,5 @@ module type CssImplementationIntf = {
   let injectRule: (. Js.Json.t) => unit
   let injectRaw: (. string) => unit
   let make: (. Js.Json.t) => string
-  let makeKeyFrames: (. Js.Dict.t<Js.Json.t>) => string
+  let makeKeyFrames: (. dict<Js.Json.t>) => string
 }

--- a/tests/syntax_tests/data/idempotency/bs-webapi/src/Webapi/Webapi__Url.res
+++ b/tests/syntax_tests/data/idempotency/bs-webapi/src/Webapi/Webapi__Url.res
@@ -2,7 +2,7 @@ module URLSearchParams = {
   type t
 
   @new external make: string => t = "URLSearchParams"
-  @new external makeWithDict: Js.Dict.t<string> => t = "URLSearchParams"
+  @new external makeWithDict: dict<string> => t = "URLSearchParams"
   @new external makeWithArray: array<(string, string)> => t = "URLSearchParams"
 }
 

--- a/tests/syntax_tests/data/idempotency/covid-19charts.com/src/Data.res
+++ b/tests/syntax_tests/data/idempotency/covid-19charts.com/src/Data.res
@@ -10,7 +10,7 @@ module Map: {
   let set: (t<'key, 'value>, 'key, 'value) => unit
   let empty: unit => t<'key, 'value>
 } = {
-  type t<'key, 'value> = Js.Dict.t<'value> constraint 'key = string
+  type t<'key, 'value> = dict<'value> constraint 'key = string
   let keys = Js.Dict.keys
   let get = Js.Dict.unsafeGet
   let get_opt = Js.Dict.get

--- a/tests/syntax_tests/data/idempotency/covid-19charts.com/src/SerializeQueryParam.res
+++ b/tests/syntax_tests/data/idempotency/covid-19charts.com/src/SerializeQueryParam.res
@@ -24,8 +24,8 @@ type locationFragments = {
 }
 
 @module("serialize-query-params")
-external updateInLocation: (Js.Dict.t<option<encoded>>, Window.location) => locationFragments =
+external updateInLocation: (dict<option<encoded>>, Window.location) => locationFragments =
   "updateInLocation"
 
 @module("serialize-query-params")
-external parse: string => Js.Dict.t<encoded> = "parse"
+external parse: string => dict<encoded> = "parse"

--- a/tests/syntax_tests/data/idempotency/nook-exchange/Item.res
+++ b/tests/syntax_tests/data/idempotency/nook-exchange/Item.res
@@ -243,7 +243,7 @@ let getCanonicalVariant = (~item, ~variant) =>
 type variantNames =
   | NameOneDimension(array<string>)
   | NameTwoDimensions((array<string>, array<string>))
-let variantNames: Js.Dict.t<variantNames> = variantsJson |> {
+let variantNames: dict<variantNames> = variantsJson |> {
   open Json.Decode
   dict(
     oneOf(list{
@@ -261,8 +261,8 @@ type translationItem = {
   variants: option<variantNames>,
 }
 type translations = {
-  items: Js.Dict.t<translationItem>,
-  materials: Js.Dict.t<string>,
+  items: dict<translationItem>,
+  materials: dict<string>,
 }
 let translations: ref<option<translations>> = ref(None)
 let setTranslations = json => {

--- a/tests/syntax_tests/data/idempotency/nook-exchange/User.res
+++ b/tests/syntax_tests/data/idempotency/nook-exchange/User.res
@@ -72,7 +72,7 @@ type t = {
   id: string,
   username: string,
   email: option<string>,
-  items: Js.Dict.t<item>,
+  items: dict<item>,
   profileText: string,
   enableCatalogCheckbox: bool,
   followeeIds: option<array<string>>,

--- a/tests/syntax_tests/data/idempotency/nook-exchange/Utils.res
+++ b/tests/syntax_tests/data/idempotency/nook-exchange/Utils.res
@@ -1,8 +1,8 @@
 @val @scope("Object")
-external objectAssign: (Js.Dict.t<'a>, Js.Dict.t<'a>) => unit = "assign"
+external objectAssign: (dict<'a>, dict<'a>) => unit = "assign"
 
 @val @scope("Object") @variadic
-external objectAssignMany: array<Js.Dict.t<'a>> => unit = "assign"
+external objectAssignMany: array<dict<'a>> => unit = "assign"
 
 let cloneJsDict = dict => {
   let clone = Js.Dict.empty()
@@ -20,7 +20,7 @@ type any
 let _internalDeleteJsDictKey: (any, string) => unit = %raw(
   "function(dict, key) { delete dict[key]; }"
 )
-external convertToAny: Js.Dict.t<'a> => any = "%identity"
+external convertToAny: dict<'a> => any = "%identity"
 
 let deleteJsDictKey = (dict, key) => _internalDeleteJsDictKey(convertToAny(dict), key)
 

--- a/tests/syntax_tests/data/idempotency/reasonml.org/bindings/Next.res
+++ b/tests/syntax_tests/data/idempotency/reasonml.org/bindings/Next.res
@@ -1,4 +1,4 @@
-type getInitialPropsFn<'a> = {"query": Js.Dict.t<string>, "req": Js.Nullable.t<'a>} => Js.Promise.t<
+type getInitialPropsFn<'a> = {"query": dict<string>, "req": Js.Nullable.t<'a>} => Js.Promise.t<
   'a,
 >
 

--- a/tests/syntax_tests/data/idempotency/reasonml.org/layouts/BeltDocsLayout.res
+++ b/tests/syntax_tests/data/idempotency/reasonml.org/layouts/BeltDocsLayout.res
@@ -1,7 +1,7 @@
 module Link = Next.Link
 
 // Structure defined by `scripts/extract-indices.js`
-let indexData: Js.Dict.t<{
+let indexData: dict<{
   "moduleName": string,
   "headers": array<{
     "name": string,

--- a/tests/syntax_tests/data/idempotency/reasonml.org/layouts/CommunityLayout.res
+++ b/tests/syntax_tests/data/idempotency/reasonml.org/layouts/CommunityLayout.res
@@ -1,7 +1,7 @@
 module Link = Next.Link
 
 // Structure defined by `scripts/extract-tocs.js`
-let tocData: Js.Dict.t<{
+let tocData: dict<{
   "title": string,
   "headers": array<{
     "name": string,

--- a/tests/syntax_tests/data/idempotency/reasonml.org/layouts/GenTypeDocsLayout.res
+++ b/tests/syntax_tests/data/idempotency/reasonml.org/layouts/GenTypeDocsLayout.res
@@ -15,7 +15,7 @@ hljs.registerLanguage('json', jsonHighlightJs);
 module Link = Next.Link
 
 // Structure defined by `scripts/extract-tocs.js`
-let tocData: Js.Dict.t<{
+let tocData: dict<{
   "title": string,
   "headers": array<{
     "name": string,

--- a/tests/syntax_tests/data/idempotency/reasonml.org/layouts/JsDocsLayout.res
+++ b/tests/syntax_tests/data/idempotency/reasonml.org/layouts/JsDocsLayout.res
@@ -1,7 +1,7 @@
 module Link = Next.Link
 
 // Structure defined by `scripts/extract-indices.js`
-let indexData: Js.Dict.t<{
+let indexData: dict<{
   "moduleName": string,
   "headers": array<{
     "name": string,

--- a/tests/syntax_tests/data/idempotency/reasonml.org/layouts/ManualDocsLayout.res
+++ b/tests/syntax_tests/data/idempotency/reasonml.org/layouts/ManualDocsLayout.res
@@ -1,7 +1,7 @@
 module Link = Next.Link
 
 // Structure defined by `scripts/extract-tocs.js`
-let tocData: Js.Dict.t<{
+let tocData: dict<{
   "title": string,
   "headers": array<{
     "name": string,

--- a/tests/syntax_tests/data/idempotency/reasonml.org/layouts/ReasonCompilerDocsLayout.res
+++ b/tests/syntax_tests/data/idempotency/reasonml.org/layouts/ReasonCompilerDocsLayout.res
@@ -1,7 +1,7 @@
 module Link = Next.Link
 
 // Structure defined by `scripts/extract-tocs.js`
-let tocData: Js.Dict.t<{
+let tocData: dict<{
   "title": string,
   "headers": array<{
     "name": string,

--- a/tests/syntax_tests/data/idempotency/reasonml.org/layouts/ReasonReactDocsLayout.res
+++ b/tests/syntax_tests/data/idempotency/reasonml.org/layouts/ReasonReactDocsLayout.res
@@ -1,7 +1,7 @@
 module Link = Next.Link
 
 // Structure defined by `scripts/extract-tocs.js`
-let tocData: Js.Dict.t<{
+let tocData: dict<{
   "title": string,
   "headers": array<{
     "name": string,

--- a/tests/syntax_tests/data/idempotency/wildcards-world-ui/UserProvider.res
+++ b/tests/syntax_tests/data/idempotency/wildcards-world-ui/UserProvider.res
@@ -6,7 +6,7 @@ open Globals
 type threeBoxImageData = {
   @as("@type")
   imageType: string,
-  contentUrl: Js.Dict.t<string>,
+  contentUrl: dict<string>,
 }
 type threeBoxImage = array<threeBoxImageData>
 type threeBoxTwitterVerification = {
@@ -32,7 +32,7 @@ type threeBoxUserInfo = {
 type userVerification = {threeBox: threeBoxUserInfo}
 
 type userInfo = {
-  userInfo: Js.Dict.t<userVerification>,
+  userInfo: dict<userVerification>,
   update: (string, bool) => unit,
 }
 

--- a/tests/syntax_tests/data/parsing/grammar/typexpr/es6Arrow.res
+++ b/tests/syntax_tests/data/parsing/grammar/typexpr/es6Arrow.res
@@ -40,7 +40,7 @@ type t = @attrBeforeLblA ((~a: int) =>  (@attrBeforeLblB ((~b: int) => (@attr fl
 type t = @attr ~a: int => unit
 
 type getInitialPropsFn<'a> = {
-  "query": Js.Dict.t<string>,
+  "query": dict<string>,
   "req": Js.Nullable.t<Js.t<'a>>,
 } => Js.Promise.t<Js.t<'a>>
 

--- a/tests/syntax_tests/data/parsing/grammar/typexpr/expected/es6Arrow.res.txt
+++ b/tests/syntax_tests/data/parsing/grammar/typexpr/expected/es6Arrow.res.txt
@@ -72,6 +72,6 @@ type nonrec t =
       [ `Has_arity1 ]) function$)[@attrBeforeLblA ])
 type nonrec t = ((a:((int)[@res.namedArgLoc ]) -> unit)[@attr ])
 type nonrec 'a getInitialPropsFn =
-  (< query: string Js.Dict.t  ;req: 'a Js.t Js.Nullable.t   >  ->
+  (< query: string dict  ;req: 'a Js.t Js.Nullable.t   >  ->
      'a Js.t Js.Promise.t,
     [ `Has_arity1 ]) function$

--- a/tests/syntax_tests/data/printer/typexpr/arrow.res
+++ b/tests/syntax_tests/data/printer/typexpr/arrow.res
@@ -102,7 +102,7 @@ type arrows = (int, (float => unit) => unit, float) => unit
 let prepare_expansion: ((type_expr, type_expr)) => (type_expr, type_expr) = f
 
 type getInitialPropsFn<'a> = {
-  "query": Js.Dict.t<string>,
+  "query": dict<string>,
   "req": Js.Nullable.t<Js.t<'a>>,
 } => Js.Promise.t<Js.t<'a>>
 

--- a/tests/syntax_tests/data/printer/typexpr/expected/arrow.res.txt
+++ b/tests/syntax_tests/data/printer/typexpr/expected/arrow.res.txt
@@ -222,7 +222,7 @@ type arrows = (int, (float => unit) => unit, float) => unit
 let prepare_expansion: ((type_expr, type_expr)) => (type_expr, type_expr) = f
 
 type getInitialPropsFn<'a> = {
-  "query": Js.Dict.t<string>,
+  "query": dict<string>,
   "req": Js.Nullable.t<Js.t<'a>>,
 } => Js.Promise.t<Js.t<'a>>
 

--- a/tests/tests/src/UntaggedVariants.res
+++ b/tests/tests/src/UntaggedVariants.res
@@ -144,7 +144,7 @@ module Json = {
     | @as(null) Null
     | String(string)
     | Number(float)
-    | Object(Js.Dict.t<t>)
+    | Object(dict<t>)
     | Array(array<t>)
 
   type tagged_t =
@@ -153,7 +153,7 @@ module Json = {
     | JSONNull
     | JSONString(string)
     | JSONNumber(float)
-    | JSONObject(Js.Dict.t<t>)
+    | JSONObject(dict<t>)
     | JSONArray(array<t>)
 
   let classify = (x: t) =>
@@ -319,7 +319,7 @@ module ComplexPattern = {
     | @as(null) Null
     | String(string)
     | Number(float)
-    | Object(Js.Dict.t<t>)
+    | Object(dict<t>)
     | Array(array<t>)
 
   type tagged_t =
@@ -328,7 +328,7 @@ module ComplexPattern = {
     | JSONNull
     | JSONString(string)
     | JSONNumber(float)
-    | JSONObject(Js.Dict.t<t>)
+    | JSONObject(dict<t>)
     | JSONArray(array<t>)
 
   let someJson: t = %raw(`'[{"name": "Haan"}, {"name": "Mr"}, false]'`)->Obj.magic
@@ -417,7 +417,7 @@ module AllInstanceofTypes = {
 }
 
 module Aliased = {
-  type dict = Js.Dict.t<string>
+  type dict = dict<string>
   type fn = unit => option<string>
   @unboxed type t = Object(dict) | String(string) | Function(fn)
 

--- a/tests/tests/src/bs_qualified.res
+++ b/tests/tests/src/bs_qualified.res
@@ -5,7 +5,7 @@ type param
 @scope("commands") @module("vscode") @variadic
 external executeCommands: (string, array<param>) => unit = "executeCommands"
 
-@scope("process") @val external env: Js.Dict.t<string> = "env"
+@scope("process") @val external env: dict<string> = "env"
 
 let f = (a, b, c) => {
   executeCommands("hi", [a, b, c])

--- a/tests/tests/src/js_json_test.res
+++ b/tests/tests/src/js_json_test.res
@@ -24,7 +24,7 @@ let () = {
     let ty = J.classify(v)
     switch ty {
     | J.JSONObject(x) =>
-      /* compiler infer x : J.t Js.Dict.t */
+      /* compiler infer x : J.t dict */
       switch Js.Dict.get(x, "x") {
       | Some(v) =>
         let ty2 = J.classify(v)

--- a/tests/tests/src/reactDOMRe.res
+++ b/tests/tests/src/reactDOMRe.res
@@ -2573,7 +2573,7 @@ module Style = {
   @val
   external combine: (@as(json`{}`) _, style, style) => t = "Object.assign"
 
-  external _dictToStyle: Js.Dict.t<string> => style = "%identity"
+  external _dictToStyle: dict<string> => style = "%identity"
 
   let unsafeAddProp = (style, key, value) => {
     let dict = Js.Dict.empty()


### PR DESCRIPTION
Use the builtin type `dict` everywhere instead of `Dict.t`/`Js.Dict.t`.

Remove `Dict.t` for consistency (we don't have `Array.t` or `String.t` either.