### PR TITLE
Negation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@
 - Provide additional context in error message when `unit` is expected. https://github.com/rescript-lang/rescript-compiler/pull/7045
 - Improve error message when passing an object where a record is expected. https://github.com/rescript-lang/rescript-compiler/pull/7101
 - Improve code generation or pattern matching of untagged variants. https://github.com/rescript-lang/rescript-compiler/pull/7128
+- Improve negation handling in combination with and/or to simplify generated code (especially coming out of pattern matching). https://github.com/rescript-lang/rescript-compiler/pull/7138
+
 
 #### :house: Internal
 

--- a/compiler/core/js_exp_make.ml
+++ b/compiler/core/js_exp_make.ml
@@ -794,7 +794,7 @@ let rec simplify_and (e1 : t) (e2 : t) : t option =
   | ( Bin
         ( EqEqEq,
           {expression_desc = Typeof {expression_desc = Var ia}},
-          {expression_desc = Str {txt = "boolean" | "string"}} ),
+          {expression_desc = Str {txt = "boolean" | "string" | "number"}} ),
       Bin
         ( EqEqEq,
           {expression_desc = Var ib},
@@ -806,7 +806,7 @@ let rec simplify_and (e1 : t) (e2 : t) : t option =
       Bin
         ( EqEqEq,
           {expression_desc = Typeof {expression_desc = Var ia}},
-          {expression_desc = Str {txt = "boolean" | "string"}} ) )
+          {expression_desc = Str {txt = "boolean" | "string" | "number"}} ) )
     when Js_op_util.same_vident ia ib ->
     (* Note: case boolean / Bool _ is handled above *)
     Some false_

--- a/compiler/core/js_exp_make.ml
+++ b/compiler/core/js_exp_make.ml
@@ -881,6 +881,7 @@ let rec simplify_and (e1 : t) (e2 : t) : t option =
            _ ) as is_array) )
     when Js_op_util.same_vident ia ib ->
     Some {expression_desc = is_array; comment = None}
+  | x, y when x = y -> Some e1
   | _ -> None
 
 (**

--- a/compiler/core/js_exp_make.ml
+++ b/compiler/core/js_exp_make.ml
@@ -977,6 +977,7 @@ let rec econd ?comment (pred : t) (ifso : t) (ifnot : t) : t =
   | (Number _ | Array _ | Caml_block _), _, _ when no_side_effect pred ->
     ifso (* a block can not be false in OCAML, CF - relies on flow inference*)
   | Bool true, _, _ -> ifso
+  | _, Bool true, Bool false -> pred
   | _, Cond (pred1, ifso1, ifnot1), _
     when Js_analyzer.eq_expression ifnot1 ifnot ->
     (* {[

--- a/lib/es6/Belt_Result.js
+++ b/lib/es6/Belt_Result.js
@@ -53,11 +53,7 @@ function getWithDefault(opt, $$default) {
 }
 
 function isOk(x) {
-  if (x.TAG === "Ok") {
-    return true;
-  } else {
-    return false;
-  }
+  return x.TAG === "Ok";
 }
 
 function isError(x) {

--- a/lib/es6/Result.js
+++ b/lib/es6/Result.js
@@ -47,11 +47,7 @@ function getOr(opt, $$default) {
 }
 
 function isOk(x) {
-  if (x.TAG === "Ok") {
-    return true;
-  } else {
-    return false;
-  }
+  return x.TAG === "Ok";
 }
 
 function isError(x) {

--- a/lib/js/Belt_Result.js
+++ b/lib/js/Belt_Result.js
@@ -53,11 +53,7 @@ function getWithDefault(opt, $$default) {
 }
 
 function isOk(x) {
-  if (x.TAG === "Ok") {
-    return true;
-  } else {
-    return false;
-  }
+  return x.TAG === "Ok";
 }
 
 function isError(x) {

--- a/lib/js/Result.js
+++ b/lib/js/Result.js
@@ -47,11 +47,7 @@ function getOr(opt, $$default) {
 }
 
 function isOk(x) {
-  if (x.TAG === "Ok") {
-    return true;
-  } else {
-    return false;
-  }
+  return x.TAG === "Ok";
 }
 
 function isError(x) {

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -60,7 +60,12 @@ async function runTests() {
   }
 
   if (mochaTest) {
-    cp.execSync(rescript_exe, {
+    cp.execSync(`${rescript_exe} clean`, {
+      cwd: path.join(__dirname, "..", "tests/tests"),
+      stdio: [0, 1, 2],
+    });
+
+    cp.execSync(`${rescript_exe} build`, {
       cwd: path.join(__dirname, "..", "tests/tests"),
       stdio: [0, 1, 2],
     });

--- a/tests/tests/src/UntaggedVariants.mjs
+++ b/tests/tests/src/UntaggedVariants.mjs
@@ -386,9 +386,9 @@ function check$1(s) {
       return;
     }
     let match = s[0];
-    if (match === undefined || match === null || match === true) {
+    if (match === true) {
       let match$1 = s[1];
-      if (match$1 === undefined || match$1 === null || match$1 === false) {
+      if (match$1 === false) {
         let match$2 = s[2];
         if (match$2 === undefined || match$2 === null || match$2 === false || match$2 === true) {
           console.log("Nope...");

--- a/tests/tests/src/and_or_simplify.mjs
+++ b/tests/tests/src/and_or_simplify.mjs
@@ -2,11 +2,7 @@
 
 
 function check_null_eq_typeof(x) {
-  if (typeof x !== "boolean" || x !== null) {
-    return 4;
-  } else {
-    return 3;
-  }
+  return 4;
 }
 
 function check_null_neq_typeof(x) {
@@ -18,11 +14,7 @@ function check_null_neq_typeof(x) {
 }
 
 function check_undefined_eq_typeof(x) {
-  if (typeof x !== "boolean" || x !== undefined) {
-    return 4;
-  } else {
-    return 3;
-  }
+  return 4;
 }
 
 function check_undefined_neq_typeof(x) {

--- a/tests/tests/src/and_or_simplify.mjs
+++ b/tests/tests/src/and_or_simplify.mjs
@@ -6,7 +6,7 @@ function check_null_eq_typeof(x) {
 }
 
 function check_null_neq_typeof(x) {
-  if (typeof x !== "boolean" || x === null) {
+  if (typeof x !== "boolean") {
     return 4;
   } else {
     return 3;
@@ -18,7 +18,7 @@ function check_undefined_eq_typeof(x) {
 }
 
 function check_undefined_neq_typeof(x) {
-  if (typeof x !== "boolean" || x === undefined) {
+  if (typeof x !== "boolean") {
     return 4;
   } else {
     return 3;

--- a/tests/tests/src/and_or_simplify.res
+++ b/tests/tests/src/and_or_simplify.res
@@ -1,5 +1,5 @@
 @unboxed
-type t = | @as(null) Null | @as(undefined) Undefined | B(bool) //| S(string)
+type t = | @as(null) Null | @as(undefined) Undefined | B(bool) | S(string) | I(int)
 
 let check_null_eq_typeof = x =>
   switch x {

--- a/tests/tests/src/bdd.mjs
+++ b/tests/tests/src/bdd.mjs
@@ -7,11 +7,7 @@ function $$eval(_bdd, vars) {
   while (true) {
     let bdd = _bdd;
     if (typeof bdd !== "object") {
-      if (bdd === "One") {
-        return true;
-      } else {
-        return false;
-      }
+      return bdd === "One";
     }
     if (Primitive_array.get(vars, bdd._1)) {
       _bdd = bdd._3;
@@ -366,11 +362,7 @@ function random_vars(n) {
 
 function bool_equal(a, b) {
   if (a) {
-    if (b) {
-      return true;
-    } else {
-      return false;
-    }
+    return b;
   } else if (b) {
     return false;
   } else {

--- a/tests/tests/src/caml_compare_test.mjs
+++ b/tests/tests/src/caml_compare_test.mjs
@@ -10,7 +10,7 @@ try {
   function_equal_test = Primitive_object.equal(x => x + 1 | 0, x => x + 2 | 0);
 } catch (raw_exn) {
   let exn = Primitive_exceptions.internalToException(raw_exn);
-  function_equal_test = exn.RE_EXN_ID === "Invalid_argument" && exn._1 === "equal: functional value" ? true : false;
+  function_equal_test = exn.RE_EXN_ID === "Invalid_argument" ? exn._1 === "equal: functional value" : false;
 }
 
 let suites = {

--- a/tests/tests/src/core/Core_JsonTests.mjs
+++ b/tests/tests/src/core/Core_JsonTests.mjs
@@ -17,7 +17,7 @@ function decodeJsonTest() {
           decodedCorrectly = false;
         } else {
           let match$3 = match$1[1];
-          decodedCorrectly = match$3 === null || !(typeof match$3 === "boolean" && !match$3) ? false : true;
+          decodedCorrectly = match$3 === null ? false : typeof match$3 === "boolean" && !match$3;
         }
       } else {
         decodedCorrectly = false;

--- a/tests/tests/src/core/Core_NullableTests.mjs
+++ b/tests/tests/src/core/Core_NullableTests.mjs
@@ -7,7 +7,7 @@ function shouldHandleNullableValues() {
   let tUndefined = undefined;
   let tValue = "hello";
   let tmp;
-  tmp = (tNull === null || tNull === undefined) && tNull === null ? true : false;
+  tmp = tNull === null || tNull === undefined ? true : false;
   Test.run([
     [
       "Core_NullableTests.res",

--- a/tests/tests/src/core/Core_NullableTests.mjs
+++ b/tests/tests/src/core/Core_NullableTests.mjs
@@ -7,7 +7,7 @@ function shouldHandleNullableValues() {
   let tUndefined = undefined;
   let tValue = "hello";
   let tmp;
-  tmp = tNull === null || tNull === undefined ? true : false;
+  tmp = tNull === null ? true : false;
   Test.run([
     [
       "Core_NullableTests.res",

--- a/tests/tests/src/core/Core_NullableTests.mjs
+++ b/tests/tests/src/core/Core_NullableTests.mjs
@@ -7,7 +7,7 @@ function shouldHandleNullableValues() {
   let tUndefined = undefined;
   let tValue = "hello";
   let tmp;
-  tmp = tNull === null ? true : false;
+  tmp = tNull === null || tNull === undefined ? tNull === null : false;
   Test.run([
     [
       "Core_NullableTests.res",
@@ -18,7 +18,7 @@ function shouldHandleNullableValues() {
     "Should handle null"
   ], tmp, (prim0, prim1) => prim0 === prim1, true);
   let tmp$1;
-  tmp$1 = (tUndefined === null || tUndefined === undefined) && tUndefined !== null ? true : false;
+  tmp$1 = (tUndefined === null || tUndefined === undefined) && tUndefined !== null;
   Test.run([
     [
       "Core_NullableTests.res",
@@ -29,7 +29,7 @@ function shouldHandleNullableValues() {
     "Should handle undefined"
   ], tmp$1, (prim0, prim1) => prim0 === prim1, true);
   let tmp$2;
-  tmp$2 = tValue === null || tValue === undefined || tValue !== "hello" ? false : true;
+  tmp$2 = tValue === null || tValue === undefined ? false : tValue === "hello";
   Test.run([
     [
       "Core_NullableTests.res",

--- a/tests/tests/src/core/Core_PromiseTest.mjs
+++ b/tests/tests/src/core/Core_PromiseTest.mjs
@@ -171,7 +171,7 @@ function testExnThrow() {
       Error: new Error()
     };
   }), e => {
-    let isTestErr = e.RE_EXN_ID === TestError && e._1 === "Thrown exn" ? true : false;
+    let isTestErr = e.RE_EXN_ID === TestError ? e._1 === "Thrown exn" : false;
     Test.run([
       [
         "Core_PromiseTest.res",

--- a/tests/tests/src/gpr496_test.mjs
+++ b/tests/tests/src/gpr496_test.mjs
@@ -67,7 +67,7 @@ function ff(x, y) {
   return Primitive_bool.min(x, y());
 }
 
-eq("File \"gpr496_test.res\", line 40, characters 12-19", true < false ? true : false, false);
+eq("File \"gpr496_test.res\", line 40, characters 12-19", true < false, false);
 
 Mt.from_pair_suites("Gpr496_test", suites.contents);
 

--- a/tests/tests/src/gpr_1698_test.mjs
+++ b/tests/tests/src/gpr_1698_test.mjs
@@ -6,11 +6,7 @@ function is_number(_expr) {
     let expr = _expr;
     switch (expr.TAG) {
       case "Val" :
-        if (expr._0.TAG === "Natural") {
-          return true;
-        } else {
-          return false;
-        }
+        return expr._0.TAG === "Natural";
       case "Neg" :
         _expr = expr._0;
         continue;

--- a/tests/tests/src/gpr_4924_test.mjs
+++ b/tests/tests/src/gpr_4924_test.mjs
@@ -19,8 +19,8 @@ function u(b) {
 }
 
 function u1(b) {
-  if (typeof b !== "object" && b === "A") {
-    return true;
+  if (typeof b !== "object") {
+    return b === "A";
   } else {
     return false;
   }
@@ -65,8 +65,8 @@ function u5(b) {
 }
 
 function u6(b) {
-  if (typeof b !== "object" && b === "A") {
-    return true;
+  if (typeof b !== "object") {
+    return b === "A";
   } else {
     return false;
   }

--- a/tests/tests/src/inline_map2_test.mjs
+++ b/tests/tests/src/inline_map2_test.mjs
@@ -81,13 +81,7 @@ function Make(Ord) {
       return create(create(l, x, d, rl._0), rl._1, rl._2, create(rl._3, rv, rd, rr));
     }
   };
-  let is_empty = x => {
-    if (typeof x !== "object") {
-      return true;
-    } else {
-      return false;
-    }
-  };
+  let is_empty = x => typeof x !== "object";
   let add = (x, data, x_) => {
     if (typeof x_ !== "object") {
       return {
@@ -523,11 +517,7 @@ function Make(Ord) {
       let e2 = _e2;
       let e1 = _e1;
       if (typeof e1 !== "object") {
-        if (typeof e2 !== "object") {
-          return true;
-        } else {
-          return false;
-        }
+        return typeof e2 !== "object";
       }
       if (typeof e2 !== "object") {
         return false;
@@ -688,11 +678,7 @@ function bal(l, x, d, r) {
 }
 
 function is_empty(x) {
-  if (typeof x !== "object") {
-    return true;
-  } else {
-    return false;
-  }
+  return typeof x !== "object";
 }
 
 function add(x, data, x_) {
@@ -1154,11 +1140,7 @@ function equal(cmp, m1, m2) {
     let e2 = _e2;
     let e1 = _e1;
     if (typeof e1 !== "object") {
-      if (typeof e2 !== "object") {
-        return true;
-      } else {
-        return false;
-      }
+      return typeof e2 !== "object";
     }
     if (typeof e2 !== "object") {
       return false;
@@ -1350,11 +1332,7 @@ function bal$1(l, x, d, r) {
 }
 
 function is_empty$1(x) {
-  if (typeof x !== "object") {
-    return true;
-  } else {
-    return false;
-  }
+  return typeof x !== "object";
 }
 
 function add$1(x, data, x_) {
@@ -1816,11 +1794,7 @@ function equal$1(cmp, m1, m2) {
     let e2 = _e2;
     let e1 = _e1;
     if (typeof e1 !== "object") {
-      if (typeof e2 !== "object") {
-        return true;
-      } else {
-        return false;
-      }
+      return typeof e2 !== "object";
     }
     if (typeof e2 !== "object") {
       return false;

--- a/tests/tests/src/js_bool_test.mjs
+++ b/tests/tests/src/js_bool_test.mjs
@@ -3,27 +3,15 @@
 import * as Mt from "./mt.mjs";
 
 function f(x) {
-  if (x) {
-    return true;
-  } else {
-    return false;
-  }
+  return x;
 }
 
 function f2(x) {
-  if (x) {
-    return true;
-  } else {
-    return false;
-  }
+  return x;
 }
 
 function f4(x) {
-  if (x) {
-    return true;
-  } else {
-    return false;
-  }
+  return x;
 }
 
 let u = 1;

--- a/tests/tests/src/mario_game.mjs
+++ b/tests/tests/src/mario_game.mjs
@@ -928,19 +928,11 @@ function get_obj(x) {
 }
 
 function is_player(x) {
-  if (x.TAG === "Player") {
-    return true;
-  } else {
-    return false;
-  }
+  return x.TAG === "Player";
 }
 
 function is_enemy(x) {
-  if (x.TAG === "Enemy") {
-    return true;
-  } else {
-    return false;
-  }
+  return x.TAG === "Enemy";
 }
 
 function equals(col1, col2) {
@@ -1262,7 +1254,7 @@ function col_bypass(c1, c2) {
       ctypes = c2.TAG === "Enemy" ? c1._2.invuln > 0 : false;
       break;
     case "Enemy" :
-      ctypes = c2.TAG === "Item" ? true : false;
+      ctypes = c2.TAG === "Item";
       break;
     case "Item" :
       switch (c2.TAG) {

--- a/tests/tests/src/option_repr_test.mjs
+++ b/tests/tests/src/option_repr_test.mjs
@@ -221,9 +221,9 @@ b("File \"option_repr_test.res\", line 127, characters 3-10", Belt_List.every(xs
 let xs_1$1 = {
   hd: neqx(undefined, null),
   tl: {
-    hd: Primitive_object.equal(Primitive_option.some(undefined), Primitive_option.some(undefined)) && Primitive_object.equal(Primitive_option.some(undefined), Primitive_option.some(undefined)),
+    hd: Primitive_object.equal(Primitive_option.some(undefined), Primitive_option.some(undefined)),
     tl: {
-      hd: Primitive_object.equal(Primitive_option.some(Primitive_option.some(undefined)), Primitive_option.some(Primitive_option.some(undefined))) && Primitive_object.equal(Primitive_option.some(Primitive_option.some(undefined)), Primitive_option.some(Primitive_option.some(undefined))),
+      hd: Primitive_object.equal(Primitive_option.some(Primitive_option.some(undefined)), Primitive_option.some(Primitive_option.some(undefined))),
       tl: {
         hd: Primitive_object.notequal(Primitive_option.some(Primitive_option.some(Primitive_option.some(undefined))), Primitive_option.some(Primitive_option.some(undefined))) && Primitive_object.notequal(Primitive_option.some(Primitive_option.some(undefined)), Primitive_option.some(Primitive_option.some(Primitive_option.some(undefined)))),
         tl: /* [] */0

--- a/tests/tests/src/rbset.mjs
+++ b/tests/tests/src/rbset.mjs
@@ -22,11 +22,7 @@ function blackify(x) {
 }
 
 function is_empty(x) {
-  if (typeof x !== "object") {
-    return true;
-  } else {
-    return false;
-  }
+  return typeof x !== "object";
 }
 
 function mem(x, _x_) {

--- a/tests/tests/src/reasonReactRouter.mjs
+++ b/tests/tests/src/reasonReactRouter.mjs
@@ -108,11 +108,7 @@ function urlNotEqual(a, b) {
       let bList = _bList;
       let aList = _aList;
       if (!aList) {
-        if (bList) {
-          return true;
-        } else {
-          return false;
-        }
+        return bList;
       }
       if (!bList) {
         return true;

--- a/tests/tests/src/set_gen.mjs
+++ b/tests/tests/src/set_gen.mjs
@@ -67,11 +67,7 @@ function max_elt(_x) {
 }
 
 function is_empty(x) {
-  if (typeof x !== "object") {
-    return true;
-  } else {
-    return false;
-  }
+  return typeof x !== "object";
 }
 
 function cardinal_aux(_acc, _x) {

--- a/tests/tests/src/test_bool_equal.mjs
+++ b/tests/tests/src/test_bool_equal.mjs
@@ -3,11 +3,7 @@
 
 function bool_equal(x, y) {
   if (x) {
-    if (y) {
-      return true;
-    } else {
-      return false;
-    }
+    return y;
   } else if (y) {
     return false;
   } else {

--- a/tests/tests/src/test_set.mjs
+++ b/tests/tests/src/test_set.mjs
@@ -224,13 +224,7 @@ function Make(Ord) {
       match$1[2]
     ];
   };
-  let is_empty = x => {
-    if (typeof x !== "object") {
-      return true;
-    } else {
-      return false;
-    }
-  };
+  let is_empty = x => typeof x !== "object";
   let mem = (x, _x_) => {
     while (true) {
       let x_ = _x_;

--- a/tests/tests/src/variantsMatching.mjs
+++ b/tests/tests/src/variantsMatching.mjs
@@ -96,11 +96,7 @@ function third(l) {
     return false;
   }
   let match$1 = match.tl;
-  if (match$1 && !(match$1.hd !== 3 || match$1.tl)) {
-    return true;
-  } else {
-    return false;
-  }
+  return match$1 && !(match$1.hd !== 3 || match$1.tl);
 }
 
 function third2(l) {
@@ -125,11 +121,7 @@ function third2(l) {
     return false;
   }
   let tmp = match$1._1;
-  if (typeof tmp !== "object") {
-    return true;
-  } else {
-    return false;
-  }
+  return typeof tmp !== "object";
 }
 
 function foo(x) {


### PR DESCRIPTION
Better logic to simplify negation.

For comparison,

```res
@unboxed
type t = | @as(null) Null | @as(undefined) Undefined | B(bool) | S(string) | I(int)

let check_null_eq_typeof = x =>
  switch x {
  | B(_) if x == Null => 3
  | _ => 4
  }

let check_null_neq_typeof = x =>
  switch x {
  | B(_) if x != Null => 3
  | _ => 4
  }

```

on latest playground generates:

```js
function check_null_eq_typeof(x) {
  if (typeof x !== "number" && typeof x !== "string" && typeof x !== "boolean" || !(typeof x === "boolean" && x === null)) {
    return 4;
  } else {
    return 3;
  }
}

function check_null_neq_typeof(x) {
  if (typeof x !== "number" && typeof x !== "string" && typeof x !== "boolean" || !(typeof x === "boolean" && x !== null)) {
    return 4;
  } else {
    return 3;
  }
}
```

while here it generates:
```js
function check_null_eq_typeof(x) {
  return 4;
}

function check_null_neq_typeof(x) {
  if (typeof x !== "boolean") {
    return 4;
  } else {
    return 3;
  }
}

```

For reference, the code without untagged variants is the following:
```js
function check_null_eq_typeof(x) {
  if (typeof x !== "object" || !(x.TAG === "B" && x === "Null")) {
    return 4;
  } else {
    return 3;
  }
}

function check_null_neq_typeof(x) {
  if (typeof x !== "object" || !(x.TAG === "B" && x !== "Null")) {
    return 4;
  } else {
    return 3;
  }
}

```