### PR TITLE
Apply switch optimization to tagged variants.

### DIFF
--- a/compiler/core/lam_compile.ml
+++ b/compiler/core/lam_compile.ml
@@ -740,8 +740,7 @@ let compile output_prefix =
               | _ -> false
             in
             if
-              untagged
-              && List.length sw_consts = 0
+              List.length sw_consts = 0
               && eq_default sw_num_default sw_blocks_default
             then
               compile_cases ~untagged ~cxt

--- a/lib/es6/Intl_NumberFormat_Grouping.js
+++ b/lib/es6/Intl_NumberFormat_Grouping.js
@@ -4,9 +4,6 @@ import * as Type from "./Type.js";
 
 function parseJsValue(value) {
   let value$1 = Type.Classify.classify(value);
-  if (typeof value$1 !== "object") {
-    return;
-  }
   switch (value$1.TAG) {
     case "Bool" :
       return {

--- a/lib/es6/Primitive_module.js
+++ b/lib/es6/Primitive_module.js
@@ -72,17 +72,6 @@ function update(shape, o, n) {
       return;
     }
   };
-  if (typeof shape !== "object") {
-    throw {
-      RE_EXN_ID: "Assert_failure",
-      _1: [
-        "Primitive_module.res",
-        68,
-        9
-      ],
-      Error: new Error()
-    };
-  }
   if (shape.TAG === "Module") {
     let comps = shape._0;
     for (let i = 0, i_finish = comps.length; i < i_finish; ++i) {

--- a/lib/js/Intl_NumberFormat_Grouping.js
+++ b/lib/js/Intl_NumberFormat_Grouping.js
@@ -4,9 +4,6 @@ let Type = require("./Type.js");
 
 function parseJsValue(value) {
   let value$1 = Type.Classify.classify(value);
-  if (typeof value$1 !== "object") {
-    return;
-  }
   switch (value$1.TAG) {
     case "Bool" :
       return {

--- a/lib/js/Primitive_module.js
+++ b/lib/js/Primitive_module.js
@@ -72,17 +72,6 @@ function update(shape, o, n) {
       return;
     }
   };
-  if (typeof shape !== "object") {
-    throw {
-      RE_EXN_ID: "Assert_failure",
-      _1: [
-        "Primitive_module.res",
-        68,
-        9
-      ],
-      Error: new Error()
-    };
-  }
   if (shape.TAG === "Module") {
     let comps = shape._0;
     for (let i = 0, i_finish = comps.length; i < i_finish; ++i) {

--- a/tests/tests/src/core/Core_TempTests.mjs
+++ b/tests/tests/src/core/Core_TempTests.mjs
@@ -101,11 +101,11 @@ let json$1 = $$JSON.Classify.classify(json);
 
 let tmp;
 
-if (typeof json$1 !== "object" || json$1.TAG !== "Object") {
-  tmp = undefined;
-} else {
+if (json$1.TAG === "Object") {
   let value = $$JSON.Classify.classify(json$1._0["foo"]);
-  tmp = typeof value !== "object" || value.TAG !== "String" ? undefined : value._0;
+  tmp = value.TAG === "String" ? value._0 : undefined;
+} else {
+  tmp = undefined;
 }
 
 console.log(tmp);

--- a/tests/tests/src/js_json_test.mjs
+++ b/tests/tests/src/js_json_test.mjs
@@ -54,12 +54,6 @@ let v = JSON.parse(" { \"x\" : [1, 2, 3 ] } ");
 
 add_test("File \"js_json_test.res\", line 23, characters 11-18", () => {
   let ty = Js_json.classify(v);
-  if (typeof ty !== "object") {
-    return {
-      TAG: "Ok",
-      _0: false
-    };
-  }
   if (ty.TAG !== "JSONObject") {
     return {
       TAG: "Ok",
@@ -74,12 +68,6 @@ add_test("File \"js_json_test.res\", line 23, characters 11-18", () => {
     };
   }
   let ty2 = Js_json.classify(v$1);
-  if (typeof ty2 !== "object") {
-    return {
-      TAG: "Ok",
-      _0: false
-    };
-  }
   if (ty2.TAG !== "JSONArray") {
     return {
       TAG: "Ok",
@@ -88,17 +76,6 @@ add_test("File \"js_json_test.res\", line 23, characters 11-18", () => {
   }
   ty2._0.forEach(x => {
     let ty3 = Js_json.classify(x);
-    if (typeof ty3 !== "object") {
-      throw {
-        RE_EXN_ID: "Assert_failure",
-        _1: [
-          "js_json_test.res",
-          39,
-          21
-        ],
-        Error: new Error()
-      };
-    }
     if (ty3.TAG === "JSONNumber") {
       return;
     }
@@ -169,10 +146,10 @@ let ty$2 = Js_json.classify(json$2);
 
 let exit = 0;
 
-if (typeof ty$2 !== "object" || ty$2.TAG !== "JSONNumber") {
-  exit = 1;
-} else {
+if (ty$2.TAG === "JSONNumber") {
   eq("File \"js_json_test.res\", line 80, characters 26-33", ty$2._0, 1.23456789);
+} else {
+  exit = 1;
 }
 
 if (exit === 1) {
@@ -188,10 +165,10 @@ let ty$3 = Js_json.classify(json$3);
 
 let exit$1 = 0;
 
-if (typeof ty$3 !== "object" || ty$3.TAG !== "JSONNumber") {
-  exit$1 = 1;
-} else {
+if (ty$3.TAG === "JSONNumber") {
   eq("File \"js_json_test.res\", line 90, characters 26-33", ty$3._0 | 0, -1347440721);
+} else {
+  exit$1 = 1;
 }
 
 if (exit$1 === 1) {

--- a/tests/tests/src/variant.mjs
+++ b/tests/tests/src/variant.mjs
@@ -31,10 +31,10 @@ function fooA1(x) {
 }
 
 function fooC(x) {
-  if (typeof x !== "object" || x.TAG !== "C") {
-    return 42;
-  } else {
+  if (x.TAG === "C") {
     return x._0 + x._1 | 0;
+  } else {
+    return 42;
   }
 }
 


### PR DESCRIPTION
This PR illustrates what happens when the switch optimisation from https://github.com/rescript-lang/rescript-compiler/pull/7135 is applied to tagged variants.