### PR TITLE
More boolean simplifications in generated code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - optimize JavaScript code generation by using x == null checks and improving type-based optimizations for string/number literals. https://github.com/rescript-lang/rescript-compiler/pull/7141
 - Improve pattern matching on optional fields. https://github.com/rescript-lang/rescript-compiler/pull/7143 https://github.com/rescript-lang/rescript-compiler/pull/7144
 - Optimize compilation of switch statements for untagged variants when there are no literal cases. https://github.com/rescript-lang/rescript-compiler/pull/7135
+- Further improve boolean optimizations. https://github.com/rescript-lang/rescript-compiler/pull/7149
 
 
 #### :house: Internal

--- a/compiler/core/js_exp_make.ml
+++ b/compiler/core/js_exp_make.ml
@@ -752,8 +752,8 @@ let rec simplify_and ~n (e1 : t) (e2 : t) : t option =
         match simplify_and ~n:(n + 1) a b with
         | None -> None
         | Some e -> simplify_and_force ~n:(n + 1) e e2)
-      | Some a_, None -> simplify_and_force ~n:(n + 1) a_ e2
-      | None, Some b_ -> simplify_and_force ~n:(n + 1) e1 b_
+      | Some a_, None -> simplify_and_force ~n:(n + 1) a_ b
+      | None, Some b_ -> simplify_and_force ~n:(n + 1) a b_
       | Some a_, Some b_ -> simplify_and_force ~n:(n + 1) a_ b_)
     | _, Bin (And, a, b) ->
       simplify_and ~n:(n + 1)
@@ -763,7 +763,10 @@ let rec simplify_and ~n (e1 : t) (e2 : t) : t option =
       let ao = simplify_and ~n:(n + 1) a e2 in
       let bo = simplify_and ~n:(n + 1) b e2 in
       match (ao, bo) with
-      | None, _ | _, None -> None
+      | None, _ | _, None -> (
+        match simplify_or ~n:(n + 1) a b with
+        | None -> None
+        | Some e -> simplify_and_force ~n:(n + 1) e e2)
       | Some a_, Some b_ -> simplify_or_force ~n:(n + 1) a_ b_)
     | ( Bin
           ( ((EqEqEq | NotEqEq) as op1),

--- a/compiler/core/js_exp_make.ml
+++ b/compiler/core/js_exp_make.ml
@@ -745,16 +745,16 @@ let rec simplify_and ~n (e1 : t) (e2 : t) : t option =
     | Bool true, _ -> Some e2
     | _, Bool true -> Some e1
     | Bin (And, a, b), _ -> (
-      match simplify_and ~n:(n + 1) a b with
-      | Some e -> simplify_and_force ~n:(n + 1) e e2
-      | None -> (
-        let ao = simplify_and ~n:(n + 1) a e2 in
-        let bo = simplify_and ~n:(n + 1) b e2 in
-        match (ao, bo) with
-        | None, None -> None
-        | Some a_, None -> simplify_and_force ~n:(n + 1) a_ e2
-        | None, Some b_ -> simplify_and_force ~n:(n + 1) e1 b_
-        | Some a_, Some b_ -> simplify_and_force ~n:(n + 1) a_ b_))
+      let ao = simplify_and ~n:(n + 1) a e2 in
+      let bo = simplify_and ~n:(n + 1) b e2 in
+      match (ao, bo) with
+      | None, None -> (
+        match simplify_and ~n:(n + 1) a b with
+        | None -> None
+        | Some e -> simplify_and_force ~n:(n + 1) e e2)
+      | Some a_, None -> simplify_and_force ~n:(n + 1) a_ e2
+      | None, Some b_ -> simplify_and_force ~n:(n + 1) e1 b_
+      | Some a_, Some b_ -> simplify_and_force ~n:(n + 1) a_ b_)
     | _, Bin (And, a, b) ->
       simplify_and ~n:(n + 1)
         {expression_desc = Bin (And, e1, a); comment = None}

--- a/tests/tests/src/core/Core_JsonTests.mjs
+++ b/tests/tests/src/core/Core_JsonTests.mjs
@@ -7,9 +7,9 @@ function decodeJsonTest() {
   let decodedCorrectly;
   if (typeof json === "object" && !Array.isArray(json)) {
     let match = json["someProp"];
-    if (match !== undefined && typeof match === "object" && !Array.isArray(match)) {
+    if (typeof match === "object" && !Array.isArray(match)) {
       let match$1 = match["thirdProp"];
-      if (match$1 !== undefined && Array.isArray(match$1) && match$1.length === 2) {
+      if (Array.isArray(match$1) && match$1.length === 2) {
         let match$2 = match$1[0];
         if (typeof match$2 === "boolean" && match$2) {
           let match$3 = match$1[1];

--- a/tests/tests/src/core/Core_JsonTests.mjs
+++ b/tests/tests/src/core/Core_JsonTests.mjs
@@ -11,9 +11,9 @@ function decodeJsonTest() {
       let match$1 = match["thirdProp"];
       if (Array.isArray(match$1) && match$1.length === 2) {
         let match$2 = match$1[0];
-        if (typeof match$2 === "boolean" && match$2) {
+        if (match$2 === true) {
           let match$3 = match$1[1];
-          decodedCorrectly = typeof match$3 === "boolean" && !match$3;
+          decodedCorrectly = match$3 === false;
         } else {
           decodedCorrectly = false;
         }

--- a/tests/tests/src/core/Core_NullableTests.mjs
+++ b/tests/tests/src/core/Core_NullableTests.mjs
@@ -18,7 +18,7 @@ function shouldHandleNullableValues() {
     "Should handle null"
   ], tmp, (prim0, prim1) => prim0 === prim1, true);
   let tmp$1;
-  tmp$1 = (tUndefined == null) && tUndefined !== null;
+  tmp$1 = tUndefined === undefined;
   Test.run([
     [
       "Core_NullableTests.res",


### PR DESCRIPTION
This handles all the boolean simplifications in https://github.com/rescript-lang/rescript-compiler/issues/7142.
What's left from that issue is conditionals `b ? x : y`, that can be done separately.
